### PR TITLE
Adds LOG_LEVEL and LOG_MODE to authorino deployment

### DIFF
--- a/api/v1beta1/authorino_types.go
+++ b/api/v1beta1/authorino_types.go
@@ -41,6 +41,8 @@ const (
 	EnvVarOidcTlsCertKeyPath string = "OIDC_TLS_CERT_KEY"
 	AuthConfigLabelSelector  string = "AUTH_CONFIG_LABEL_SELECTOR"
 	SecretLabelSelector      string = "SECRET_LABEL_SELECTOR"
+	EnvLogLevel              string = "LOG_LEVEL"
+	EnvLogMode               string = "LOG_MODE"
 
 	// Authorino TLS file paths
 	DefaultTlsCertPath        string = "/etc/ssl/certs/tls.crt"
@@ -78,6 +80,8 @@ type AuthorinoSpec struct {
 	Image                    string     `json:"image,omitempty"`
 	Replicas                 *int32     `json:"replicas,omitempty"`
 	ImagePullPolicy          string     `json:"imagePullPolicy,omitempty"`
+	LogLevel                 string     `json:"logLevel,omitempty"`
+	LogMode                  string     `json:"logMode,omitempty"`
 	ClusterWide              bool       `json:"clusterWide,omitempty"`
 	Listener                 Listener   `json:"listener,omitempty"`
 	OIDCServer               OIDCServer `json:"oidcServer,omitempty"`

--- a/config/crd/bases/operator.authorino.kuadrant.io_authorinos.yaml
+++ b/config/crd/bases/operator.authorino.kuadrant.io_authorinos.yaml
@@ -65,6 +65,10 @@ spec:
                         type: boolean
                     type: object
                 type: object
+              logLevel:
+                type: string
+              logMode:
+                type: string
               oidcServer:
                 properties:
                   port:

--- a/config/install/manifests.yaml
+++ b/config/install/manifests.yaml
@@ -56,6 +56,10 @@ spec:
                         type: boolean
                     type: object
                 type: object
+              logLevel:
+                type: string
+              logMode:
+                type: string
               oidcServer:
                 properties:
                   port:

--- a/controllers/authorino_controller.go
+++ b/controllers/authorino_controller.go
@@ -312,6 +312,20 @@ func (r *AuthorinoReconciler) buildAuthorinoEnv(authorino *api.Authorino) []k8sc
 		})
 	}
 
+	if authorino.Spec.LogLevel != "" {
+		envVar = append(envVar, k8score.EnvVar{
+			Name:  api.EnvLogLevel,
+			Value: fmt.Sprint(authorino.Spec.LogLevel),
+		})
+	}
+
+	if authorino.Spec.LogMode != "" {
+		envVar = append(envVar, k8score.EnvVar{
+			Name:  api.EnvLogMode,
+			Value: fmt.Sprint(authorino.Spec.LogMode),
+		})
+	}
+
 	if authorino.Spec.SecretLabelSelectors != "" {
 		envVar = append(envVar, k8score.EnvVar{
 			Name:  api.SecretLabelSelector,


### PR DESCRIPTION
This PR adds the ability to set the two [env vars](https://github.com/Kuadrant/authorino/blob/main/main.go#L53-L54) to define the log mode and level in Authorino via the API. 

```yaml
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino
spec:
  replicas: 1
  clusterWide: false
  logLevel: info
  logMode: production
  listener:
    tls:
      enabled: false
      certSecretName: ""
  oidcServer:
    tls:
      enabled: false
      certSecretName: ""
```


See [here](https://github.com/Kuadrant/authorino/pull/172) for further reference.

Closes https://github.com/Kuadrant/authorino-operator/issues/2

## Verification steps

1. Check out this branch
2. Build a new image locally `make docker-build OPERATOR_IMAGE=authorino-operator:local`
3. Deploy the image on the cluster 
```bash
// example using kind

# create cluster
$ kind create cluster --name authorino
# load the image on the cluster
$ kind load docker-image authorino-operator:local --name
# create a namespace for the operator
$ kubectl create namespace authorino-operator
# install the operator
$ make install deploy OPERATOR_IMAGE=authorino-operator:local
```
4. Create an instance of authorino with the two new env vars
```bash
kubectl -n myapp apply -f -<<EOF
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino
spec:
  replicas: 1
  clusterWide: false
  logLevel: info
  logMode: production
  listener:
    tls:
      enabled: false
      certSecretName: ""
  oidcServer:
    tls:
      enabled: false
      certSecretName: ""
EOF
```
5. Check if the two env vars are present in the deployment object 
```$ kubectl get deployment authorino -n myapp -o json | jq -r .spec.template.spec.containers```
