### PR TITLE
Fix CRD annotation and image tag

### DIFF
--- a/config/crd/bases/operator.authorino.kuadrant.io_authorinos.yaml
+++ b/config/crd/bases/operator.authorino.kuadrant.io_authorinos.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: authorinos.operator.authorino.kuadrant.io
 spec:

--- a/config/install/manifests.yaml
+++ b/config/install/manifests.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: authorinos.operator.authorino.kuadrant.io
 spec:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/authorino-operator
-  newTag: 0.0.1
+  newTag: v0.0.1


### PR DESCRIPTION
Fixed CRD annotation (kubebuilder version) and authorin-operator image tag (missing "v" prefix).

Missing in #9.