### PR TITLE
Authorino K8s auth ClusterRole

### DIFF
--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -1210,8 +1210,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
-  name: authorino-manager-role
+  name: authorino-manager-k8s-auth-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -1219,6 +1218,19 @@ rules:
   - tokenreviews
   verbs:
   - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: authorino-manager-role
+rules:
 - apiGroups:
   - authorino.kuadrant.io
   resources:
@@ -1239,12 +1251,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/controllers/authorino_controller_test.go
+++ b/controllers/authorino_controller_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Authorino controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			leaderElectionRole := &k8srbac.Role{}
-			leaderElectionNsdName := namespacedName(AuthorinoNamespace, leaderElectionRoleName)
+			leaderElectionNsdName := namespacedName(AuthorinoNamespace, authorinoLeaderElectionRoleName)
 			Eventually(func() bool {
 				err := k8sClient.Get(context.TODO(),
 					leaderElectionNsdName,

--- a/controllers/authorino_controller_test.go
+++ b/controllers/authorino_controller_test.go
@@ -73,16 +73,30 @@ var _ = Describe("Authorino controller", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			var binding client.Object = &k8srbac.ClusterRoleBinding{}
-			if !authorinoInstance.Spec.ClusterWide {
+			var binding client.Object
+			var bindingNsdName types.NamespacedName
+			if authorinoInstance.Spec.ClusterWide {
+				binding = &k8srbac.ClusterRoleBinding{}
+				bindingNsdName = types.NamespacedName{Name: "authorino"}
+			} else {
 				binding = &k8srbac.RoleBinding{}
+				bindingNsdName = namespacedName(AuthorinoNamespace, authorinoInstance.Name+"-authorino")
 			}
-			bindingNsdName := namespacedName(AuthorinoNamespace, authorinoInstance.Name+"-authorino")
 
 			Eventually(func() bool {
 				err := k8sClient.Get(context.TODO(),
 					bindingNsdName,
 					binding)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			k8sAuthBinding := &k8srbac.ClusterRoleBinding{}
+			k8sAuthBindingNsdName := types.NamespacedName{Name: "authorino-k8s-auth"}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(),
+					k8sAuthBindingNsdName,
+					k8sAuthBinding)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -112,7 +112,7 @@ var _ = AfterSuite(func() {
 func getAuthorinoClusterRole() *k8srbac.ClusterRole {
 	return &k8srbac.ClusterRole{
 		ObjectMeta: v1.ObjectMeta{
-			Name: authorinoClusterRoleName,
+			Name: authorinoManagerClusterRoleName,
 		},
 	}
 }

--- a/pkg/resources/k8s_rbac.go
+++ b/pkg/resources/k8s_rbac.go
@@ -1,46 +1,91 @@
 package resources
 
 import (
+	k8score "k8s.io/api/core/v1"
 	k8srbac "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetAuthorinoClusterRoleBinding(clusterRoleName, saName, saNamespace string) *k8srbac.ClusterRoleBinding {
-	roleRef, roleSubject := getRoleRefAndSubject(clusterRoleName, "ClusterRole", saName, saNamespace)
+func GetAuthorinoClusterRoleBinding(clusterRoleName string, serviceAccount k8score.ServiceAccount) *k8srbac.ClusterRoleBinding {
+	roleRef, roleSubject := getRoleRefAndSubject(clusterRoleName, "ClusterRole", serviceAccount)
 	return &k8srbac.ClusterRoleBinding{
 		RoleRef:  roleRef,
 		Subjects: []k8srbac.Subject{roleSubject},
 	}
 }
 
-func GetAuthorinoRoleBinding(roleName, saName, saNamespace string) *k8srbac.RoleBinding {
-	roleRef, roleSubject := getRoleRefAndSubject(roleName, "ClusterRole", saName, saNamespace)
+func GetAuthorinoRoleBinding(roleName string, serviceAccount k8score.ServiceAccount) *k8srbac.RoleBinding {
+	roleRef, roleSubject := getRoleRefAndSubject(roleName, "ClusterRole", serviceAccount)
 	return &k8srbac.RoleBinding{
 		RoleRef:  roleRef,
 		Subjects: []k8srbac.Subject{roleSubject},
 	}
 }
 
-func GetAuthorinoLeaderElectionRoleBinding(roleName, saName, saNamespace string) *k8srbac.RoleBinding {
-	roleRef, roleSubject := getRoleRefAndSubject(roleName, "Role", saName, saNamespace)
+func GetAuthorinoLeaderElectionRoleBinding(roleName string, serviceAccount k8score.ServiceAccount) *k8srbac.RoleBinding {
+	roleRef, roleSubject := getRoleRefAndSubject(roleName, "Role", serviceAccount)
 	return &k8srbac.RoleBinding{
 		RoleRef:  roleRef,
 		Subjects: []k8srbac.Subject{roleSubject},
 	}
 }
 
-func getRoleRefAndSubject(roleName, roleKind, saName, saNamespace string) (k8srbac.RoleRef, k8srbac.Subject) {
+func getRoleRefAndSubject(roleName, roleKind string, serviceAccount k8score.ServiceAccount) (k8srbac.RoleRef, k8srbac.Subject) {
 	var roleRef = k8srbac.RoleRef{
 		Name: roleName,
 		Kind: roleKind,
 	}
 
 	var roleSubject = k8srbac.Subject{
-		Kind:      k8srbac.ServiceAccountKind,
-		Name:      saName,
-		Namespace: saNamespace,
+		Kind:      serviceAccount.Kind,
+		Name:      serviceAccount.Name,
+		Namespace: serviceAccount.Namespace,
 	}
 
 	return roleRef, roleSubject
+}
+
+// Makes sure a given serviceaccount is among the subjects of a rolebinding or clusterrolebinding
+func AppendSubjectToRoleBinding(roleBinding client.Object, serviceAccount k8score.ServiceAccount) client.Object {
+	subject := buildSubjectForRoleBinding(serviceAccount)
+	if rb, ok := roleBinding.(*k8srbac.RoleBinding); ok {
+		if subjectIncluded(rb.Subjects, subject) {
+			return rb
+		}
+		rb.Subjects = append(rb.Subjects, subject)
+		return rb
+	} else {
+		return appendSubjectToClusterRoleBinding(roleBinding, subject)
+	}
+}
+
+func appendSubjectToClusterRoleBinding(roleBinding client.Object, subject k8srbac.Subject) client.Object {
+	if rb, ok := roleBinding.(*k8srbac.ClusterRoleBinding); ok {
+		if subjectIncluded(rb.Subjects, subject) {
+			return rb
+		}
+		rb.Subjects = append(rb.Subjects, subject)
+		return rb
+	} else {
+		return nil
+	}
+}
+
+func buildSubjectForRoleBinding(serviceAccount k8score.ServiceAccount) k8srbac.Subject {
+	return k8srbac.Subject{
+		Kind:      serviceAccount.Kind,
+		Name:      serviceAccount.Name,
+		Namespace: serviceAccount.Namespace,
+	}
+}
+
+func subjectIncluded(subjects []k8srbac.Subject, subject k8srbac.Subject) bool {
+	for _, s := range subjects {
+		if s.Kind == subject.Kind && s.Name == subject.Name && s.Namespace == subject.Namespace {
+			return true
+		}
+	}
+	return false
 }
 
 func GetLeaderElectionRules() []k8srbac.PolicyRule {

--- a/pkg/resources/k8s_rbac.go
+++ b/pkg/resources/k8s_rbac.go
@@ -6,6 +6,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func GetAuthorinoServiceAccount(namespace, saName string) *k8score.ServiceAccount {
+  return &k8score.ServiceAccount{
+		ObjectMeta: getObjectMeta(namespace, saName),
+	}
+}
+
 func GetAuthorinoClusterRoleBinding(clusterRoleName string, serviceAccount k8score.ServiceAccount) *k8srbac.ClusterRoleBinding {
 	roleRef, roleSubject := getRoleRefAndSubject(clusterRoleName, "ClusterRole", serviceAccount)
 	return &k8srbac.ClusterRoleBinding{
@@ -47,7 +53,7 @@ func getRoleRefAndSubject(roleName, roleKind string, serviceAccount k8score.Serv
 
 // Makes sure a given serviceaccount is among the subjects of a rolebinding or clusterrolebinding
 func AppendSubjectToRoleBinding(roleBinding client.Object, serviceAccount k8score.ServiceAccount) client.Object {
-	subject := buildSubjectForRoleBinding(serviceAccount)
+	subject := GetSubjectForRoleBinding(serviceAccount)
 	if rb, ok := roleBinding.(*k8srbac.RoleBinding); ok {
 		if subjectIncluded(rb.Subjects, subject) {
 			return rb
@@ -71,7 +77,7 @@ func appendSubjectToClusterRoleBinding(roleBinding client.Object, subject k8srba
 	}
 }
 
-func buildSubjectForRoleBinding(serviceAccount k8score.ServiceAccount) k8srbac.Subject {
+func GetSubjectForRoleBinding(serviceAccount k8score.ServiceAccount) k8srbac.Subject {
 	return k8srbac.Subject{
 		Kind:      serviceAccount.Kind,
 		Name:      serviceAccount.Name,

--- a/pkg/resources/k8s_rbac.go
+++ b/pkg/resources/k8s_rbac.go
@@ -3,34 +3,30 @@ package resources
 import (
 	k8score "k8s.io/api/core/v1"
 	k8srbac "k8s.io/api/rbac/v1"
+	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetAuthorinoServiceAccount(namespace, saName string) *k8score.ServiceAccount {
+func GetAuthorinoServiceAccount(namespace, crName string) *k8score.ServiceAccount {
   return &k8score.ServiceAccount{
-		ObjectMeta: getObjectMeta(namespace, saName),
+		TypeMeta: k8smeta.TypeMeta{	Kind: "ServiceAccount" },
+		ObjectMeta: getObjectMeta(namespace, authorinoServiceAccountName(crName)),
 	}
 }
 
-func GetAuthorinoClusterRoleBinding(clusterRoleName string, serviceAccount k8score.ServiceAccount) *k8srbac.ClusterRoleBinding {
+func GetAuthorinoClusterRoleBinding(roleBindingName, clusterRoleName string, serviceAccount k8score.ServiceAccount) *k8srbac.ClusterRoleBinding {
 	roleRef, roleSubject := getRoleRefAndSubject(clusterRoleName, "ClusterRole", serviceAccount)
 	return &k8srbac.ClusterRoleBinding{
+		ObjectMeta: k8smeta.ObjectMeta{Name: roleBindingName},
 		RoleRef:  roleRef,
 		Subjects: []k8srbac.Subject{roleSubject},
 	}
 }
 
-func GetAuthorinoRoleBinding(roleName string, serviceAccount k8score.ServiceAccount) *k8srbac.RoleBinding {
-	roleRef, roleSubject := getRoleRefAndSubject(roleName, "ClusterRole", serviceAccount)
+func GetAuthorinoRoleBinding(namespace, crName, roleBindingNameSuffix, roleKind, roleName string, serviceAccount k8score.ServiceAccount) *k8srbac.RoleBinding {
+	roleRef, roleSubject := getRoleRefAndSubject(roleName, roleKind, serviceAccount)
 	return &k8srbac.RoleBinding{
-		RoleRef:  roleRef,
-		Subjects: []k8srbac.Subject{roleSubject},
-	}
-}
-
-func GetAuthorinoLeaderElectionRoleBinding(roleName string, serviceAccount k8score.ServiceAccount) *k8srbac.RoleBinding {
-	roleRef, roleSubject := getRoleRefAndSubject(roleName, "Role", serviceAccount)
-	return &k8srbac.RoleBinding{
+		ObjectMeta: getObjectMeta(namespace, authorinoRoleBindingName(crName, roleBindingNameSuffix)),
 		RoleRef:  roleRef,
 		Subjects: []k8srbac.Subject{roleSubject},
 	}

--- a/pkg/resources/k8s_util.go
+++ b/pkg/resources/k8s_util.go
@@ -1,6 +1,8 @@
 package resources
 
 import (
+	"fmt"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -13,4 +15,12 @@ func labelsForAuthorino(name string) map[string]string {
 		"control-plane":      "controller-manager",
 		"authorino-resource": name,
 	}
+}
+
+func authorinoServiceAccountName(crName string) string {
+	return fmt.Sprintf("%s-authorino", crName)
+}
+
+func authorinoRoleBindingName(crName, roleBindingNameSuffix string) string {
+	return fmt.Sprintf("%s-%s", crName, roleBindingNameSuffix)
 }


### PR DESCRIPTION
Add support for `authorino-manager-k8s-auth-role` `Role`.

Related to https://github.com/Kuadrant/authorino/pull/211

Plus:
- Fixes owner references of Authorino `Service`, `ServiceAccount` and other resources.
- Fixes `ClusterRoleBinding`s created to append new subjects instead of always creating another binding – prevents overriding the cluster-scoped resource when there are more than one instance of Authorino with the same name (in different k8s namespaces of course)
- ~Prepends the name of the `Authorino` CR's namespace to the name of the `ClusterRoleBinding`s created.~

TODO:
- [ ] ~Fix unique names of the `ClusterRoleBinding`s – `<cr-namespace>-<cr-name>-<crb-name>` is not enough to prevent clashes (e.g. `namespace: foo-x / name: bar` and `namespace: foo / name: x-bar`)~
- [x] Fix cleanup on deletion of `Authorino` custom resources – Due to the fix for appending subjects to the `ClusterRoleBinding` instead of creating new ones, the cleanup is now broken. When the `Authorino` resource is deleted, the corresponding `ServiceAccount` is not removed from the list of subjects of the `ClusterRoleBinding`s. To fix that, we can either
    - ~get back to creating one set of `ClusterRoleBinding`s per Authorino instance (adding the name and the namespace of the `Authorino` resource to the name of the `ClusterRoleBinding`, to avoid overwriting)~ – it will not work due to k8s ownerreferences not allowed between cluster-scoped dependents and namespaced owners ([ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/)), or
    - implement the removal of the subject from the `ClusterRoleBinding`s on 404 Not Found of `Authorino` CRs caught by the reconciler. [DONE]

### Verification steps

Build and deploy images of Authorino and Authorino Operator that contains the required changes:

```sh
cd $GOPATH/src/github.com/kuadrant/authorino-operator
git checkout authorino-k8s-auth-role
make docker-build OPERATOR_IMAGE=authorino-operator:local

cd $GOPATH/src/github.com/kuadrant/authorino
git checkout fix/k8s-auth-namespaced
make cluster
make cert-manager
make local-build # kind load docker-image authorino:local --name authorino
kind load docker-image authorino-operator:local --name authorino
make install-operator OPERATOR_VERSION=authorino-k8s-auth-role
kubectl -n authorino-operator patch deployment/authorino-operator-controller-manager -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","image":"authorino-operator:local"}]}}}}'
make install
make namespace
make deploy

kubectl -n authorino apply -f -<<EOF
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino-2
spec:
  clusterWide: false
  listener:
    tls:
      enabled: false
  oidcServer:
    tls:
      enabled: false
EOF
```

Check the resources created:

```sh
kubectl get clusterroles -o name | grep authorino-manager
# clusterrole.rbac.authorization.k8s.io/authorino-manager-k8s-auth-role
# clusterrole.rbac.authorization.k8s.io/authorino-manager-role

kubectl get clusterrolebindings | grep authorino-manager
# authorino-k8s-auth                                     ClusterRole/authorino-manager-k8s-auth-role                                        46s

kubectl get clusterrolebindings/authorino-k8s-auth -o yaml
# apiVersion: rbac.authorization.k8s.io/v1
# kind: ClusterRoleBinding
# metadata:
#   creationTimestamp: "2022-01-12T12:08:58Z"
#   name: authorino-k8s-auth
#   resourceVersion: "3734"
#   uid: 3c99dc92-2173-4c4c-bec5-0d94906dd8d7
# roleRef:
#   apiGroup: rbac.authorization.k8s.io
#   kind: ClusterRole
#   name: authorino-manager-k8s-auth-role
# subjects:
# - kind: ServiceAccount
#   name: authorino-authorino
#   namespace: authorino
# - kind: ServiceAccount
#   name: authorino-2-authorino
#   namespace: authorino

kubectl -n authorino get serviceaccounts -o name | grep authorino
# serviceaccount/authorino-2-authorino
# serviceaccount/authorino-authorino

kubectl -n authorino get rolebindings | grep authorino
# authorino-2-authorino                   ClusterRole/authorino-manager-role    106s
# authorino-2-authorino-leader-election   Role/authorino-leader-election-role   106s
# authorino-authorino                     ClusterRole/authorino-manager-role    3m49s
# authorino-authorino-leader-election     Role/authorino-leader-election-role   3m49s
```

Delete one of the Authorino instances and check again:

```sh
kubectl -n authorino delete authorinos/authorino
# authorino.operator.authorino.kuadrant.io "authorino" deleted

kubectl get clusterrolebindings | grep authorino-manager
# authorino-k8s-auth                                     ClusterRole/authorino-manager-k8s-auth-role                                        4m58s

kubectl get clusterrolebindings/authorino-k8s-auth -o yaml
# apiVersion: rbac.authorization.k8s.io/v1
# kind: ClusterRoleBinding
# metadata:
#   creationTimestamp: "2022-01-12T12:08:58Z"
#   name: authorino-k8s-auth
#   resourceVersion: "3734"
#   uid: 3c99dc92-2173-4c4c-bec5-0d94906dd8d7
# roleRef:
#   apiGroup: rbac.authorization.k8s.io
#   kind: ClusterRole
#   name: authorino-manager-k8s-auth-role
# subjects:
# - kind: ServiceAccount
#   name: authorino-2-authorino
#   namespace: authorino
```
