### PR TITLE
[WIP] Authorino manifest config

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,21 @@ jobs:
         run: |
           make verify-manifests
 
+  verify-bundle:
+    name: Verify bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.16.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run make verify-bundle
+        run: |
+          make verify-bundle
+
   verify-fmt:
     name: Verify fmt
     runs-on: ubuntu-latest

--- a/bundle/manifests/authorino-operator-authorino-authconfig-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/authorino-operator-authorino-authconfig-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: authorino-manager-role
+  name: authorino-operator-authorino-authconfig-editor-role
 rules:
 - apiGroups:
   - authorino.kuadrant.io
@@ -15,29 +15,9 @@ rules:
   - list
   - patch
   - update
-  - watch
 - apiGroups:
   - authorino.kuadrant.io
   resources:
   - authconfigs/status
   verbs:
   - get
-  - patch
-  - update
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-  - get
-  - list
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch

--- a/bundle/manifests/authorino-operator-authorino-authconfig-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/authorino-operator-authorino-authconfig-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -2,19 +2,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: authorino-authconfig-editor-role
+  name: authorino-operator-authorino-authconfig-viewer-role
 rules:
 - apiGroups:
   - authorino.kuadrant.io
   resources:
   - authconfigs
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
+  - watch
 - apiGroups:
   - authorino.kuadrant.io
   resources:

--- a/bundle/manifests/authorino-operator-authorino-manager-k8s-auth-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/authorino-operator-authorino-manager-k8s-auth-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: authorino-proxy-role
+  name: authorino-operator-authorino-manager-k8s-auth-role
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/bundle/manifests/authorino-operator-authorino-manager-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/authorino-operator-authorino-manager-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: authorino-operator-authorino-manager-role
+rules:
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/bundle/manifests/authorino-operator-authorino-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/authorino-operator-authorino-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: authorino-metrics-reader
+  name: authorino-operator-authorino-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics

--- a/bundle/manifests/authorino-operator-authorino-proxy-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/authorino-operator-authorino-proxy-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -2,19 +2,17 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: authorino-authconfig-viewer-role
+  name: authorino-operator-authorino-proxy-role
 rules:
 - apiGroups:
-  - authorino.kuadrant.io
+  - authentication.k8s.io
   resources:
-  - authconfigs
+  - tokenreviews
   verbs:
-  - get
-  - list
-  - watch
+  - create
 - apiGroups:
-  - authorino.kuadrant.io
+  - authorization.k8s.io
   resources:
-  - authconfigs/status
+  - subjectaccessreviews
   verbs:
-  - get
+  - create

--- a/config/authorino/authorino_manifests.yaml
+++ b/config/authorino/authorino_manifests.yaml
@@ -1,0 +1,1298 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: authconfigs.authorino.kuadrant.io
+spec:
+  group: authorino.kuadrant.io
+  names:
+    kind: AuthConfig
+    listKind: AuthConfigList
+    plural: authconfigs
+    singular: authconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready?
+      jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    - description: Number of trusted identity sources
+      jsonPath: .status.numIdentitySources
+      name: Id sources
+      priority: 2
+      type: integer
+    - description: Number of external metadata sources
+      jsonPath: .status.numMetadataSources
+      name: Metadata sources
+      priority: 2
+      type: integer
+    - description: Number of authorization policies
+      jsonPath: .status.numAuthorizationPolicies
+      name: Authz policies
+      priority: 2
+      type: integer
+    - description: Number of items added to the client response
+      jsonPath: .status.numResponseItems
+      name: Response items
+      priority: 2
+      type: integer
+    - description: Whether issuing Festival Wristbands
+      jsonPath: .status.festivalWristbandEnabled
+      name: Wristband
+      priority: 2
+      type: boolean
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: AuthConfig is the schema for Authorino's AuthConfig API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specifies the desired state of the AuthConfig resource, i.e.
+              the authencation/authorization scheme to be applied to protect the matching
+              service hosts.
+            properties:
+              authorization:
+                description: Authorization is the list of authorization policies.
+                  All policies in this list MUST evaluate to "true" for a request
+                  be successful in the authorization phase.
+                items:
+                  description: 'Authorization policy to be enforced. Apart from "name",
+                    one of the following parameters is required and only one of the
+                    following parameters is allowed: "opa", "json" or "kubernetes".'
+                  oneOf:
+                  - properties:
+                      name: {}
+                      opa: {}
+                    required:
+                    - name
+                    - opa
+                  - properties:
+                      json: {}
+                      name: {}
+                    required:
+                    - name
+                    - json
+                  - properties:
+                      kubernetes: {}
+                      name: {}
+                    required:
+                    - name
+                    - kubernetes
+                  properties:
+                    json:
+                      description: JSON pattern matching authorization policy.
+                      properties:
+                        conditions:
+                          description: Conditions that must match for Authorino to
+                            enforce this policy; otherwise, the policy will be skipped.
+                          items:
+                            properties:
+                              operator:
+                                description: 'The binary operator to be applied to
+                                  the content fetched from the authorization JSON,
+                                  for comparison with "value". Possible values are:
+                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
+                                  for arrays), "excl" (excludes; for arrays), "matches"
+                                  (regex)'
+                                enum:
+                                - eq
+                                - neq
+                                - incl
+                                - excl
+                                - matches
+                                type: string
+                              selector:
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                                  The value is used to fetch content from the input
+                                  authorization JSON built by Authorino along the
+                                  identity and metadata phases.
+                                type: string
+                              value:
+                                description: The value of reference for the comparison
+                                  with the content fetched from the authorization
+                                  policy. If used with the "matches" operator, the
+                                  value must compile to a valid Golang regex.
+                                type: string
+                            required:
+                            - operator
+                            - selector
+                            - value
+                            type: object
+                          type: array
+                        rules:
+                          description: The rules that must all evaluate to "true"
+                            for the request to be authorized.
+                          items:
+                            properties:
+                              operator:
+                                description: 'The binary operator to be applied to
+                                  the content fetched from the authorization JSON,
+                                  for comparison with "value". Possible values are:
+                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
+                                  for arrays), "excl" (excludes; for arrays), "matches"
+                                  (regex)'
+                                enum:
+                                - eq
+                                - neq
+                                - incl
+                                - excl
+                                - matches
+                                type: string
+                              selector:
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                                  The value is used to fetch content from the input
+                                  authorization JSON built by Authorino along the
+                                  identity and metadata phases.
+                                type: string
+                              value:
+                                description: The value of reference for the comparison
+                                  with the content fetched from the authorization
+                                  policy. If used with the "matches" operator, the
+                                  value must compile to a valid Golang regex.
+                                type: string
+                            required:
+                            - operator
+                            - selector
+                            - value
+                            type: object
+                          type: array
+                      type: object
+                    kubernetes:
+                      description: Kubernetes authorization policy based on `SubjectAccessReview`
+                        Path and Verb are inferred from the request.
+                      properties:
+                        conditions:
+                          description: Conditions that must match for Authorino to
+                            enforce this policy; otherwise, the policy will be skipped.
+                          items:
+                            properties:
+                              operator:
+                                description: 'The binary operator to be applied to
+                                  the content fetched from the authorization JSON,
+                                  for comparison with "value". Possible values are:
+                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
+                                  for arrays), "excl" (excludes; for arrays), "matches"
+                                  (regex)'
+                                enum:
+                                - eq
+                                - neq
+                                - incl
+                                - excl
+                                - matches
+                                type: string
+                              selector:
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                                  The value is used to fetch content from the input
+                                  authorization JSON built by Authorino along the
+                                  identity and metadata phases.
+                                type: string
+                              value:
+                                description: The value of reference for the comparison
+                                  with the content fetched from the authorization
+                                  policy. If used with the "matches" operator, the
+                                  value must compile to a valid Golang regex.
+                                type: string
+                            required:
+                            - operator
+                            - selector
+                            - value
+                            type: object
+                          type: array
+                        groups:
+                          description: Groups to test for.
+                          items:
+                            type: string
+                          type: array
+                        resourceAttributes:
+                          description: Use ResourceAttributes for checking permissions
+                            on Kubernetes resources If omitted, it performs a non-resource
+                            `SubjectAccessReview`, with verb and path inferred from
+                            the request.
+                          properties:
+                            group:
+                              properties:
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    authJSON:
+                                      description: 'Selector to fill the value from
+                                        the authorization JSON. Any patterns supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The value can be just the pattern
+                                        with the path to fetch from the authorization
+                                        JSON (e.g. ''context.request.http.host'')
+                                        or a string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                        The following string modifiers are available:
+                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
+                                      type: string
+                                  type: object
+                              type: object
+                            name:
+                              properties:
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    authJSON:
+                                      description: 'Selector to fill the value from
+                                        the authorization JSON. Any patterns supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The value can be just the pattern
+                                        with the path to fetch from the authorization
+                                        JSON (e.g. ''context.request.http.host'')
+                                        or a string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                        The following string modifiers are available:
+                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
+                                      type: string
+                                  type: object
+                              type: object
+                            namespace:
+                              properties:
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    authJSON:
+                                      description: 'Selector to fill the value from
+                                        the authorization JSON. Any patterns supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The value can be just the pattern
+                                        with the path to fetch from the authorization
+                                        JSON (e.g. ''context.request.http.host'')
+                                        or a string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                        The following string modifiers are available:
+                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
+                                      type: string
+                                  type: object
+                              type: object
+                            resource:
+                              properties:
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    authJSON:
+                                      description: 'Selector to fill the value from
+                                        the authorization JSON. Any patterns supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The value can be just the pattern
+                                        with the path to fetch from the authorization
+                                        JSON (e.g. ''context.request.http.host'')
+                                        or a string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                        The following string modifiers are available:
+                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
+                                      type: string
+                                  type: object
+                              type: object
+                            subresource:
+                              properties:
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    authJSON:
+                                      description: 'Selector to fill the value from
+                                        the authorization JSON. Any patterns supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The value can be just the pattern
+                                        with the path to fetch from the authorization
+                                        JSON (e.g. ''context.request.http.host'')
+                                        or a string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                        The following string modifiers are available:
+                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
+                                      type: string
+                                  type: object
+                              type: object
+                            verb:
+                              properties:
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    authJSON:
+                                      description: 'Selector to fill the value from
+                                        the authorization JSON. Any patterns supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The value can be just the pattern
+                                        with the path to fetch from the authorization
+                                        JSON (e.g. ''context.request.http.host'')
+                                        or a string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                        The following string modifiers are available:
+                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        user:
+                          description: User to test for. If without "Groups", then
+                            is it interpreted as "What if User were not a member of
+                            any groups"
+                          properties:
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                authJSON:
+                                  description: 'Selector to fill the value from the
+                                    authorization JSON. Any patterns supported by
+                                    https://pkg.go.dev/github.com/tidwall/gjson can
+                                    be used. The value can be just the pattern with
+                                    the path to fetch from the authorization JSON
+                                    (e.g. ''context.request.http.host'') or a string
+                                    template with variable placeholders that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!")
+                                    The following string modifiers are available:
+                                    @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, and @base64:encode|decode.'
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - user
+                      type: object
+                    name:
+                      description: Name of the authorization policy. It can be used
+                        to refer to the resolved authorization object in other configs.
+                      type: string
+                    opa:
+                      description: Open Policy Agent (OPA) authorization policy.
+                      properties:
+                        externalRegistry:
+                          description: External registry of OPA policies.
+                          properties:
+                            credentials:
+                              description: Defines where client credentials will be
+                                passed in the request to the service. If omitted,
+                                it defaults to client credentials passed in the HTTP
+                                Authorization header and the "Bearer" prefix expected
+                                prepended to the secret value.
+                              properties:
+                                in:
+                                  default: authorization_header
+                                  description: The location in the request where client
+                                    credentials shall be passed on requests authenticating
+                                    with this identity source/authentication mode.
+                                  enum:
+                                  - authorization_header
+                                  - custom_header
+                                  - query
+                                  - cookie
+                                  type: string
+                                keySelector:
+                                  description: Used in conjunction with the `in` parameter.
+                                    When used with `authorization_header`, the value
+                                    is the prefix of the client credentials string,
+                                    separated by a white-space, in the HTTP Authorization
+                                    header (e.g. "Bearer", "Basic"). When used with
+                                    `custom_header`, `query` or `cookie`, the value
+                                    is the name of the HTTP header, query string parameter
+                                    or cookie key, respectively.
+                                  type: string
+                              required:
+                              - keySelector
+                              type: object
+                            endpoint:
+                              description: Endpoint of the HTTP external registry.
+                                The endpoint must respond with either plain/text or
+                                application/json content-type. In the latter case,
+                                the JSON returned in the body must include a path
+                                `result.raw`, where the raw Rego policy will be extracted
+                                from. This complies with the specification of the
+                                OPA REST API (https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
+                              type: string
+                            sharedSecretRef:
+                              description: Reference to a Secret key whose value will
+                                be passed by Authorino in the request. The HTTP service
+                                can use the shared secret to authenticate the origin
+                                of the request.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          type: object
+                        inlineRego:
+                          description: Authorization policy as a Rego language document.
+                            The Rego document must include the "allow" condition,
+                            set by Authorino to "false" by default (i.e. requests
+                            are unauthorized unless changed). The Rego document must
+                            NOT include the "package" declaration in line 1.
+                          type: string
+                      type: object
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+              denyWith:
+                description: Custom denial response codes, statuses and headers to
+                  override default 40x's.
+                properties:
+                  unauthenticated:
+                    description: Denial status customization when the request is unauthenticated.
+                    properties:
+                      code:
+                        description: HTTP status code to override the default denial
+                          status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        description: HTTP response headers to override the default
+                          denial headers.
+                        items:
+                          properties:
+                            name:
+                              description: The name of the claim
+                              type: string
+                            value:
+                              description: Static value of the claim
+                              x-kubernetes-preserve-unknown-fields: true
+                            valueFrom:
+                              description: Dynamic value of the claim
+                              properties:
+                                authJSON:
+                                  description: 'Selector to fill the value from the
+                                    authorization JSON. Any patterns supported by
+                                    https://pkg.go.dev/github.com/tidwall/gjson can
+                                    be used. The value can be just the pattern with
+                                    the path to fetch from the authorization JSON
+                                    (e.g. ''context.request.http.host'') or a string
+                                    template with variable placeholders that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!")
+                                    The following string modifiers are available:
+                                    @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, and @base64:encode|decode.'
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      message:
+                        description: HTTP message to override the default denial message.
+                        type: string
+                    type: object
+                  unauthorized:
+                    description: Denial status customization when the request is unauthorized.
+                    properties:
+                      code:
+                        description: HTTP status code to override the default denial
+                          status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        description: HTTP response headers to override the default
+                          denial headers.
+                        items:
+                          properties:
+                            name:
+                              description: The name of the claim
+                              type: string
+                            value:
+                              description: Static value of the claim
+                              x-kubernetes-preserve-unknown-fields: true
+                            valueFrom:
+                              description: Dynamic value of the claim
+                              properties:
+                                authJSON:
+                                  description: 'Selector to fill the value from the
+                                    authorization JSON. Any patterns supported by
+                                    https://pkg.go.dev/github.com/tidwall/gjson can
+                                    be used. The value can be just the pattern with
+                                    the path to fetch from the authorization JSON
+                                    (e.g. ''context.request.http.host'') or a string
+                                    template with variable placeholders that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!")
+                                    The following string modifiers are available:
+                                    @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, and @base64:encode|decode.'
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      message:
+                        description: HTTP message to override the default denial message.
+                        type: string
+                    type: object
+                type: object
+              hosts:
+                description: The list of public host names of the services protected
+                  by this authentication/authorization scheme. Authorino uses the
+                  requested host to lookup for the corresponding authentication/authorization
+                  configs to enforce.
+                items:
+                  type: string
+                type: array
+              identity:
+                description: List of identity sources/authentication modes. At least
+                  one config of this list MUST evaluate to a valid identity for a
+                  request to be successful in the identity verification phase.
+                items:
+                  description: 'The identity source/authentication mode config. Apart
+                    from "name", one of the following parameters is required and only
+                    one of the following parameters is allowed: "oicd", "apiKey" or
+                    "kubernetes".'
+                  oneOf:
+                  - properties:
+                      credentials: {}
+                      name: {}
+                      oauth2: {}
+                    required:
+                    - name
+                    - oauth2
+                  - properties:
+                      credentials: {}
+                      name: {}
+                      oidc: {}
+                    required:
+                    - name
+                    - oidc
+                  - properties:
+                      apiKey: {}
+                      credentials: {}
+                      name: {}
+                    required:
+                    - name
+                    - apiKey
+                  - properties:
+                      credentials: {}
+                      kubernetes: {}
+                      name: {}
+                    required:
+                    - name
+                    - kubernetes
+                  properties:
+                    apiKey:
+                      properties:
+                        labelSelectors:
+                          additionalProperties:
+                            type: string
+                          description: The map of label selectors used by Authorino
+                            to match secrets from the cluster storing valid credentials
+                            to authenticate to this service
+                          type: object
+                      required:
+                      - labelSelectors
+                      type: object
+                    credentials:
+                      description: Defines where client credentials are required to
+                        be passed in the request for this identity source/authentication
+                        mode. If omitted, it defaults to client credentials passed
+                        in the HTTP Authorization header and the "Bearer" prefix expected
+                        prepended to the credentials value (token, API key, etc).
+                      properties:
+                        in:
+                          default: authorization_header
+                          description: The location in the request where client credentials
+                            shall be passed on requests authenticating with this identity
+                            source/authentication mode.
+                          enum:
+                          - authorization_header
+                          - custom_header
+                          - query
+                          - cookie
+                          type: string
+                        keySelector:
+                          description: Used in conjunction with the `in` parameter.
+                            When used with `authorization_header`, the value is the
+                            prefix of the client credentials string, separated by
+                            a white-space, in the HTTP Authorization header (e.g.
+                            "Bearer", "Basic"). When used with `custom_header`, `query`
+                            or `cookie`, the value is the name of the HTTP header,
+                            query string parameter or cookie key, respectively.
+                          type: string
+                      required:
+                      - keySelector
+                      type: object
+                    extendedProperties:
+                      description: Extends the resolved identity object with additional
+                        custom properties before appending to the authorization JSON.
+                        It requires the resolved identity object to always be of the
+                        JSON type 'object'. Other JSON types (array, string, etc)
+                        will break.
+                      items:
+                        properties:
+                          name:
+                            description: The name of the claim
+                            type: string
+                          value:
+                            description: Static value of the claim
+                            x-kubernetes-preserve-unknown-fields: true
+                          valueFrom:
+                            description: Dynamic value of the claim
+                            properties:
+                              authJSON:
+                                description: 'Selector to fill the value from the
+                                  authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The value can be just the pattern with
+                                  the path to fetch from the authorization JSON (e.g.
+                                  ''context.request.http.host'') or a string template
+                                  with variable placeholders that resolve to patterns
+                                  (e.g. "Hello, {auth.identity.name}!") The following
+                                  string modifiers are available: @extract:{sep:"
+                                  ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                                  and @base64:encode|decode.'
+                                type: string
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    kubernetes:
+                      properties:
+                        audiences:
+                          description: The list of audiences (scopes) that must be
+                            claimed in a Kubernetes authentication token supplied
+                            in the request, and reviewed by Authorino. If omitted,
+                            Authorino will review tokens expecting the host name of
+                            the requested protected service amongst the audiences.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    name:
+                      description: The name of this identity source/authentication
+                        mode. It usually identifies a source of identities or group
+                        of users/clients of the protected service. It can be used
+                        to refer to the resolved identity object in other configs.
+                      type: string
+                    oauth2:
+                      properties:
+                        credentialsRef:
+                          description: Reference to a Kubernetes secret in the same
+                            namespace, that stores client credentials to the OAuth2
+                            server.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        tokenIntrospectionUrl:
+                          description: The full URL of the token introspection endpoint.
+                          type: string
+                        tokenTypeHint:
+                          description: The token type hint for the token introspection.
+                            If omitted, it defaults to "access_token".
+                          type: string
+                      required:
+                      - credentialsRef
+                      - tokenIntrospectionUrl
+                      type: object
+                    oidc:
+                      properties:
+                        endpoint:
+                          description: Endpoint of the OIDC issuer. Authorino will
+                            append to this value the well-known path to the OpenID
+                            Connect discovery endpoint (i.e. "/.well-known/openid-configuration"),
+                            used to automatically discover the OpenID Connect configuration,
+                            whose set of claims is expected to include (among others)
+                            the "jkws_uri" claim. The value must coincide with the
+                            value of  the "iss" (issuer) claim of the discovered OpenID
+                            Connect configuration.
+                          type: string
+                        ttl:
+                          description: Decides how long to wait before refreshing
+                            the OIDC configuration (in seconds).
+                          type: integer
+                      required:
+                      - endpoint
+                      type: object
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+              metadata:
+                description: List of metadata source configs. Authorino fetches JSON
+                  content from sources on this list on every request.
+                items:
+                  description: 'The metadata config. Apart from "name", one of the
+                    following parameters is required and only one of the following
+                    parameters is allowed: "userInfo" or "uma".'
+                  oneOf:
+                  - properties:
+                      name: {}
+                      userInfo: {}
+                    required:
+                    - name
+                    - userInfo
+                  - properties:
+                      name: {}
+                      uma: {}
+                    required:
+                    - name
+                    - uma
+                  - properties:
+                      name: {}
+                      uma: {}
+                    required:
+                    - name
+                    - http
+                  properties:
+                    http:
+                      description: Generic HTTP interface to obtain authorization
+                        metadata from a HTTP service.
+                      properties:
+                        bodyParameters:
+                          description: Custom parameters to encode in the body of
+                            the HTTP request. Use it with method=POST; for GET requests,
+                            specify parameters using placeholders in the endpoint.
+                          items:
+                            properties:
+                              name:
+                                description: The name of the claim
+                                type: string
+                              value:
+                                description: Static value of the claim
+                                x-kubernetes-preserve-unknown-fields: true
+                              valueFrom:
+                                description: Dynamic value of the claim
+                                properties:
+                                  authJSON:
+                                    description: 'Selector to fill the value from
+                                      the authorization JSON. Any patterns supported
+                                      by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The value can be just the pattern
+                                      with the path to fetch from the authorization
+                                      JSON (e.g. ''context.request.http.host'') or
+                                      a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                      The following string modifiers are available:
+                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower, and @base64:encode|decode.'
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        contentType:
+                          default: application/x-www-form-urlencoded
+                          description: Content-Type of the request body.
+                          enum:
+                          - application/x-www-form-urlencoded
+                          - application/json
+                          type: string
+                        credentials:
+                          description: Defines where client credentials will be passed
+                            in the request to the service. If omitted, it defaults
+                            to client credentials passed in the HTTP Authorization
+                            header and the "Bearer" prefix expected prepended to the
+                            secret value.
+                          properties:
+                            in:
+                              default: authorization_header
+                              description: The location in the request where client
+                                credentials shall be passed on requests authenticating
+                                with this identity source/authentication mode.
+                              enum:
+                              - authorization_header
+                              - custom_header
+                              - query
+                              - cookie
+                              type: string
+                            keySelector:
+                              description: Used in conjunction with the `in` parameter.
+                                When used with `authorization_header`, the value is
+                                the prefix of the client credentials string, separated
+                                by a white-space, in the HTTP Authorization header
+                                (e.g. "Bearer", "Basic"). When used with `custom_header`,
+                                `query` or `cookie`, the value is the name of the
+                                HTTP header, query string parameter or cookie key,
+                                respectively.
+                              type: string
+                          required:
+                          - keySelector
+                          type: object
+                        endpoint:
+                          description: Endpoint of the HTTP service. The endpoint
+                            accepts variable placeholders in the format "{selector}",
+                            where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                            and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
+                          type: string
+                        headers:
+                          description: Custom headers in the HTTP request.
+                          items:
+                            properties:
+                              name:
+                                description: The name of the claim
+                                type: string
+                              value:
+                                description: Static value of the claim
+                                x-kubernetes-preserve-unknown-fields: true
+                              valueFrom:
+                                description: Dynamic value of the claim
+                                properties:
+                                  authJSON:
+                                    description: 'Selector to fill the value from
+                                      the authorization JSON. Any patterns supported
+                                      by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The value can be just the pattern
+                                      with the path to fetch from the authorization
+                                      JSON (e.g. ''context.request.http.host'') or
+                                      a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                      The following string modifiers are available:
+                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower, and @base64:encode|decode.'
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        method:
+                          description: 'HTTP verb used in the request to the service.
+                            Accepted values: GET (default), POST. When the request
+                            method is POST, the authorization JSON is passed in the
+                            body of the request.'
+                          enum:
+                          - GET
+                          - POST
+                          type: string
+                        sharedSecretRef:
+                          description: Reference to a Secret key whose value will
+                            be passed by Authorino in the request. The HTTP service
+                            can use the shared secret to authenticate the origin of
+                            the request.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - endpoint
+                      type: object
+                    name:
+                      description: The name of the metadata source. It can be used
+                        to refer to the resolved metadata object in other configs.
+                      type: string
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
+                    uma:
+                      description: User-Managed Access (UMA) source of resource data.
+                      properties:
+                        credentialsRef:
+                          description: Reference to a Kubernetes secret in the same
+                            namespace, that stores client credentials to the resource
+                            registration API of the UMA server.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        endpoint:
+                          description: The endpoint of the UMA server. The value must
+                            coincide with the "issuer" claim of the UMA config discovered
+                            from the well-known uma configuration endpoint.
+                          type: string
+                      required:
+                      - credentialsRef
+                      - endpoint
+                      type: object
+                    userInfo:
+                      description: OpendID Connect UserInfo linked to an OIDC identity
+                        config of this same spec.
+                      properties:
+                        identitySource:
+                          description: The name of an OIDC identity source included
+                            in the "identity" section and whose OpenID Connect configuration
+                            discovered includes the OIDC "userinfo_endpoint" claim.
+                          type: string
+                      required:
+                      - identitySource
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              response:
+                description: List of response configs. Authorino gathers data from
+                  the auth pipeline to build custom responses for the client.
+                items:
+                  description: 'Dynamic response to return to the client. Apart from
+                    "name", one of the following parameters is required and only one
+                    of the following parameters is allowed: "wristband" or "json".'
+                  properties:
+                    json:
+                      properties:
+                        properties:
+                          description: List of JSON property-value pairs to be added
+                            to the dynamic response.
+                          items:
+                            properties:
+                              name:
+                                description: The name of the claim
+                                type: string
+                              value:
+                                description: Static value of the claim
+                                x-kubernetes-preserve-unknown-fields: true
+                              valueFrom:
+                                description: Dynamic value of the claim
+                                properties:
+                                  authJSON:
+                                    description: 'Selector to fill the value from
+                                      the authorization JSON. Any patterns supported
+                                      by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The value can be just the pattern
+                                      with the path to fetch from the authorization
+                                      JSON (e.g. ''context.request.http.host'') or
+                                      a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                      The following string modifiers are available:
+                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower, and @base64:encode|decode.'
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      required:
+                      - properties
+                      type: object
+                    name:
+                      description: Name of the custom response. It can be used to
+                        refer to the resolved response object in other configs.
+                      type: string
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
+                    wrapper:
+                      default: httpHeader
+                      description: How Authorino wraps the response. Use "httpHeader"
+                        (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata"
+                        to wrap the response as Envoy Dynamic Metadata
+                      enum:
+                      - httpHeader
+                      - envoyDynamicMetadata
+                      type: string
+                    wrapperKey:
+                      description: The name of key used in the wrapped response (name
+                        of the HTTP header or property of the Envoy Dynamic Metadata
+                        JSON). If omitted, it will be set to the name of the configuration.
+                      type: string
+                    wristband:
+                      properties:
+                        customClaims:
+                          description: Any claims to be added to the wristband token
+                            apart from the standard JWT claims (iss, iat, exp) added
+                            by default.
+                          items:
+                            properties:
+                              name:
+                                description: The name of the claim
+                                type: string
+                              value:
+                                description: Static value of the claim
+                                x-kubernetes-preserve-unknown-fields: true
+                              valueFrom:
+                                description: Dynamic value of the claim
+                                properties:
+                                  authJSON:
+                                    description: 'Selector to fill the value from
+                                      the authorization JSON. Any patterns supported
+                                      by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The value can be just the pattern
+                                      with the path to fetch from the authorization
+                                      JSON (e.g. ''context.request.http.host'') or
+                                      a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
+                                      The following string modifiers are available:
+                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower, and @base64:encode|decode.'
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        issuer:
+                          description: 'The endpoint to the Authorino service that
+                            issues the wristband (format: <scheme>://<host>:<port>/<realm>,
+                            where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                          type: string
+                        signingKeyRefs:
+                          description: Reference by name to Kubernetes secrets and
+                            corresponding signing algorithms. The secrets must contain
+                            a `key.pem` entry whose value is the signing key formatted
+                            as PEM.
+                          items:
+                            properties:
+                              algorithm:
+                                description: Algorithm to sign the wristband token
+                                  using the signing key provided
+                                enum:
+                                - ES256
+                                - ES384
+                                - ES512
+                                - RS256
+                                - RS384
+                                - RS512
+                                type: string
+                              name:
+                                description: Name of the signing key. The value is
+                                  used to reference the Kubernetes secret that stores
+                                  the key and in the `kid` claim of the wristband
+                                  token header.
+                                type: string
+                            required:
+                            - algorithm
+                            - name
+                            type: object
+                          type: array
+                        tokenDuration:
+                          description: Time span of the wristband token, in seconds.
+                          format: int64
+                          type: integer
+                      required:
+                      - issuer
+                      - signingKeyRefs
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - hosts
+            type: object
+          status:
+            description: AuthConfigStatus defines the observed state of AuthConfig
+            properties:
+              festivalWristbandEnabled:
+                type: boolean
+              numAuthorizationPolicies:
+                format: int64
+                type: integer
+              numIdentitySources:
+                format: int64
+                type: integer
+              numMetadataSources:
+                format: int64
+                type: integer
+              numResponseItems:
+                format: int64
+                type: integer
+              ready:
+                type: boolean
+            required:
+            - festivalWristbandEnabled
+            - numAuthorizationPolicies
+            - numIdentitySources
+            - numMetadataSources
+            - numResponseItems
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-authconfig-editor-role
+rules:
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-authconfig-viewer-role
+rules:
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-manager-k8s-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: authorino-manager-role
+rules:
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/config/authorino/kustomization.yaml
+++ b/config/authorino/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- authorino_manifests.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,6 +16,7 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
+- ../authorino
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -1,3 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: authorino-operator
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -50,30 +57,20 @@ spec:
         description: AuthConfig is the schema for Authorino's AuthConfig API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: Specifies the desired state of the AuthConfig resource, i.e.
-              the authencation/authorization scheme to be applied to protect the matching
-              service hosts.
+            description: Specifies the desired state of the AuthConfig resource, i.e. the authencation/authorization scheme to be applied to protect the matching service hosts.
             properties:
               authorization:
-                description: Authorization is the list of authorization policies.
-                  All policies in this list MUST evaluate to "true" for a request
-                  be successful in the authorization phase.
+                description: Authorization is the list of authorization policies. All policies in this list MUST evaluate to "true" for a request be successful in the authorization phase.
                 items:
-                  description: 'Authorization policy to be enforced. Apart from "name",
-                    one of the following parameters is required and only one of the
-                    following parameters is allowed: "opa", "json" or "kubernetes".'
+                  description: 'Authorization policy to be enforced. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "opa", "json" or "kubernetes".'
                   oneOf:
                   - properties:
                       name: {}
@@ -98,17 +95,11 @@ spec:
                       description: JSON pattern matching authorization policy.
                       properties:
                         conditions:
-                          description: Conditions that must match for Authorino to
-                            enforce this policy; otherwise, the policy will be skipped.
+                          description: Conditions that must match for Authorino to enforce this policy; otherwise, the policy will be skipped.
                           items:
                             properties:
                               operator:
-                                description: 'The binary operator to be applied to
-                                  the content fetched from the authorization JSON,
-                                  for comparison with "value". Possible values are:
-                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
-                                  for arrays), "excl" (excludes; for arrays), "matches"
-                                  (regex)'
+                                description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
                                 enum:
                                 - eq
                                 - neq
@@ -117,16 +108,10 @@ spec:
                                 - matches
                                 type: string
                               selector:
-                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                                  The value is used to fetch content from the input
-                                  authorization JSON built by Authorino along the
-                                  identity and metadata phases.
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                                 type: string
                               value:
-                                description: The value of reference for the comparison
-                                  with the content fetched from the authorization
-                                  policy. If used with the "matches" operator, the
-                                  value must compile to a valid Golang regex.
+                                description: The value of reference for the comparison with the content fetched from the authorization policy. If used with the "matches" operator, the value must compile to a valid Golang regex.
                                 type: string
                             required:
                             - operator
@@ -135,17 +120,11 @@ spec:
                             type: object
                           type: array
                         rules:
-                          description: The rules that must all evaluate to "true"
-                            for the request to be authorized.
+                          description: The rules that must all evaluate to "true" for the request to be authorized.
                           items:
                             properties:
                               operator:
-                                description: 'The binary operator to be applied to
-                                  the content fetched from the authorization JSON,
-                                  for comparison with "value". Possible values are:
-                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
-                                  for arrays), "excl" (excludes; for arrays), "matches"
-                                  (regex)'
+                                description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
                                 enum:
                                 - eq
                                 - neq
@@ -154,16 +133,10 @@ spec:
                                 - matches
                                 type: string
                               selector:
-                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                                  The value is used to fetch content from the input
-                                  authorization JSON built by Authorino along the
-                                  identity and metadata phases.
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                                 type: string
                               value:
-                                description: The value of reference for the comparison
-                                  with the content fetched from the authorization
-                                  policy. If used with the "matches" operator, the
-                                  value must compile to a valid Golang regex.
+                                description: The value of reference for the comparison with the content fetched from the authorization policy. If used with the "matches" operator, the value must compile to a valid Golang regex.
                                 type: string
                             required:
                             - operator
@@ -173,21 +146,14 @@ spec:
                           type: array
                       type: object
                     kubernetes:
-                      description: Kubernetes authorization policy based on `SubjectAccessReview`
-                        Path and Verb are inferred from the request.
+                      description: Kubernetes authorization policy based on `SubjectAccessReview` Path and Verb are inferred from the request.
                       properties:
                         conditions:
-                          description: Conditions that must match for Authorino to
-                            enforce this policy; otherwise, the policy will be skipped.
+                          description: Conditions that must match for Authorino to enforce this policy; otherwise, the policy will be skipped.
                           items:
                             properties:
                               operator:
-                                description: 'The binary operator to be applied to
-                                  the content fetched from the authorization JSON,
-                                  for comparison with "value". Possible values are:
-                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
-                                  for arrays), "excl" (excludes; for arrays), "matches"
-                                  (regex)'
+                                description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
                                 enum:
                                 - eq
                                 - neq
@@ -196,16 +162,10 @@ spec:
                                 - matches
                                 type: string
                               selector:
-                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                                  The value is used to fetch content from the input
-                                  authorization JSON built by Authorino along the
-                                  identity and metadata phases.
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                                 type: string
                               value:
-                                description: The value of reference for the comparison
-                                  with the content fetched from the authorization
-                                  policy. If used with the "matches" operator, the
-                                  value must compile to a valid Golang regex.
+                                description: The value of reference for the comparison with the content fetched from the authorization policy. If used with the "matches" operator, the value must compile to a valid Golang regex.
                                 type: string
                             required:
                             - operator
@@ -219,10 +179,7 @@ spec:
                             type: string
                           type: array
                         resourceAttributes:
-                          description: Use ResourceAttributes for checking permissions
-                            on Kubernetes resources If omitted, it performs a non-resource
-                            `SubjectAccessReview`, with verb and path inferred from
-                            the request.
+                          description: Use ResourceAttributes for checking permissions on Kubernetes resources If omitted, it performs a non-resource `SubjectAccessReview`, with verb and path inferred from the request.
                           properties:
                             group:
                               properties:
@@ -231,17 +188,7 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
@@ -252,17 +199,7 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
@@ -273,17 +210,7 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
@@ -294,17 +221,7 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
@@ -315,17 +232,7 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
@@ -336,42 +243,20 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                           type: object
                         user:
-                          description: User to test for. If without "Groups", then
-                            is it interpreted as "What if User were not a member of
-                            any groups"
+                          description: User to test for. If without "Groups", then is it interpreted as "What if User were not a member of any groups"
                           properties:
                             value:
                               type: string
                             valueFrom:
                               properties:
                                 authJSON:
-                                  description: 'Selector to fill the value from the
-                                    authorization JSON. Any patterns supported by
-                                    https://pkg.go.dev/github.com/tidwall/gjson can
-                                    be used. The value can be just the pattern with
-                                    the path to fetch from the authorization JSON
-                                    (e.g. ''context.request.http.host'') or a string
-                                    template with variable placeholders that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!")
-                                    The following string modifiers are available:
-                                    @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           type: object
@@ -379,8 +264,7 @@ spec:
                       - user
                       type: object
                     name:
-                      description: Name of the authorization policy. It can be used
-                        to refer to the resolved authorization object in other configs.
+                      description: Name of the authorization policy. It can be used to refer to the resolved authorization object in other configs.
                       type: string
                     opa:
                       description: Open Policy Agent (OPA) authorization policy.
@@ -389,17 +273,11 @@ spec:
                           description: External registry of OPA policies.
                           properties:
                             credentials:
-                              description: Defines where client credentials will be
-                                passed in the request to the service. If omitted,
-                                it defaults to client credentials passed in the HTTP
-                                Authorization header and the "Bearer" prefix expected
-                                prepended to the secret value.
+                              description: Defines where client credentials will be passed in the request to the service. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
                               properties:
                                 in:
                                   default: authorization_header
-                                  description: The location in the request where client
-                                    credentials shall be passed on requests authenticating
-                                    with this identity source/authentication mode.
+                                  description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
                                   enum:
                                   - authorization_header
                                   - custom_header
@@ -407,40 +285,22 @@ spec:
                                   - cookie
                                   type: string
                                 keySelector:
-                                  description: Used in conjunction with the `in` parameter.
-                                    When used with `authorization_header`, the value
-                                    is the prefix of the client credentials string,
-                                    separated by a white-space, in the HTTP Authorization
-                                    header (e.g. "Bearer", "Basic"). When used with
-                                    `custom_header`, `query` or `cookie`, the value
-                                    is the name of the HTTP header, query string parameter
-                                    or cookie key, respectively.
+                                  description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
                                   type: string
                               required:
                               - keySelector
                               type: object
                             endpoint:
-                              description: Endpoint of the HTTP external registry.
-                                The endpoint must respond with either plain/text or
-                                application/json content-type. In the latter case,
-                                the JSON returned in the body must include a path
-                                `result.raw`, where the raw Rego policy will be extracted
-                                from. This complies with the specification of the
-                                OPA REST API (https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
+                              description: Endpoint of the HTTP external registry. The endpoint must respond with either plain/text or application/json content-type. In the latter case, the JSON returned in the body must include a path `result.raw`, where the raw Rego policy will be extracted from. This complies with the specification of the OPA REST API (https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
                               type: string
                             sharedSecretRef:
-                              description: Reference to a Secret key whose value will
-                                be passed by Authorino in the request. The HTTP service
-                                can use the shared secret to authenticate the origin
-                                of the request.
+                              description: Reference to a Secret key whose value will be passed by Authorino in the request. The HTTP service can use the shared secret to authenticate the origin of the request.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
+                                  description: The key of the secret to select from.  Must be a valid secret key.
                                   type: string
                                 name:
-                                  description: The name of the secret in the Authorino's
-                                    namespace to select from.
+                                  description: The name of the secret in the Authorino's namespace to select from.
                                   type: string
                               required:
                               - key
@@ -448,40 +308,31 @@ spec:
                               type: object
                           type: object
                         inlineRego:
-                          description: Authorization policy as a Rego language document.
-                            The Rego document must include the "allow" condition,
-                            set by Authorino to "false" by default (i.e. requests
-                            are unauthorized unless changed). The Rego document must
-                            NOT include the "package" declaration in line 1.
+                          description: Authorization policy as a Rego language document. The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed). The Rego document must NOT include the "package" declaration in line 1.
                           type: string
                       type: object
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
+                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
                       type: integer
                   required:
                   - name
                   type: object
                 type: array
               denyWith:
-                description: Custom denial response codes, statuses and headers to
-                  override default 40x's.
+                description: Custom denial response codes, statuses and headers to override default 40x's.
                 properties:
                   unauthenticated:
                     description: Denial status customization when the request is unauthenticated.
                     properties:
                       code:
-                        description: HTTP status code to override the default denial
-                          status code.
+                        description: HTTP status code to override the default denial status code.
                         format: int64
                         maximum: 599
                         minimum: 300
                         type: integer
                       headers:
-                        description: HTTP response headers to override the default
-                          denial headers.
+                        description: HTTP response headers to override the default denial headers.
                         items:
                           properties:
                             name:
@@ -494,17 +345,7 @@ spec:
                               description: Dynamic value of the claim
                               properties:
                                 authJSON:
-                                  description: 'Selector to fill the value from the
-                                    authorization JSON. Any patterns supported by
-                                    https://pkg.go.dev/github.com/tidwall/gjson can
-                                    be used. The value can be just the pattern with
-                                    the path to fetch from the authorization JSON
-                                    (e.g. ''context.request.http.host'') or a string
-                                    template with variable placeholders that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!")
-                                    The following string modifiers are available:
-                                    @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           required:
@@ -519,15 +360,13 @@ spec:
                     description: Denial status customization when the request is unauthorized.
                     properties:
                       code:
-                        description: HTTP status code to override the default denial
-                          status code.
+                        description: HTTP status code to override the default denial status code.
                         format: int64
                         maximum: 599
                         minimum: 300
                         type: integer
                       headers:
-                        description: HTTP response headers to override the default
-                          denial headers.
+                        description: HTTP response headers to override the default denial headers.
                         items:
                           properties:
                             name:
@@ -540,17 +379,7 @@ spec:
                               description: Dynamic value of the claim
                               properties:
                                 authJSON:
-                                  description: 'Selector to fill the value from the
-                                    authorization JSON. Any patterns supported by
-                                    https://pkg.go.dev/github.com/tidwall/gjson can
-                                    be used. The value can be just the pattern with
-                                    the path to fetch from the authorization JSON
-                                    (e.g. ''context.request.http.host'') or a string
-                                    template with variable placeholders that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!")
-                                    The following string modifiers are available:
-                                    @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           required:
@@ -563,22 +392,14 @@ spec:
                     type: object
                 type: object
               hosts:
-                description: The list of public host names of the services protected
-                  by this authentication/authorization scheme. Authorino uses the
-                  requested host to lookup for the corresponding authentication/authorization
-                  configs to enforce.
+                description: The list of public host names of the services protected by this authentication/authorization scheme. Authorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.
                 items:
                   type: string
                 type: array
               identity:
-                description: List of identity sources/authentication modes. At least
-                  one config of this list MUST evaluate to a valid identity for a
-                  request to be successful in the identity verification phase.
+                description: List of identity sources/authentication modes. At least one config of this list MUST evaluate to a valid identity for a request to be successful in the identity verification phase.
                 items:
-                  description: 'The identity source/authentication mode config. Apart
-                    from "name", one of the following parameters is required and only
-                    one of the following parameters is allowed: "oicd", "apiKey" or
-                    "kubernetes".'
+                  description: 'The identity source/authentication mode config. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "oicd", "apiKey" or "kubernetes".'
                   oneOf:
                   - properties:
                       credentials: {}
@@ -614,25 +435,17 @@ spec:
                         labelSelectors:
                           additionalProperties:
                             type: string
-                          description: The map of label selectors used by Authorino
-                            to match secrets from the cluster storing valid credentials
-                            to authenticate to this service
+                          description: The map of label selectors used by Authorino to match secrets from the cluster storing valid credentials to authenticate to this service
                           type: object
                       required:
                       - labelSelectors
                       type: object
                     credentials:
-                      description: Defines where client credentials are required to
-                        be passed in the request for this identity source/authentication
-                        mode. If omitted, it defaults to client credentials passed
-                        in the HTTP Authorization header and the "Bearer" prefix expected
-                        prepended to the credentials value (token, API key, etc).
+                      description: Defines where client credentials are required to be passed in the request for this identity source/authentication mode. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the credentials value (token, API key, etc).
                       properties:
                         in:
                           default: authorization_header
-                          description: The location in the request where client credentials
-                            shall be passed on requests authenticating with this identity
-                            source/authentication mode.
+                          description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
                           enum:
                           - authorization_header
                           - custom_header
@@ -640,23 +453,13 @@ spec:
                           - cookie
                           type: string
                         keySelector:
-                          description: Used in conjunction with the `in` parameter.
-                            When used with `authorization_header`, the value is the
-                            prefix of the client credentials string, separated by
-                            a white-space, in the HTTP Authorization header (e.g.
-                            "Bearer", "Basic"). When used with `custom_header`, `query`
-                            or `cookie`, the value is the name of the HTTP header,
-                            query string parameter or cookie key, respectively.
+                          description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
                           type: string
                       required:
                       - keySelector
                       type: object
                     extendedProperties:
-                      description: Extends the resolved identity object with additional
-                        custom properties before appending to the authorization JSON.
-                        It requires the resolved identity object to always be of the
-                        JSON type 'object'. Other JSON types (array, string, etc)
-                        will break.
+                      description: Extends the resolved identity object with additional custom properties before appending to the authorization JSON. It requires the resolved identity object to always be of the JSON type 'object'. Other JSON types (array, string, etc) will break.
                       items:
                         properties:
                           name:
@@ -669,16 +472,7 @@ spec:
                             description: Dynamic value of the claim
                             properties:
                               authJSON:
-                                description: 'Selector to fill the value from the
-                                  authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                  can be used. The value can be just the pattern with
-                                  the path to fetch from the authorization JSON (e.g.
-                                  ''context.request.http.host'') or a string template
-                                  with variable placeholders that resolve to patterns
-                                  (e.g. "Hello, {auth.identity.name}!") The following
-                                  string modifiers are available: @extract:{sep:"
-                                  ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                                  and @base64:encode|decode.'
+                                description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                 type: string
                             type: object
                         required:
@@ -688,39 +482,28 @@ spec:
                     kubernetes:
                       properties:
                         audiences:
-                          description: The list of audiences (scopes) that must be
-                            claimed in a Kubernetes authentication token supplied
-                            in the request, and reviewed by Authorino. If omitted,
-                            Authorino will review tokens expecting the host name of
-                            the requested protected service amongst the audiences.
+                          description: The list of audiences (scopes) that must be claimed in a Kubernetes authentication token supplied in the request, and reviewed by Authorino. If omitted, Authorino will review tokens expecting the host name of the requested protected service amongst the audiences.
                           items:
                             type: string
                           type: array
                       type: object
                     name:
-                      description: The name of this identity source/authentication
-                        mode. It usually identifies a source of identities or group
-                        of users/clients of the protected service. It can be used
-                        to refer to the resolved identity object in other configs.
+                      description: The name of this identity source/authentication mode. It usually identifies a source of identities or group of users/clients of the protected service. It can be used to refer to the resolved identity object in other configs.
                       type: string
                     oauth2:
                       properties:
                         credentialsRef:
-                          description: Reference to a Kubernetes secret in the same
-                            namespace, that stores client credentials to the OAuth2
-                            server.
+                          description: Reference to a Kubernetes secret in the same namespace, that stores client credentials to the OAuth2 server.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                         tokenIntrospectionUrl:
                           description: The full URL of the token introspection endpoint.
                           type: string
                         tokenTypeHint:
-                          description: The token type hint for the token introspection.
-                            If omitted, it defaults to "access_token".
+                          description: The token type hint for the token introspection. If omitted, it defaults to "access_token".
                           type: string
                       required:
                       - credentialsRef
@@ -729,39 +512,26 @@ spec:
                     oidc:
                       properties:
                         endpoint:
-                          description: Endpoint of the OIDC issuer. Authorino will
-                            append to this value the well-known path to the OpenID
-                            Connect discovery endpoint (i.e. "/.well-known/openid-configuration"),
-                            used to automatically discover the OpenID Connect configuration,
-                            whose set of claims is expected to include (among others)
-                            the "jkws_uri" claim. The value must coincide with the
-                            value of  the "iss" (issuer) claim of the discovered OpenID
-                            Connect configuration.
+                          description: Endpoint of the OIDC issuer. Authorino will append to this value the well-known path to the OpenID Connect discovery endpoint (i.e. "/.well-known/openid-configuration"), used to automatically discover the OpenID Connect configuration, whose set of claims is expected to include (among others) the "jkws_uri" claim. The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
                           type: string
                         ttl:
-                          description: Decides how long to wait before refreshing
-                            the OIDC configuration (in seconds).
+                          description: Decides how long to wait before refreshing the OIDC configuration (in seconds).
                           type: integer
                       required:
                       - endpoint
                       type: object
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
+                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
                       type: integer
                   required:
                   - name
                   type: object
                 type: array
               metadata:
-                description: List of metadata source configs. Authorino fetches JSON
-                  content from sources on this list on every request.
+                description: List of metadata source configs. Authorino fetches JSON content from sources on this list on every request.
                 items:
-                  description: 'The metadata config. Apart from "name", one of the
-                    following parameters is required and only one of the following
-                    parameters is allowed: "userInfo" or "uma".'
+                  description: 'The metadata config. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "userInfo" or "uma".'
                   oneOf:
                   - properties:
                       name: {}
@@ -783,13 +553,10 @@ spec:
                     - http
                   properties:
                     http:
-                      description: Generic HTTP interface to obtain authorization
-                        metadata from a HTTP service.
+                      description: Generic HTTP interface to obtain authorization metadata from a HTTP service.
                       properties:
                         bodyParameters:
-                          description: Custom parameters to encode in the body of
-                            the HTTP request. Use it with method=POST; for GET requests,
-                            specify parameters using placeholders in the endpoint.
+                          description: Custom parameters to encode in the body of the HTTP request. Use it with method=POST; for GET requests, specify parameters using placeholders in the endpoint.
                           items:
                             properties:
                               name:
@@ -802,17 +569,7 @@ spec:
                                 description: Dynamic value of the claim
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from
-                                      the authorization JSON. Any patterns supported
-                                      by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The value can be just the pattern
-                                      with the path to fetch from the authorization
-                                      JSON (e.g. ''context.request.http.host'') or
-                                      a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                      The following string modifiers are available:
-                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -827,17 +584,11 @@ spec:
                           - application/json
                           type: string
                         credentials:
-                          description: Defines where client credentials will be passed
-                            in the request to the service. If omitted, it defaults
-                            to client credentials passed in the HTTP Authorization
-                            header and the "Bearer" prefix expected prepended to the
-                            secret value.
+                          description: Defines where client credentials will be passed in the request to the service. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
                           properties:
                             in:
                               default: authorization_header
-                              description: The location in the request where client
-                                credentials shall be passed on requests authenticating
-                                with this identity source/authentication mode.
+                              description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
                               enum:
                               - authorization_header
                               - custom_header
@@ -845,23 +596,13 @@ spec:
                               - cookie
                               type: string
                             keySelector:
-                              description: Used in conjunction with the `in` parameter.
-                                When used with `authorization_header`, the value is
-                                the prefix of the client credentials string, separated
-                                by a white-space, in the HTTP Authorization header
-                                (e.g. "Bearer", "Basic"). When used with `custom_header`,
-                                `query` or `cookie`, the value is the name of the
-                                HTTP header, query string parameter or cookie key,
-                                respectively.
+                              description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
                               type: string
                           required:
                           - keySelector
                           type: object
                         endpoint:
-                          description: Endpoint of the HTTP service. The endpoint
-                            accepts variable placeholders in the format "{selector}",
-                            where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                            and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
+                          description: Endpoint of the HTTP service. The endpoint accepts variable placeholders in the format "{selector}", where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
                           type: string
                         headers:
                           description: Custom headers in the HTTP request.
@@ -877,17 +618,7 @@ spec:
                                 description: Dynamic value of the claim
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from
-                                      the authorization JSON. Any patterns supported
-                                      by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The value can be just the pattern
-                                      with the path to fetch from the authorization
-                                      JSON (e.g. ''context.request.http.host'') or
-                                      a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                      The following string modifiers are available:
-                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -895,27 +626,19 @@ spec:
                             type: object
                           type: array
                         method:
-                          description: 'HTTP verb used in the request to the service.
-                            Accepted values: GET (default), POST. When the request
-                            method is POST, the authorization JSON is passed in the
-                            body of the request.'
+                          description: 'HTTP verb used in the request to the service. Accepted values: GET (default), POST. When the request method is POST, the authorization JSON is passed in the body of the request.'
                           enum:
                           - GET
                           - POST
                           type: string
                         sharedSecretRef:
-                          description: Reference to a Secret key whose value will
-                            be passed by Authorino in the request. The HTTP service
-                            can use the shared secret to authenticate the origin of
-                            the request.
+                          description: Reference to a Secret key whose value will be passed by Authorino in the request. The HTTP service can use the shared secret to authenticate the origin of the request.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
+                              description: The key of the secret to select from.  Must be a valid secret key.
                               type: string
                             name:
-                              description: The name of the secret in the Authorino's
-                                namespace to select from.
+                              description: The name of the secret in the Authorino's namespace to select from.
                               type: string
                           required:
                           - key
@@ -925,45 +648,34 @@ spec:
                       - endpoint
                       type: object
                     name:
-                      description: The name of the metadata source. It can be used
-                        to refer to the resolved metadata object in other configs.
+                      description: The name of the metadata source. It can be used to refer to the resolved metadata object in other configs.
                       type: string
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
+                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
                       type: integer
                     uma:
                       description: User-Managed Access (UMA) source of resource data.
                       properties:
                         credentialsRef:
-                          description: Reference to a Kubernetes secret in the same
-                            namespace, that stores client credentials to the resource
-                            registration API of the UMA server.
+                          description: Reference to a Kubernetes secret in the same namespace, that stores client credentials to the resource registration API of the UMA server.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                         endpoint:
-                          description: The endpoint of the UMA server. The value must
-                            coincide with the "issuer" claim of the UMA config discovered
-                            from the well-known uma configuration endpoint.
+                          description: The endpoint of the UMA server. The value must coincide with the "issuer" claim of the UMA config discovered from the well-known uma configuration endpoint.
                           type: string
                       required:
                       - credentialsRef
                       - endpoint
                       type: object
                     userInfo:
-                      description: OpendID Connect UserInfo linked to an OIDC identity
-                        config of this same spec.
+                      description: OpendID Connect UserInfo linked to an OIDC identity config of this same spec.
                       properties:
                         identitySource:
-                          description: The name of an OIDC identity source included
-                            in the "identity" section and whose OpenID Connect configuration
-                            discovered includes the OIDC "userinfo_endpoint" claim.
+                          description: The name of an OIDC identity source included in the "identity" section and whose OpenID Connect configuration discovered includes the OIDC "userinfo_endpoint" claim.
                           type: string
                       required:
                       - identitySource
@@ -973,18 +685,14 @@ spec:
                   type: object
                 type: array
               response:
-                description: List of response configs. Authorino gathers data from
-                  the auth pipeline to build custom responses for the client.
+                description: List of response configs. Authorino gathers data from the auth pipeline to build custom responses for the client.
                 items:
-                  description: 'Dynamic response to return to the client. Apart from
-                    "name", one of the following parameters is required and only one
-                    of the following parameters is allowed: "wristband" or "json".'
+                  description: 'Dynamic response to return to the client. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "wristband" or "json".'
                   properties:
                     json:
                       properties:
                         properties:
-                          description: List of JSON property-value pairs to be added
-                            to the dynamic response.
+                          description: List of JSON property-value pairs to be added to the dynamic response.
                           items:
                             properties:
                               name:
@@ -997,17 +705,7 @@ spec:
                                 description: Dynamic value of the claim
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from
-                                      the authorization JSON. Any patterns supported
-                                      by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The value can be just the pattern
-                                      with the path to fetch from the authorization
-                                      JSON (e.g. ''context.request.http.host'') or
-                                      a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                      The following string modifiers are available:
-                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -1018,35 +716,26 @@ spec:
                       - properties
                       type: object
                     name:
-                      description: Name of the custom response. It can be used to
-                        refer to the resolved response object in other configs.
+                      description: Name of the custom response. It can be used to refer to the resolved response object in other configs.
                       type: string
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
+                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
                       type: integer
                     wrapper:
                       default: httpHeader
-                      description: How Authorino wraps the response. Use "httpHeader"
-                        (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata"
-                        to wrap the response as Envoy Dynamic Metadata
+                      description: How Authorino wraps the response. Use "httpHeader" (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata" to wrap the response as Envoy Dynamic Metadata
                       enum:
                       - httpHeader
                       - envoyDynamicMetadata
                       type: string
                     wrapperKey:
-                      description: The name of key used in the wrapped response (name
-                        of the HTTP header or property of the Envoy Dynamic Metadata
-                        JSON). If omitted, it will be set to the name of the configuration.
+                      description: The name of key used in the wrapped response (name of the HTTP header or property of the Envoy Dynamic Metadata JSON). If omitted, it will be set to the name of the configuration.
                       type: string
                     wristband:
                       properties:
                         customClaims:
-                          description: Any claims to be added to the wristband token
-                            apart from the standard JWT claims (iss, iat, exp) added
-                            by default.
+                          description: Any claims to be added to the wristband token apart from the standard JWT claims (iss, iat, exp) added by default.
                           items:
                             properties:
                               name:
@@ -1059,17 +748,7 @@ spec:
                                 description: Dynamic value of the claim
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from
-                                      the authorization JSON. Any patterns supported
-                                      by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The value can be just the pattern
-                                      with the path to fetch from the authorization
-                                      JSON (e.g. ''context.request.http.host'') or
-                                      a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                      The following string modifiers are available:
-                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -1077,20 +756,14 @@ spec:
                             type: object
                           type: array
                         issuer:
-                          description: 'The endpoint to the Authorino service that
-                            issues the wristband (format: <scheme>://<host>:<port>/<realm>,
-                            where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                          description: 'The endpoint to the Authorino service that issues the wristband (format: <scheme>://<host>:<port>/<realm>, where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
                           type: string
                         signingKeyRefs:
-                          description: Reference by name to Kubernetes secrets and
-                            corresponding signing algorithms. The secrets must contain
-                            a `key.pem` entry whose value is the signing key formatted
-                            as PEM.
+                          description: Reference by name to Kubernetes secrets and corresponding signing algorithms. The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
                           items:
                             properties:
                               algorithm:
-                                description: Algorithm to sign the wristband token
-                                  using the signing key provided
+                                description: Algorithm to sign the wristband token using the signing key provided
                                 enum:
                                 - ES256
                                 - ES384
@@ -1100,10 +773,7 @@ spec:
                                 - RS512
                                 type: string
                               name:
-                                description: Name of the signing key. The value is
-                                  used to reference the Kubernetes secret that stores
-                                  the key and in the `kid` claim of the wristband
-                                  token header.
+                                description: Name of the signing key. The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
                                 type: string
                             required:
                             - algorithm
@@ -1163,146 +833,6 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: authorino-authconfig-editor-role
-rules:
-- apiGroups:
-  - authorino.kuadrant.io
-  resources:
-  - authconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - authorino.kuadrant.io
-  resources:
-  - authconfigs/status
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: authorino-authconfig-viewer-role
-rules:
-- apiGroups:
-  - authorino.kuadrant.io
-  resources:
-  - authconfigs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - authorino.kuadrant.io
-  resources:
-  - authconfigs/status
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: authorino-manager-k8s-auth-role
-rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: authorino-manager-role
-rules:
-- apiGroups:
-  - authorino.kuadrant.io
-  resources:
-  - authconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - authorino.kuadrant.io
-  resources:
-  - authconfigs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-  - get
-  - list
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: authorino-metrics-reader
-rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: authorino-proxy-role
-rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: authorino-operator
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1531,6 +1061,139 @@ rules:
   verbs:
   - create
   - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-operator-authorino-authconfig-editor-role
+rules:
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-operator-authorino-authconfig-viewer-role
+rules:
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-operator-authorino-manager-k8s-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: authorino-operator-authorino-manager-role
+rules:
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-operator-authorino-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-operator-authorino-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config/install/kustomization.yaml
+++ b/config/install/kustomization.yaml
@@ -8,3 +8,4 @@ namePrefix: authorino-operator-
 bases:
 - ../crd
 - ../rbac
+- ../authorino

--- a/config/install/manifests.yaml
+++ b/config/install/manifests.yaml
@@ -4,6 +4,835 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
+  name: authconfigs.authorino.kuadrant.io
+spec:
+  group: authorino.kuadrant.io
+  names:
+    kind: AuthConfig
+    listKind: AuthConfigList
+    plural: authconfigs
+    singular: authconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready?
+      jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    - description: Number of trusted identity sources
+      jsonPath: .status.numIdentitySources
+      name: Id sources
+      priority: 2
+      type: integer
+    - description: Number of external metadata sources
+      jsonPath: .status.numMetadataSources
+      name: Metadata sources
+      priority: 2
+      type: integer
+    - description: Number of authorization policies
+      jsonPath: .status.numAuthorizationPolicies
+      name: Authz policies
+      priority: 2
+      type: integer
+    - description: Number of items added to the client response
+      jsonPath: .status.numResponseItems
+      name: Response items
+      priority: 2
+      type: integer
+    - description: Whether issuing Festival Wristbands
+      jsonPath: .status.festivalWristbandEnabled
+      name: Wristband
+      priority: 2
+      type: boolean
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: AuthConfig is the schema for Authorino's AuthConfig API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specifies the desired state of the AuthConfig resource, i.e. the authencation/authorization scheme to be applied to protect the matching service hosts.
+            properties:
+              authorization:
+                description: Authorization is the list of authorization policies. All policies in this list MUST evaluate to "true" for a request be successful in the authorization phase.
+                items:
+                  description: 'Authorization policy to be enforced. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "opa", "json" or "kubernetes".'
+                  oneOf:
+                  - properties:
+                      name: {}
+                      opa: {}
+                    required:
+                    - name
+                    - opa
+                  - properties:
+                      json: {}
+                      name: {}
+                    required:
+                    - name
+                    - json
+                  - properties:
+                      kubernetes: {}
+                      name: {}
+                    required:
+                    - name
+                    - kubernetes
+                  properties:
+                    json:
+                      description: JSON pattern matching authorization policy.
+                      properties:
+                        conditions:
+                          description: Conditions that must match for Authorino to enforce this policy; otherwise, the policy will be skipped.
+                          items:
+                            properties:
+                              operator:
+                                description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                                enum:
+                                - eq
+                                - neq
+                                - incl
+                                - excl
+                                - matches
+                                type: string
+                              selector:
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                                type: string
+                              value:
+                                description: The value of reference for the comparison with the content fetched from the authorization policy. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                type: string
+                            required:
+                            - operator
+                            - selector
+                            - value
+                            type: object
+                          type: array
+                        rules:
+                          description: The rules that must all evaluate to "true" for the request to be authorized.
+                          items:
+                            properties:
+                              operator:
+                                description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                                enum:
+                                - eq
+                                - neq
+                                - incl
+                                - excl
+                                - matches
+                                type: string
+                              selector:
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                                type: string
+                              value:
+                                description: The value of reference for the comparison with the content fetched from the authorization policy. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                type: string
+                            required:
+                            - operator
+                            - selector
+                            - value
+                            type: object
+                          type: array
+                      type: object
+                    kubernetes:
+                      description: Kubernetes authorization policy based on `SubjectAccessReview` Path and Verb are inferred from the request.
+                      properties:
+                        conditions:
+                          description: Conditions that must match for Authorino to enforce this policy; otherwise, the policy will be skipped.
+                          items:
+                            properties:
+                              operator:
+                                description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                                enum:
+                                - eq
+                                - neq
+                                - incl
+                                - excl
+                                - matches
+                                type: string
+                              selector:
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                                type: string
+                              value:
+                                description: The value of reference for the comparison with the content fetched from the authorization policy. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                type: string
+                            required:
+                            - operator
+                            - selector
+                            - value
+                            type: object
+                          type: array
+                        groups:
+                          description: Groups to test for.
+                          items:
+                            type: string
+                          type: array
+                        resourceAttributes:
+                          description: Use ResourceAttributes for checking permissions on Kubernetes resources If omitted, it performs a non-resource `SubjectAccessReview`, with verb and path inferred from the request.
+                          properties:
+                            group:
+                              properties:
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    authJSON:
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      type: string
+                                  type: object
+                              type: object
+                            name:
+                              properties:
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    authJSON:
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      type: string
+                                  type: object
+                              type: object
+                            namespace:
+                              properties:
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    authJSON:
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      type: string
+                                  type: object
+                              type: object
+                            resource:
+                              properties:
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    authJSON:
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      type: string
+                                  type: object
+                              type: object
+                            subresource:
+                              properties:
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    authJSON:
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      type: string
+                                  type: object
+                              type: object
+                            verb:
+                              properties:
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    authJSON:
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        user:
+                          description: User to test for. If without "Groups", then is it interpreted as "What if User were not a member of any groups"
+                          properties:
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                authJSON:
+                                  description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - user
+                      type: object
+                    name:
+                      description: Name of the authorization policy. It can be used to refer to the resolved authorization object in other configs.
+                      type: string
+                    opa:
+                      description: Open Policy Agent (OPA) authorization policy.
+                      properties:
+                        externalRegistry:
+                          description: External registry of OPA policies.
+                          properties:
+                            credentials:
+                              description: Defines where client credentials will be passed in the request to the service. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                              properties:
+                                in:
+                                  default: authorization_header
+                                  description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
+                                  enum:
+                                  - authorization_header
+                                  - custom_header
+                                  - query
+                                  - cookie
+                                  type: string
+                                keySelector:
+                                  description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
+                                  type: string
+                              required:
+                              - keySelector
+                              type: object
+                            endpoint:
+                              description: Endpoint of the HTTP external registry. The endpoint must respond with either plain/text or application/json content-type. In the latter case, the JSON returned in the body must include a path `result.raw`, where the raw Rego policy will be extracted from. This complies with the specification of the OPA REST API (https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
+                              type: string
+                            sharedSecretRef:
+                              description: Reference to a Secret key whose value will be passed by Authorino in the request. The HTTP service can use the shared secret to authenticate the origin of the request.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          type: object
+                        inlineRego:
+                          description: Authorization policy as a Rego language document. The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed). The Rego document must NOT include the "package" declaration in line 1.
+                          type: string
+                      type: object
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+              denyWith:
+                description: Custom denial response codes, statuses and headers to override default 40x's.
+                properties:
+                  unauthenticated:
+                    description: Denial status customization when the request is unauthenticated.
+                    properties:
+                      code:
+                        description: HTTP status code to override the default denial status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        description: HTTP response headers to override the default denial headers.
+                        items:
+                          properties:
+                            name:
+                              description: The name of the claim
+                              type: string
+                            value:
+                              description: Static value of the claim
+                              x-kubernetes-preserve-unknown-fields: true
+                            valueFrom:
+                              description: Dynamic value of the claim
+                              properties:
+                                authJSON:
+                                  description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      message:
+                        description: HTTP message to override the default denial message.
+                        type: string
+                    type: object
+                  unauthorized:
+                    description: Denial status customization when the request is unauthorized.
+                    properties:
+                      code:
+                        description: HTTP status code to override the default denial status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        description: HTTP response headers to override the default denial headers.
+                        items:
+                          properties:
+                            name:
+                              description: The name of the claim
+                              type: string
+                            value:
+                              description: Static value of the claim
+                              x-kubernetes-preserve-unknown-fields: true
+                            valueFrom:
+                              description: Dynamic value of the claim
+                              properties:
+                                authJSON:
+                                  description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      message:
+                        description: HTTP message to override the default denial message.
+                        type: string
+                    type: object
+                type: object
+              hosts:
+                description: The list of public host names of the services protected by this authentication/authorization scheme. Authorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.
+                items:
+                  type: string
+                type: array
+              identity:
+                description: List of identity sources/authentication modes. At least one config of this list MUST evaluate to a valid identity for a request to be successful in the identity verification phase.
+                items:
+                  description: 'The identity source/authentication mode config. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "oicd", "apiKey" or "kubernetes".'
+                  oneOf:
+                  - properties:
+                      credentials: {}
+                      name: {}
+                      oauth2: {}
+                    required:
+                    - name
+                    - oauth2
+                  - properties:
+                      credentials: {}
+                      name: {}
+                      oidc: {}
+                    required:
+                    - name
+                    - oidc
+                  - properties:
+                      apiKey: {}
+                      credentials: {}
+                      name: {}
+                    required:
+                    - name
+                    - apiKey
+                  - properties:
+                      credentials: {}
+                      kubernetes: {}
+                      name: {}
+                    required:
+                    - name
+                    - kubernetes
+                  properties:
+                    apiKey:
+                      properties:
+                        labelSelectors:
+                          additionalProperties:
+                            type: string
+                          description: The map of label selectors used by Authorino to match secrets from the cluster storing valid credentials to authenticate to this service
+                          type: object
+                      required:
+                      - labelSelectors
+                      type: object
+                    credentials:
+                      description: Defines where client credentials are required to be passed in the request for this identity source/authentication mode. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the credentials value (token, API key, etc).
+                      properties:
+                        in:
+                          default: authorization_header
+                          description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
+                          enum:
+                          - authorization_header
+                          - custom_header
+                          - query
+                          - cookie
+                          type: string
+                        keySelector:
+                          description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
+                          type: string
+                      required:
+                      - keySelector
+                      type: object
+                    extendedProperties:
+                      description: Extends the resolved identity object with additional custom properties before appending to the authorization JSON. It requires the resolved identity object to always be of the JSON type 'object'. Other JSON types (array, string, etc) will break.
+                      items:
+                        properties:
+                          name:
+                            description: The name of the claim
+                            type: string
+                          value:
+                            description: Static value of the claim
+                            x-kubernetes-preserve-unknown-fields: true
+                          valueFrom:
+                            description: Dynamic value of the claim
+                            properties:
+                              authJSON:
+                                description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                type: string
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    kubernetes:
+                      properties:
+                        audiences:
+                          description: The list of audiences (scopes) that must be claimed in a Kubernetes authentication token supplied in the request, and reviewed by Authorino. If omitted, Authorino will review tokens expecting the host name of the requested protected service amongst the audiences.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    name:
+                      description: The name of this identity source/authentication mode. It usually identifies a source of identities or group of users/clients of the protected service. It can be used to refer to the resolved identity object in other configs.
+                      type: string
+                    oauth2:
+                      properties:
+                        credentialsRef:
+                          description: Reference to a Kubernetes secret in the same namespace, that stores client credentials to the OAuth2 server.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        tokenIntrospectionUrl:
+                          description: The full URL of the token introspection endpoint.
+                          type: string
+                        tokenTypeHint:
+                          description: The token type hint for the token introspection. If omitted, it defaults to "access_token".
+                          type: string
+                      required:
+                      - credentialsRef
+                      - tokenIntrospectionUrl
+                      type: object
+                    oidc:
+                      properties:
+                        endpoint:
+                          description: Endpoint of the OIDC issuer. Authorino will append to this value the well-known path to the OpenID Connect discovery endpoint (i.e. "/.well-known/openid-configuration"), used to automatically discover the OpenID Connect configuration, whose set of claims is expected to include (among others) the "jkws_uri" claim. The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
+                          type: string
+                        ttl:
+                          description: Decides how long to wait before refreshing the OIDC configuration (in seconds).
+                          type: integer
+                      required:
+                      - endpoint
+                      type: object
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+              metadata:
+                description: List of metadata source configs. Authorino fetches JSON content from sources on this list on every request.
+                items:
+                  description: 'The metadata config. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "userInfo" or "uma".'
+                  oneOf:
+                  - properties:
+                      name: {}
+                      userInfo: {}
+                    required:
+                    - name
+                    - userInfo
+                  - properties:
+                      name: {}
+                      uma: {}
+                    required:
+                    - name
+                    - uma
+                  - properties:
+                      name: {}
+                      uma: {}
+                    required:
+                    - name
+                    - http
+                  properties:
+                    http:
+                      description: Generic HTTP interface to obtain authorization metadata from a HTTP service.
+                      properties:
+                        bodyParameters:
+                          description: Custom parameters to encode in the body of the HTTP request. Use it with method=POST; for GET requests, specify parameters using placeholders in the endpoint.
+                          items:
+                            properties:
+                              name:
+                                description: The name of the claim
+                                type: string
+                              value:
+                                description: Static value of the claim
+                                x-kubernetes-preserve-unknown-fields: true
+                              valueFrom:
+                                description: Dynamic value of the claim
+                                properties:
+                                  authJSON:
+                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        contentType:
+                          default: application/x-www-form-urlencoded
+                          description: Content-Type of the request body.
+                          enum:
+                          - application/x-www-form-urlencoded
+                          - application/json
+                          type: string
+                        credentials:
+                          description: Defines where client credentials will be passed in the request to the service. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                          properties:
+                            in:
+                              default: authorization_header
+                              description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
+                              enum:
+                              - authorization_header
+                              - custom_header
+                              - query
+                              - cookie
+                              type: string
+                            keySelector:
+                              description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
+                              type: string
+                          required:
+                          - keySelector
+                          type: object
+                        endpoint:
+                          description: Endpoint of the HTTP service. The endpoint accepts variable placeholders in the format "{selector}", where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
+                          type: string
+                        headers:
+                          description: Custom headers in the HTTP request.
+                          items:
+                            properties:
+                              name:
+                                description: The name of the claim
+                                type: string
+                              value:
+                                description: Static value of the claim
+                                x-kubernetes-preserve-unknown-fields: true
+                              valueFrom:
+                                description: Dynamic value of the claim
+                                properties:
+                                  authJSON:
+                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        method:
+                          description: 'HTTP verb used in the request to the service. Accepted values: GET (default), POST. When the request method is POST, the authorization JSON is passed in the body of the request.'
+                          enum:
+                          - GET
+                          - POST
+                          type: string
+                        sharedSecretRef:
+                          description: Reference to a Secret key whose value will be passed by Authorino in the request. The HTTP service can use the shared secret to authenticate the origin of the request.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - endpoint
+                      type: object
+                    name:
+                      description: The name of the metadata source. It can be used to refer to the resolved metadata object in other configs.
+                      type: string
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      type: integer
+                    uma:
+                      description: User-Managed Access (UMA) source of resource data.
+                      properties:
+                        credentialsRef:
+                          description: Reference to a Kubernetes secret in the same namespace, that stores client credentials to the resource registration API of the UMA server.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        endpoint:
+                          description: The endpoint of the UMA server. The value must coincide with the "issuer" claim of the UMA config discovered from the well-known uma configuration endpoint.
+                          type: string
+                      required:
+                      - credentialsRef
+                      - endpoint
+                      type: object
+                    userInfo:
+                      description: OpendID Connect UserInfo linked to an OIDC identity config of this same spec.
+                      properties:
+                        identitySource:
+                          description: The name of an OIDC identity source included in the "identity" section and whose OpenID Connect configuration discovered includes the OIDC "userinfo_endpoint" claim.
+                          type: string
+                      required:
+                      - identitySource
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              response:
+                description: List of response configs. Authorino gathers data from the auth pipeline to build custom responses for the client.
+                items:
+                  description: 'Dynamic response to return to the client. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "wristband" or "json".'
+                  properties:
+                    json:
+                      properties:
+                        properties:
+                          description: List of JSON property-value pairs to be added to the dynamic response.
+                          items:
+                            properties:
+                              name:
+                                description: The name of the claim
+                                type: string
+                              value:
+                                description: Static value of the claim
+                                x-kubernetes-preserve-unknown-fields: true
+                              valueFrom:
+                                description: Dynamic value of the claim
+                                properties:
+                                  authJSON:
+                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      required:
+                      - properties
+                      type: object
+                    name:
+                      description: Name of the custom response. It can be used to refer to the resolved response object in other configs.
+                      type: string
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      type: integer
+                    wrapper:
+                      default: httpHeader
+                      description: How Authorino wraps the response. Use "httpHeader" (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata" to wrap the response as Envoy Dynamic Metadata
+                      enum:
+                      - httpHeader
+                      - envoyDynamicMetadata
+                      type: string
+                    wrapperKey:
+                      description: The name of key used in the wrapped response (name of the HTTP header or property of the Envoy Dynamic Metadata JSON). If omitted, it will be set to the name of the configuration.
+                      type: string
+                    wristband:
+                      properties:
+                        customClaims:
+                          description: Any claims to be added to the wristband token apart from the standard JWT claims (iss, iat, exp) added by default.
+                          items:
+                            properties:
+                              name:
+                                description: The name of the claim
+                                type: string
+                              value:
+                                description: Static value of the claim
+                                x-kubernetes-preserve-unknown-fields: true
+                              valueFrom:
+                                description: Dynamic value of the claim
+                                properties:
+                                  authJSON:
+                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        issuer:
+                          description: 'The endpoint to the Authorino service that issues the wristband (format: <scheme>://<host>:<port>/<realm>, where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                          type: string
+                        signingKeyRefs:
+                          description: Reference by name to Kubernetes secrets and corresponding signing algorithms. The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                          items:
+                            properties:
+                              algorithm:
+                                description: Algorithm to sign the wristband token using the signing key provided
+                                enum:
+                                - ES256
+                                - ES384
+                                - ES512
+                                - RS256
+                                - RS384
+                                - RS512
+                                type: string
+                              name:
+                                description: Name of the signing key. The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                                type: string
+                            required:
+                            - algorithm
+                            - name
+                            type: object
+                          type: array
+                        tokenDuration:
+                          description: Time span of the wristband token, in seconds.
+                          format: int64
+                          type: integer
+                      required:
+                      - issuer
+                      - signingKeyRefs
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - hosts
+            type: object
+          status:
+            description: AuthConfigStatus defines the observed state of AuthConfig
+            properties:
+              festivalWristbandEnabled:
+                type: boolean
+              numAuthorizationPolicies:
+                format: int64
+                type: integer
+              numIdentitySources:
+                format: int64
+                type: integer
+              numMetadataSources:
+                format: int64
+                type: integer
+              numResponseItems:
+                format: int64
+                type: integer
+              ready:
+                type: boolean
+            required:
+            - festivalWristbandEnabled
+            - numAuthorizationPolicies
+            - numIdentitySources
+            - numMetadataSources
+            - numResponseItems
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
   name: authorinos.operator.authorino.kuadrant.io
 spec:
   group: operator.authorino.kuadrant.io
@@ -225,6 +1054,139 @@ rules:
   verbs:
   - create
   - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-operator-authorino-authconfig-editor-role
+rules:
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-operator-authorino-authconfig-viewer-role
+rules:
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-operator-authorino-manager-k8s-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: authorino-operator-authorino-manager-role
+rules:
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-operator-authorino-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-operator-authorino-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
**Authorino manifests as config**

Store authorino manifests in their own kustomization config file and include it in the default and install kustomizations. This allows an exact copy of the upstream version manifests to be stored giving us:
 * Easier comparisons (upstream vs local).
 * Ability to add kustomizations to those manifests if required.
 * Allows them to be included in different kustomizations
   (default vs install)
 * Tidier make targets that don't differ so much from the default, which
   coincidentally will alllow the "verify-bundle" make target to work
   again on CI.

Add new make targets for dealing with the different manifest types (authorino, install and deploy) and trigger them all as part of the top level "manifests" target.
Moved all manifest targets under the development section of the Makefile.
Removed install-authorino target since install target includes authorino manifests.

**Bundle generation and CI verification**

* Add missing role file to bundle.
* Add back "verify-bundle" CI job.