### PR TITLE
Update operator-sdk install script

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,3 +37,25 @@ jobs:
       - name: Run make verify-fmt
         run: |
           make verify-fmt
+
+  test-scripts:
+    name: Test Scripts
+    strategy:
+      matrix:
+        go-version: [ 1.16.x ]
+        platform: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.platform }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run make operator-sdk
+        run: |
+          make operator-sdk

--- a/utils/install-operator-sdk.sh
+++ b/utils/install-operator-sdk.sh
@@ -20,7 +20,12 @@ if [ ! -f "$1" ]; then
   curl -sLO ${OPERATOR_SDK_DL_URL}/checksums.txt
   curl -sLO ${OPERATOR_SDK_DL_URL}/checksums.txt.asc
   gpg -u "Operator SDK (release) <cncf-operator-sdk@cncf.io>" --verify checksums.txt.asc
-  grep operator-sdk_${OS}_${ARCH} checksums.txt | sha256sum -c -
+  if [[ $OS == 'darwin' ]]; then
+    grep operator-sdk_${OS}_${ARCH} checksums.txt | shasum -a 256 -c -
+  else
+    grep operator-sdk_${OS}_${ARCH} checksums.txt | sha256sum -c -
+  fi
+  mkdir -p "$(dirname $1)"
   chmod +x operator-sdk_${OS}_${ARCH} && mv operator-sdk_${OS}_${ARCH} $1
 
   rm -rf $TMP_DIR


### PR DESCRIPTION
Update operator-sdk install script to work on both linux and mac.
* Create target directory if it doesn't exist.
* Use `shasum` to check checksums on macOS.

Add CI job to check scripts required in local development environments can execute on both linux and macOS.