### PR TITLE
Add build images CI job 

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,142 @@
+name: Build Images
+
+on:
+  push:
+    branches: [ '*' ]
+    tags: [ '*' ]
+
+env:
+  IMG_TAGS: ${{ github.ref_name }}
+  IMG_REGISTRY_HOST: quay.io
+  IMG_REGISTRY_ORG: kuadrant
+  MAIN_BRANCH_NAME: main
+  OPERATOR_NAME: authorino-operator
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Add latest tag
+        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+        id: add-latest-tag
+        run: |
+          echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.OPERATOR_NAME }}
+          tags: ${{ env.IMG_TAGS }}
+          dockerfiles: |
+            ./Dockerfile
+      - name: Push Image
+        if: ${{ !env.ACT }}
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+      - name: Print Image URL
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+
+  build-bundle:
+    needs: build
+    name: Build Bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.16.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Add latest tag
+        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+        id: add-latest-tag
+        run: |
+          echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+      - name: Run make bundle
+        if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
+        run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.ref_name }}
+      - name: Run make bundle (main)
+        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+        run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=latest VERSION=0.0.0
+      - name: Git diff
+        run: git diff
+#       Uncomment this when ORG in the Makefile to be updated to "kuadrant"
+#      - name: Verify manifests and bundle
+#        if: startsWith(github.ref, 'refs/tags/v') || github.ref_name == env.MAIN_BRANCH_NAME
+#        run: make verify-manifests verify-bundle
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.OPERATOR_NAME }}-bundle
+          tags: ${{ env.IMG_TAGS }}
+          dockerfiles: |
+            ./bundle.Dockerfile
+      - name: Push Image
+        if: ${{ !env.ACT }}
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+      - name: Print Image URL
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+
+  build-catalog:
+    name: Build Catalog
+    needs: [build, build-bundle]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.16.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Add latest tag
+        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+        id: add-latest-tag
+        run: |
+          echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+      - name: Run make catalog-generate
+        if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
+        run: make catalog-generate REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.ref_name }}
+      - name: Run make catalog-generate (main)
+        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+        run: make catalog-generate REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=latest VERSION=0.0.0
+      - name: Git diff
+        run: git diff
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.OPERATOR_NAME }}-catalog
+          tags: ${{ env.IMG_TAGS }}
+          dockerfiles: |
+            ./index.Dockerfile
+      - name: Push Image
+        if: ${{ !env.ACT }}
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+      - name: Print Image URL
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/config/authorino/kustomization.template.yaml
+++ b/config/authorino/kustomization.template.yaml
@@ -1,0 +1,2 @@
+resources:
+- github.com/Kuadrant/authorino/install?ref=${AUTHORINO_GITREF}

--- a/config/authorino/kustomization.yaml
+++ b/config/authorino/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- github.com/Kuadrant/authorino/install?ref=main

--- a/config/deploy/kustomization.yaml
+++ b/config/deploy/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - ../authorino
+  - ../default

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -1,3 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: authorino-operator
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -50,30 +57,20 @@ spec:
         description: AuthConfig is the schema for Authorino's AuthConfig API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: Specifies the desired state of the AuthConfig resource, i.e.
-              the authencation/authorization scheme to be applied to protect the matching
-              service hosts.
+            description: Specifies the desired state of the AuthConfig resource, i.e. the authencation/authorization scheme to be applied to protect the matching service hosts.
             properties:
               authorization:
-                description: Authorization is the list of authorization policies.
-                  All policies in this list MUST evaluate to "true" for a request
-                  be successful in the authorization phase.
+                description: Authorization is the list of authorization policies. All policies in this list MUST evaluate to "true" for a request be successful in the authorization phase.
                 items:
-                  description: 'Authorization policy to be enforced. Apart from "name",
-                    one of the following parameters is required and only one of the
-                    following parameters is allowed: "opa", "json" or "kubernetes".'
+                  description: 'Authorization policy to be enforced. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "opa", "json" or "kubernetes".'
                   oneOf:
                   - properties:
                       name: {}
@@ -98,8 +95,7 @@ spec:
                       description: JSON pattern matching authorization policy.
                       properties:
                         rules:
-                          description: The rules that must all evaluate to "true"
-                            for the request to be authorized.
+                          description: The rules that must all evaluate to "true" for the request to be authorized.
                           items:
                             oneOf:
                             - properties:
@@ -116,12 +112,7 @@ spec:
                               - value
                             properties:
                               operator:
-                                description: 'The binary operator to be applied to
-                                  the content fetched from the authorization JSON,
-                                  for comparison with "value". Possible values are:
-                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
-                                  for arrays), "excl" (excludes; for arrays), "matches"
-                                  (regex)'
+                                description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
                                 enum:
                                 - eq
                                 - neq
@@ -133,16 +124,10 @@ spec:
                                 description: Name of a named pattern
                                 type: string
                               selector:
-                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                                  The value is used to fetch content from the input
-                                  authorization JSON built by Authorino along the
-                                  identity and metadata phases.
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                                 type: string
                               value:
-                                description: The value of reference for the comparison
-                                  with the content fetched from the authorization
-                                  JSON. If used with the "matches" operator, the value
-                                  must compile to a valid Golang regex.
+                                description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
                                 type: string
                             type: object
                           type: array
@@ -150,8 +135,7 @@ spec:
                       - rules
                       type: object
                     kubernetes:
-                      description: Kubernetes authorization policy based on `SubjectAccessReview`
-                        Path and Verb are inferred from the request.
+                      description: Kubernetes authorization policy based on `SubjectAccessReview` Path and Verb are inferred from the request.
                       properties:
                         groups:
                           description: Groups to test for.
@@ -159,10 +143,7 @@ spec:
                             type: string
                           type: array
                         resourceAttributes:
-                          description: Use ResourceAttributes for checking permissions
-                            on Kubernetes resources If omitted, it performs a non-resource
-                            `SubjectAccessReview`, with verb and path inferred from
-                            the request.
+                          description: Use ResourceAttributes for checking permissions on Kubernetes resources If omitted, it performs a non-resource `SubjectAccessReview`, with verb and path inferred from the request.
                           properties:
                             group:
                               properties:
@@ -171,17 +152,7 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
@@ -192,17 +163,7 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
@@ -213,17 +174,7 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
@@ -234,17 +185,7 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
@@ -255,17 +196,7 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
@@ -276,42 +207,20 @@ spec:
                                 valueFrom:
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                           type: object
                         user:
-                          description: User to test for. If without "Groups", then
-                            is it interpreted as "What if User were not a member of
-                            any groups"
+                          description: User to test for. If without "Groups", then is it interpreted as "What if User were not a member of any groups"
                           properties:
                             value:
                               type: string
                             valueFrom:
                               properties:
                                 authJSON:
-                                  description: 'Selector to fill the value from the
-                                    authorization JSON. Any patterns supported by
-                                    https://pkg.go.dev/github.com/tidwall/gjson can
-                                    be used. The value can be just the pattern with
-                                    the path to fetch from the authorization JSON
-                                    (e.g. ''context.request.http.host'') or a string
-                                    template with variable placeholders that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!")
-                                    The following string modifiers are available:
-                                    @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           type: object
@@ -319,8 +228,7 @@ spec:
                       - user
                       type: object
                     name:
-                      description: Name of the authorization policy. It can be used
-                        to refer to the resolved authorization object in other configs.
+                      description: Name of the authorization policy. It can be used to refer to the resolved authorization object in other configs.
                       type: string
                     opa:
                       description: Open Policy Agent (OPA) authorization policy.
@@ -329,17 +237,11 @@ spec:
                           description: External registry of OPA policies.
                           properties:
                             credentials:
-                              description: Defines where client credentials will be
-                                passed in the request to the service. If omitted,
-                                it defaults to client credentials passed in the HTTP
-                                Authorization header and the "Bearer" prefix expected
-                                prepended to the secret value.
+                              description: Defines where client credentials will be passed in the request to the service. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
                               properties:
                                 in:
                                   default: authorization_header
-                                  description: The location in the request where client
-                                    credentials shall be passed on requests authenticating
-                                    with this identity source/authentication mode.
+                                  description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
                                   enum:
                                   - authorization_header
                                   - custom_header
@@ -347,40 +249,22 @@ spec:
                                   - cookie
                                   type: string
                                 keySelector:
-                                  description: Used in conjunction with the `in` parameter.
-                                    When used with `authorization_header`, the value
-                                    is the prefix of the client credentials string,
-                                    separated by a white-space, in the HTTP Authorization
-                                    header (e.g. "Bearer", "Basic"). When used with
-                                    `custom_header`, `query` or `cookie`, the value
-                                    is the name of the HTTP header, query string parameter
-                                    or cookie key, respectively.
+                                  description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
                                   type: string
                               required:
                               - keySelector
                               type: object
                             endpoint:
-                              description: Endpoint of the HTTP external registry.
-                                The endpoint must respond with either plain/text or
-                                application/json content-type. In the latter case,
-                                the JSON returned in the body must include a path
-                                `result.raw`, where the raw Rego policy will be extracted
-                                from. This complies with the specification of the
-                                OPA REST API (https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
+                              description: Endpoint of the HTTP external registry. The endpoint must respond with either plain/text or application/json content-type. In the latter case, the JSON returned in the body must include a path `result.raw`, where the raw Rego policy will be extracted from. This complies with the specification of the OPA REST API (https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
                               type: string
                             sharedSecretRef:
-                              description: Reference to a Secret key whose value will
-                                be passed by Authorino in the request. The HTTP service
-                                can use the shared secret to authenticate the origin
-                                of the request.
+                              description: Reference to a Secret key whose value will be passed by Authorino in the request. The HTTP service can use the shared secret to authenticate the origin of the request.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
+                                  description: The key of the secret to select from.  Must be a valid secret key.
                                   type: string
                                 name:
-                                  description: The name of the secret in the Authorino's
-                                    namespace to select from.
+                                  description: The name of the secret in the Authorino's namespace to select from.
                                   type: string
                               required:
                               - key
@@ -388,24 +272,15 @@ spec:
                               type: object
                           type: object
                         inlineRego:
-                          description: Authorization policy as a Rego language document.
-                            The Rego document must include the "allow" condition,
-                            set by Authorino to "false" by default (i.e. requests
-                            are unauthorized unless changed). The Rego document must
-                            NOT include the "package" declaration in line 1.
+                          description: Authorization policy as a Rego language document. The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed). The Rego document must NOT include the "package" declaration in line 1.
                           type: string
                       type: object
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
+                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
                       type: integer
                     when:
-                      description: Conditions for Authorino to enforce this authorization
-                        policy. If omitted, the config will be enforced for all requests.
-                        If present, all conditions must match for the config to be
-                        enforced; otherwise, the config will be skipped.
+                      description: Conditions for Authorino to enforce this authorization policy. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
                       items:
                         oneOf:
                         - properties:
@@ -422,11 +297,7 @@ spec:
                           - value
                         properties:
                           operator:
-                            description: 'The binary operator to be applied to the
-                              content fetched from the authorization JSON, for comparison
-                              with "value". Possible values are: "eq" (equal to),
-                              "neq" (not equal to), "incl" (includes; for arrays),
-                              "excl" (excludes; for arrays), "matches" (regex)'
+                            description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
                             enum:
                             - eq
                             - neq
@@ -438,16 +309,10 @@ spec:
                             description: Name of a named pattern
                             type: string
                           selector:
-                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization
-                              JSON built by Authorino along the identity and metadata
-                              phases.
+                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                             type: string
                           value:
-                            description: The value of reference for the comparison
-                              with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must
-                              compile to a valid Golang regex.
+                            description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
                             type: string
                         type: object
                       type: array
@@ -456,22 +321,19 @@ spec:
                   type: object
                 type: array
               denyWith:
-                description: Custom denial response codes, statuses and headers to
-                  override default 40x's.
+                description: Custom denial response codes, statuses and headers to override default 40x's.
                 properties:
                   unauthenticated:
                     description: Denial status customization when the request is unauthenticated.
                     properties:
                       code:
-                        description: HTTP status code to override the default denial
-                          status code.
+                        description: HTTP status code to override the default denial status code.
                         format: int64
                         maximum: 599
                         minimum: 300
                         type: integer
                       headers:
-                        description: HTTP response headers to override the default
-                          denial headers.
+                        description: HTTP response headers to override the default denial headers.
                         items:
                           properties:
                             name:
@@ -484,17 +346,7 @@ spec:
                               description: Dynamic value of the claim
                               properties:
                                 authJSON:
-                                  description: 'Selector to fill the value from the
-                                    authorization JSON. Any patterns supported by
-                                    https://pkg.go.dev/github.com/tidwall/gjson can
-                                    be used. The value can be just the pattern with
-                                    the path to fetch from the authorization JSON
-                                    (e.g. ''context.request.http.host'') or a string
-                                    template with variable placeholders that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!")
-                                    The following string modifiers are available:
-                                    @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           required:
@@ -509,15 +361,13 @@ spec:
                     description: Denial status customization when the request is unauthorized.
                     properties:
                       code:
-                        description: HTTP status code to override the default denial
-                          status code.
+                        description: HTTP status code to override the default denial status code.
                         format: int64
                         maximum: 599
                         minimum: 300
                         type: integer
                       headers:
-                        description: HTTP response headers to override the default
-                          denial headers.
+                        description: HTTP response headers to override the default denial headers.
                         items:
                           properties:
                             name:
@@ -530,17 +380,7 @@ spec:
                               description: Dynamic value of the claim
                               properties:
                                 authJSON:
-                                  description: 'Selector to fill the value from the
-                                    authorization JSON. Any patterns supported by
-                                    https://pkg.go.dev/github.com/tidwall/gjson can
-                                    be used. The value can be just the pattern with
-                                    the path to fetch from the authorization JSON
-                                    (e.g. ''context.request.http.host'') or a string
-                                    template with variable placeholders that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!")
-                                    The following string modifiers are available:
-                                    @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           required:
@@ -553,22 +393,14 @@ spec:
                     type: object
                 type: object
               hosts:
-                description: The list of public host names of the services protected
-                  by this authentication/authorization scheme. Authorino uses the
-                  requested host to lookup for the corresponding authentication/authorization
-                  configs to enforce.
+                description: The list of public host names of the services protected by this authentication/authorization scheme. Authorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.
                 items:
                   type: string
                 type: array
               identity:
-                description: List of identity sources/authentication modes. At least
-                  one config of this list MUST evaluate to a valid identity for a
-                  request to be successful in the identity verification phase.
+                description: List of identity sources/authentication modes. At least one config of this list MUST evaluate to a valid identity for a request to be successful in the identity verification phase.
                 items:
-                  description: 'The identity source/authentication mode config. Apart
-                    from "name", one of the following parameters is required and only
-                    one of the following parameters is allowed: "oicd", "apiKey" or
-                    "kubernetes".'
+                  description: 'The identity source/authentication mode config. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "oicd", "apiKey" or "kubernetes".'
                   oneOf:
                   - properties:
                       credentials: {}
@@ -612,33 +444,22 @@ spec:
                       properties:
                         allNamespaces:
                           default: false
-                          description: Whether Authorino should look for API key secrets
-                            in all namespaces or only in the same namespace of the
-                            AuthConfig. Enabling this option in namespaced Authorino
-                            instances has no effect.
+                          description: Whether Authorino should look for API key secrets in all namespaces or only in the same namespace of the AuthConfig. Enabling this option in namespaced Authorino instances has no effect.
                           type: boolean
                         labelSelectors:
                           additionalProperties:
                             type: string
-                          description: The map of label selectors used by Authorino
-                            to match secrets from the cluster storing valid credentials
-                            to authenticate to this service
+                          description: The map of label selectors used by Authorino to match secrets from the cluster storing valid credentials to authenticate to this service
                           type: object
                       required:
                       - labelSelectors
                       type: object
                     credentials:
-                      description: Defines where client credentials are required to
-                        be passed in the request for this identity source/authentication
-                        mode. If omitted, it defaults to client credentials passed
-                        in the HTTP Authorization header and the "Bearer" prefix expected
-                        prepended to the credentials value (token, API key, etc).
+                      description: Defines where client credentials are required to be passed in the request for this identity source/authentication mode. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the credentials value (token, API key, etc).
                       properties:
                         in:
                           default: authorization_header
-                          description: The location in the request where client credentials
-                            shall be passed on requests authenticating with this identity
-                            source/authentication mode.
+                          description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
                           enum:
                           - authorization_header
                           - custom_header
@@ -646,23 +467,13 @@ spec:
                           - cookie
                           type: string
                         keySelector:
-                          description: Used in conjunction with the `in` parameter.
-                            When used with `authorization_header`, the value is the
-                            prefix of the client credentials string, separated by
-                            a white-space, in the HTTP Authorization header (e.g.
-                            "Bearer", "Basic"). When used with `custom_header`, `query`
-                            or `cookie`, the value is the name of the HTTP header,
-                            query string parameter or cookie key, respectively.
+                          description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
                           type: string
                       required:
                       - keySelector
                       type: object
                     extendedProperties:
-                      description: Extends the resolved identity object with additional
-                        custom properties before appending to the authorization JSON.
-                        It requires the resolved identity object to always be of the
-                        JSON type 'object'. Other JSON types (array, string, etc)
-                        will break.
+                      description: Extends the resolved identity object with additional custom properties before appending to the authorization JSON. It requires the resolved identity object to always be of the JSON type 'object'. Other JSON types (array, string, etc) will break.
                       items:
                         properties:
                           name:
@@ -675,16 +486,7 @@ spec:
                             description: Dynamic value of the claim
                             properties:
                               authJSON:
-                                description: 'Selector to fill the value from the
-                                  authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                  can be used. The value can be just the pattern with
-                                  the path to fetch from the authorization JSON (e.g.
-                                  ''context.request.http.host'') or a string template
-                                  with variable placeholders that resolve to patterns
-                                  (e.g. "Hello, {auth.identity.name}!") The following
-                                  string modifiers are available: @extract:{sep:"
-                                  ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                                  and @base64:encode|decode.'
+                                description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                 type: string
                             type: object
                         required:
@@ -694,39 +496,28 @@ spec:
                     kubernetes:
                       properties:
                         audiences:
-                          description: The list of audiences (scopes) that must be
-                            claimed in a Kubernetes authentication token supplied
-                            in the request, and reviewed by Authorino. If omitted,
-                            Authorino will review tokens expecting the host name of
-                            the requested protected service amongst the audiences.
+                          description: The list of audiences (scopes) that must be claimed in a Kubernetes authentication token supplied in the request, and reviewed by Authorino. If omitted, Authorino will review tokens expecting the host name of the requested protected service amongst the audiences.
                           items:
                             type: string
                           type: array
                       type: object
                     name:
-                      description: The name of this identity source/authentication
-                        mode. It usually identifies a source of identities or group
-                        of users/clients of the protected service. It can be used
-                        to refer to the resolved identity object in other configs.
+                      description: The name of this identity source/authentication mode. It usually identifies a source of identities or group of users/clients of the protected service. It can be used to refer to the resolved identity object in other configs.
                       type: string
                     oauth2:
                       properties:
                         credentialsRef:
-                          description: Reference to a Kubernetes secret in the same
-                            namespace, that stores client credentials to the OAuth2
-                            server.
+                          description: Reference to a Kubernetes secret in the same namespace, that stores client credentials to the OAuth2 server.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                         tokenIntrospectionUrl:
                           description: The full URL of the token introspection endpoint.
                           type: string
                         tokenTypeHint:
-                          description: The token type hint for the token introspection.
-                            If omitted, it defaults to "access_token".
+                          description: The token type hint for the token introspection. If omitted, it defaults to "access_token".
                           type: string
                       required:
                       - credentialsRef
@@ -735,33 +526,20 @@ spec:
                     oidc:
                       properties:
                         endpoint:
-                          description: Endpoint of the OIDC issuer. Authorino will
-                            append to this value the well-known path to the OpenID
-                            Connect discovery endpoint (i.e. "/.well-known/openid-configuration"),
-                            used to automatically discover the OpenID Connect configuration,
-                            whose set of claims is expected to include (among others)
-                            the "jkws_uri" claim. The value must coincide with the
-                            value of  the "iss" (issuer) claim of the discovered OpenID
-                            Connect configuration.
+                          description: Endpoint of the OIDC issuer. Authorino will append to this value the well-known path to the OpenID Connect discovery endpoint (i.e. "/.well-known/openid-configuration"), used to automatically discover the OpenID Connect configuration, whose set of claims is expected to include (among others) the "jkws_uri" claim. The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
                           type: string
                         ttl:
-                          description: Decides how long to wait before refreshing
-                            the OIDC configuration (in seconds).
+                          description: Decides how long to wait before refreshing the OIDC configuration (in seconds).
                           type: integer
                       required:
                       - endpoint
                       type: object
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
+                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
                       type: integer
                     when:
-                      description: Conditions for Authorino to enforce this identity
-                        config. If omitted, the config will be enforced for all requests.
-                        If present, all conditions must match for the config to be
-                        enforced; otherwise, the config will be skipped.
+                      description: Conditions for Authorino to enforce this identity config. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
                       items:
                         oneOf:
                         - properties:
@@ -778,11 +556,7 @@ spec:
                           - value
                         properties:
                           operator:
-                            description: 'The binary operator to be applied to the
-                              content fetched from the authorization JSON, for comparison
-                              with "value". Possible values are: "eq" (equal to),
-                              "neq" (not equal to), "incl" (includes; for arrays),
-                              "excl" (excludes; for arrays), "matches" (regex)'
+                            description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
                             enum:
                             - eq
                             - neq
@@ -794,16 +568,10 @@ spec:
                             description: Name of a named pattern
                             type: string
                           selector:
-                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization
-                              JSON built by Authorino along the identity and metadata
-                              phases.
+                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                             type: string
                           value:
-                            description: The value of reference for the comparison
-                              with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must
-                              compile to a valid Golang regex.
+                            description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
                             type: string
                         type: object
                       type: array
@@ -812,12 +580,9 @@ spec:
                   type: object
                 type: array
               metadata:
-                description: List of metadata source configs. Authorino fetches JSON
-                  content from sources on this list on every request.
+                description: List of metadata source configs. Authorino fetches JSON content from sources on this list on every request.
                 items:
-                  description: 'The metadata config. Apart from "name", one of the
-                    following parameters is required and only one of the following
-                    parameters is allowed: "userInfo" or "uma".'
+                  description: 'The metadata config. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "userInfo" or "uma".'
                   oneOf:
                   - properties:
                       name: {}
@@ -839,13 +604,10 @@ spec:
                     - http
                   properties:
                     http:
-                      description: Generic HTTP interface to obtain authorization
-                        metadata from a HTTP service.
+                      description: Generic HTTP interface to obtain authorization metadata from a HTTP service.
                       properties:
                         bodyParameters:
-                          description: Custom parameters to encode in the body of
-                            the HTTP request. Use it with method=POST; for GET requests,
-                            specify parameters using placeholders in the endpoint.
+                          description: Custom parameters to encode in the body of the HTTP request. Use it with method=POST; for GET requests, specify parameters using placeholders in the endpoint.
                           items:
                             properties:
                               name:
@@ -858,17 +620,7 @@ spec:
                                 description: Dynamic value of the claim
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from
-                                      the authorization JSON. Any patterns supported
-                                      by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The value can be just the pattern
-                                      with the path to fetch from the authorization
-                                      JSON (e.g. ''context.request.http.host'') or
-                                      a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                      The following string modifiers are available:
-                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -883,17 +635,11 @@ spec:
                           - application/json
                           type: string
                         credentials:
-                          description: Defines where client credentials will be passed
-                            in the request to the service. If omitted, it defaults
-                            to client credentials passed in the HTTP Authorization
-                            header and the "Bearer" prefix expected prepended to the
-                            secret value.
+                          description: Defines where client credentials will be passed in the request to the service. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
                           properties:
                             in:
                               default: authorization_header
-                              description: The location in the request where client
-                                credentials shall be passed on requests authenticating
-                                with this identity source/authentication mode.
+                              description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
                               enum:
                               - authorization_header
                               - custom_header
@@ -901,23 +647,13 @@ spec:
                               - cookie
                               type: string
                             keySelector:
-                              description: Used in conjunction with the `in` parameter.
-                                When used with `authorization_header`, the value is
-                                the prefix of the client credentials string, separated
-                                by a white-space, in the HTTP Authorization header
-                                (e.g. "Bearer", "Basic"). When used with `custom_header`,
-                                `query` or `cookie`, the value is the name of the
-                                HTTP header, query string parameter or cookie key,
-                                respectively.
+                              description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
                               type: string
                           required:
                           - keySelector
                           type: object
                         endpoint:
-                          description: Endpoint of the HTTP service. The endpoint
-                            accepts variable placeholders in the format "{selector}",
-                            where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                            and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
+                          description: Endpoint of the HTTP service. The endpoint accepts variable placeholders in the format "{selector}", where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
                           type: string
                         headers:
                           description: Custom headers in the HTTP request.
@@ -933,17 +669,7 @@ spec:
                                 description: Dynamic value of the claim
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from
-                                      the authorization JSON. Any patterns supported
-                                      by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The value can be just the pattern
-                                      with the path to fetch from the authorization
-                                      JSON (e.g. ''context.request.http.host'') or
-                                      a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                      The following string modifiers are available:
-                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -951,27 +677,19 @@ spec:
                             type: object
                           type: array
                         method:
-                          description: 'HTTP verb used in the request to the service.
-                            Accepted values: GET (default), POST. When the request
-                            method is POST, the authorization JSON is passed in the
-                            body of the request.'
+                          description: 'HTTP verb used in the request to the service. Accepted values: GET (default), POST. When the request method is POST, the authorization JSON is passed in the body of the request.'
                           enum:
                           - GET
                           - POST
                           type: string
                         sharedSecretRef:
-                          description: Reference to a Secret key whose value will
-                            be passed by Authorino in the request. The HTTP service
-                            can use the shared secret to authenticate the origin of
-                            the request.
+                          description: Reference to a Secret key whose value will be passed by Authorino in the request. The HTTP service can use the shared secret to authenticate the origin of the request.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
+                              description: The key of the secret to select from.  Must be a valid secret key.
                               type: string
                             name:
-                              description: The name of the secret in the Authorino's
-                                namespace to select from.
+                              description: The name of the secret in the Authorino's namespace to select from.
                               type: string
                           required:
                           - key
@@ -981,54 +699,40 @@ spec:
                       - endpoint
                       type: object
                     name:
-                      description: The name of the metadata source. It can be used
-                        to refer to the resolved metadata object in other configs.
+                      description: The name of the metadata source. It can be used to refer to the resolved metadata object in other configs.
                       type: string
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
+                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
                       type: integer
                     uma:
                       description: User-Managed Access (UMA) source of resource data.
                       properties:
                         credentialsRef:
-                          description: Reference to a Kubernetes secret in the same
-                            namespace, that stores client credentials to the resource
-                            registration API of the UMA server.
+                          description: Reference to a Kubernetes secret in the same namespace, that stores client credentials to the resource registration API of the UMA server.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                         endpoint:
-                          description: The endpoint of the UMA server. The value must
-                            coincide with the "issuer" claim of the UMA config discovered
-                            from the well-known uma configuration endpoint.
+                          description: The endpoint of the UMA server. The value must coincide with the "issuer" claim of the UMA config discovered from the well-known uma configuration endpoint.
                           type: string
                       required:
                       - credentialsRef
                       - endpoint
                       type: object
                     userInfo:
-                      description: OpendID Connect UserInfo linked to an OIDC identity
-                        config of this same spec.
+                      description: OpendID Connect UserInfo linked to an OIDC identity config of this same spec.
                       properties:
                         identitySource:
-                          description: The name of an OIDC identity source included
-                            in the "identity" section and whose OpenID Connect configuration
-                            discovered includes the OIDC "userinfo_endpoint" claim.
+                          description: The name of an OIDC identity source included in the "identity" section and whose OpenID Connect configuration discovered includes the OIDC "userinfo_endpoint" claim.
                           type: string
                       required:
                       - identitySource
                       type: object
                     when:
-                      description: Conditions for Authorino to enforce this metadata
-                        config. If omitted, the config will be enforced for all requests.
-                        If present, all conditions must match for the config to be
-                        enforced; otherwise, the config will be skipped.
+                      description: Conditions for Authorino to enforce this metadata config. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
                       items:
                         oneOf:
                         - properties:
@@ -1045,11 +749,7 @@ spec:
                           - value
                         properties:
                           operator:
-                            description: 'The binary operator to be applied to the
-                              content fetched from the authorization JSON, for comparison
-                              with "value". Possible values are: "eq" (equal to),
-                              "neq" (not equal to), "incl" (includes; for arrays),
-                              "excl" (excludes; for arrays), "matches" (regex)'
+                            description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
                             enum:
                             - eq
                             - neq
@@ -1061,16 +761,10 @@ spec:
                             description: Name of a named pattern
                             type: string
                           selector:
-                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization
-                              JSON built by Authorino along the identity and metadata
-                              phases.
+                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                             type: string
                           value:
-                            description: The value of reference for the comparison
-                              with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must
-                              compile to a valid Golang regex.
+                            description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
                             type: string
                         type: object
                       type: array
@@ -1083,11 +777,7 @@ spec:
                   items:
                     properties:
                       operator:
-                        description: 'The binary operator to be applied to the content
-                          fetched from the authorization JSON, for comparison with
-                          "value". Possible values are: "eq" (equal to), "neq" (not
-                          equal to), "incl" (includes; for arrays), "excl" (excludes;
-                          for arrays), "matches" (regex)'
+                        description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
                         enum:
                         - eq
                         - neq
@@ -1096,35 +786,24 @@ spec:
                         - matches
                         type: string
                       selector:
-                        description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                          The value is used to fetch content from the input authorization
-                          JSON built by Authorino along the identity and metadata
-                          phases.
+                        description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                         type: string
                       value:
-                        description: The value of reference for the comparison with
-                          the content fetched from the authorization JSON. If used
-                          with the "matches" operator, the value must compile to a
-                          valid Golang regex.
+                        description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
                         type: string
                     type: object
                   type: array
-                description: Named sets of JSON patterns that can be referred in `when`
-                  conditionals and in JSON-pattern matching policy rules.
+                description: Named sets of JSON patterns that can be referred in `when` conditionals and in JSON-pattern matching policy rules.
                 type: object
               response:
-                description: List of response configs. Authorino gathers data from
-                  the auth pipeline to build custom responses for the client.
+                description: List of response configs. Authorino gathers data from the auth pipeline to build custom responses for the client.
                 items:
-                  description: 'Dynamic response to return to the client. Apart from
-                    "name", one of the following parameters is required and only one
-                    of the following parameters is allowed: "wristband" or "json".'
+                  description: 'Dynamic response to return to the client. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "wristband" or "json".'
                   properties:
                     json:
                       properties:
                         properties:
-                          description: List of JSON property-value pairs to be added
-                            to the dynamic response.
+                          description: List of JSON property-value pairs to be added to the dynamic response.
                           items:
                             properties:
                               name:
@@ -1137,17 +816,7 @@ spec:
                                 description: Dynamic value of the claim
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from
-                                      the authorization JSON. Any patterns supported
-                                      by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The value can be just the pattern
-                                      with the path to fetch from the authorization
-                                      JSON (e.g. ''context.request.http.host'') or
-                                      a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                      The following string modifiers are available:
-                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -1158,20 +827,14 @@ spec:
                       - properties
                       type: object
                     name:
-                      description: Name of the custom response. It can be used to
-                        refer to the resolved response object in other configs.
+                      description: Name of the custom response. It can be used to refer to the resolved response object in other configs.
                       type: string
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
+                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
                       type: integer
                     when:
-                      description: Conditions for Authorino to enforce this custom
-                        response config. If omitted, the config will be enforced for
-                        all requests. If present, all conditions must match for the
-                        config to be enforced; otherwise, the config will be skipped.
+                      description: Conditions for Authorino to enforce this custom response config. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
                       items:
                         oneOf:
                         - properties:
@@ -1188,11 +851,7 @@ spec:
                           - value
                         properties:
                           operator:
-                            description: 'The binary operator to be applied to the
-                              content fetched from the authorization JSON, for comparison
-                              with "value". Possible values are: "eq" (equal to),
-                              "neq" (not equal to), "incl" (includes; for arrays),
-                              "excl" (excludes; for arrays), "matches" (regex)'
+                            description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
                             enum:
                             - eq
                             - neq
@@ -1204,39 +863,27 @@ spec:
                             description: Name of a named pattern
                             type: string
                           selector:
-                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization
-                              JSON built by Authorino along the identity and metadata
-                              phases.
+                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                             type: string
                           value:
-                            description: The value of reference for the comparison
-                              with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must
-                              compile to a valid Golang regex.
+                            description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
                             type: string
                         type: object
                       type: array
                     wrapper:
                       default: httpHeader
-                      description: How Authorino wraps the response. Use "httpHeader"
-                        (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata"
-                        to wrap the response as Envoy Dynamic Metadata
+                      description: How Authorino wraps the response. Use "httpHeader" (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata" to wrap the response as Envoy Dynamic Metadata
                       enum:
                       - httpHeader
                       - envoyDynamicMetadata
                       type: string
                     wrapperKey:
-                      description: The name of key used in the wrapped response (name
-                        of the HTTP header or property of the Envoy Dynamic Metadata
-                        JSON). If omitted, it will be set to the name of the configuration.
+                      description: The name of key used in the wrapped response (name of the HTTP header or property of the Envoy Dynamic Metadata JSON). If omitted, it will be set to the name of the configuration.
                       type: string
                     wristband:
                       properties:
                         customClaims:
-                          description: Any claims to be added to the wristband token
-                            apart from the standard JWT claims (iss, iat, exp) added
-                            by default.
+                          description: Any claims to be added to the wristband token apart from the standard JWT claims (iss, iat, exp) added by default.
                           items:
                             properties:
                               name:
@@ -1249,17 +896,7 @@ spec:
                                 description: Dynamic value of the claim
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from
-                                      the authorization JSON. Any patterns supported
-                                      by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The value can be just the pattern
-                                      with the path to fetch from the authorization
-                                      JSON (e.g. ''context.request.http.host'') or
-                                      a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                      The following string modifiers are available:
-                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -1267,20 +904,14 @@ spec:
                             type: object
                           type: array
                         issuer:
-                          description: 'The endpoint to the Authorino service that
-                            issues the wristband (format: <scheme>://<host>:<port>/<realm>,
-                            where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                          description: 'The endpoint to the Authorino service that issues the wristband (format: <scheme>://<host>:<port>/<realm>, where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
                           type: string
                         signingKeyRefs:
-                          description: Reference by name to Kubernetes secrets and
-                            corresponding signing algorithms. The secrets must contain
-                            a `key.pem` entry whose value is the signing key formatted
-                            as PEM.
+                          description: Reference by name to Kubernetes secrets and corresponding signing algorithms. The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
                           items:
                             properties:
                               algorithm:
-                                description: Algorithm to sign the wristband token
-                                  using the signing key provided
+                                description: Algorithm to sign the wristband token using the signing key provided
                                 enum:
                                 - ES256
                                 - ES384
@@ -1290,10 +921,7 @@ spec:
                                 - RS512
                                 type: string
                               name:
-                                description: Name of the signing key. The value is
-                                  used to reference the Kubernetes secret that stores
-                                  the key and in the `kid` claim of the wristband
-                                  token header.
+                                description: Name of the signing key. The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
                                 type: string
                             required:
                             - algorithm
@@ -1313,11 +941,7 @@ spec:
                   type: object
                 type: array
               when:
-                description: Conditions for the AuthConfig to be enforced. If omitted,
-                  the AuthConfig will be enforced for all requests. If present, all
-                  conditions must match for the AuthConfig to be enforced; otherwise,
-                  Authorino skips the AuthConfig and returns immediately with status
-                  OK.
+                description: Conditions for the AuthConfig to be enforced. If omitted, the AuthConfig will be enforced for all requests. If present, all conditions must match for the AuthConfig to be enforced; otherwise, Authorino skips the AuthConfig and returns immediately with status OK.
                 items:
                   oneOf:
                   - properties:
@@ -1334,11 +958,7 @@ spec:
                     - value
                   properties:
                     operator:
-                      description: 'The binary operator to be applied to the content
-                        fetched from the authorization JSON, for comparison with "value".
-                        Possible values are: "eq" (equal to), "neq" (not equal to),
-                        "incl" (includes; for arrays), "excl" (excludes; for arrays),
-                        "matches" (regex)'
+                      description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
                       enum:
                       - eq
                       - neq
@@ -1350,15 +970,10 @@ spec:
                       description: Name of a named pattern
                       type: string
                     selector:
-                      description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                        The value is used to fetch content from the input authorization
-                        JSON built by Authorino along the identity and metadata phases.
+                      description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                       type: string
                     value:
-                      description: The value of reference for the comparison with
-                        the content fetched from the authorization JSON. If used with
-                        the "matches" operator, the value must compile to a valid
-                        Golang regex.
+                      description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
                       type: string
                   type: object
                 type: array
@@ -1403,146 +1018,6 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: authorino-authconfig-editor-role
-rules:
-- apiGroups:
-  - authorino.kuadrant.io
-  resources:
-  - authconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - authorino.kuadrant.io
-  resources:
-  - authconfigs/status
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: authorino-authconfig-viewer-role
-rules:
-- apiGroups:
-  - authorino.kuadrant.io
-  resources:
-  - authconfigs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - authorino.kuadrant.io
-  resources:
-  - authconfigs/status
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: authorino-manager-k8s-auth-role
-rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: authorino-manager-role
-rules:
-- apiGroups:
-  - authorino.kuadrant.io
-  resources:
-  - authconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - authorino.kuadrant.io
-  resources:
-  - authconfigs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-  - get
-  - list
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: authorino-metrics-reader
-rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: authorino-proxy-role
-rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: authorino-operator
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1775,6 +1250,121 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: authorino-authconfig-editor-role
+rules:
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-authconfig-viewer-role
+rules:
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-manager-k8s-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: authorino-manager-role
+rules:
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   creationTimestamp: null
   name: authorino-operator-manager-role
 rules:
@@ -1956,6 +1546,24 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: authorino-operator-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: authorino-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -2,6 +2,7 @@
 # used to generate the 'manifests/' directory in a bundle.
 resources:
 - bases/authorino-operator.clusterserviceversion.yaml
+- ../authorino
 - ../default
 - ../samples
 - ../scorecard


### PR DESCRIPTION
Adds a new GitHub workflow that builds and pushes the operators images (manager/bundle/catalog) to the kuadrant quay.io repo.

Updates the Makefile to bring it in line with the rest of the kuadrant operators allowing the same GH workflow to be used in all kuadrant operator repos and uses kustomizations to generate authorino and deploy manifests using the upstream operand kustomization as input.

Test runs here:

- https://github.com/mikenairn/authorino-operator/actions/runs/1860090026 (This branch "add_image_builds")
- https://github.com/mikenairn/authorino-operator/actions/runs/1860118826(main)

Notes:
- If this is merged we can remove this https://github.com/Kuadrant/kuadrant-operator/blob/main/config/dependencies/authorino/kustomization.template.yaml#L3-L4
- The install manifests haven't changed, only the order of resources since kustomize is generating it all now 381c2172b698f32bb4128e26defb02e503fe5563