### PR TITLE
Changes authorino service metric port

### DIFF
--- a/pkg/resources/k8s_services.go
+++ b/pkg/resources/k8s_services.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	k8score "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // GetAuthorinoServices returns all the service required by an instance of authorino
@@ -36,9 +35,9 @@ func newAuthService(authorinoName, serviceNamespace string) *k8score.Service {
 func newMetricService(authorinoName, serviceNamespace string) *k8score.Service {
 	serviceName := "controller-metrics"
 	return newService(serviceName, serviceNamespace, authorinoName, k8score.ServicePort{
-		Name:       "https",
-		Port:       8443,
-		TargetPort: intstr.FromString("https"),
+		Name:     "http",
+		Port:     8080,
+		Protocol: k8score.ProtocolTCP,
 	})
 }
 


### PR DESCRIPTION
As result of [removing proxy sidecar container](https://github.com/Kuadrant/authorino-operator/pull/29) from the authorino instances, there authorino metric service needs to point to the default http port exposed by authorino.

* [Default port exposed by authorino](https://github.com/Kuadrant/authorino/blob/main/main.go#L75 )
