### PR TITLE
Update Authorino manifests

### DIFF
--- a/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
+++ b/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
@@ -94,6 +94,43 @@ spec:
                     - name
                     - kubernetes
                   properties:
+                    cache:
+                      description: Caching options for the policy evaluation results
+                        when enforcing this config. Omit it to avoid caching policy
+                        evaluation results for this config.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. Cache
+                            entries from different metadata configs are stored and
+                            managed separately regardless of the key.
+                          properties:
+                            value:
+                              description: Static value
+                              type: string
+                            valueFrom:
+                              description: Dynamic value
+                              properties:
+                                authJSON:
+                                  description: 'Selector to fetch a value from the
+                                    authorization JSON. It can be any path pattern
+                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                    or a string template with variable placeholders
+                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following string modifiers are
+                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, and @base64:encode|decode.'
+                                  type: string
+                              type: object
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
                     json:
                       description: JSON pattern matching authorization policy.
                       properties:
@@ -165,127 +202,157 @@ spec:
                             the request.
                           properties:
                             group:
+                              description: StaticOrDynamicValue is either a constant
+                                static string value or a config for fetching a value
+                                from a dynamic source (e.g. a path pattern of authorization
+                                JSON)
                               properties:
                                 value:
+                                  description: Static value
                                   type: string
                                 valueFrom:
+                                  description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
                                         @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             name:
+                              description: StaticOrDynamicValue is either a constant
+                                static string value or a config for fetching a value
+                                from a dynamic source (e.g. a path pattern of authorization
+                                JSON)
                               properties:
                                 value:
+                                  description: Static value
                                   type: string
                                 valueFrom:
+                                  description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
                                         @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             namespace:
+                              description: StaticOrDynamicValue is either a constant
+                                static string value or a config for fetching a value
+                                from a dynamic source (e.g. a path pattern of authorization
+                                JSON)
                               properties:
                                 value:
+                                  description: Static value
                                   type: string
                                 valueFrom:
+                                  description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
                                         @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             resource:
+                              description: StaticOrDynamicValue is either a constant
+                                static string value or a config for fetching a value
+                                from a dynamic source (e.g. a path pattern of authorization
+                                JSON)
                               properties:
                                 value:
+                                  description: Static value
                                   type: string
                                 valueFrom:
+                                  description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
                                         @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             subresource:
+                              description: StaticOrDynamicValue is either a constant
+                                static string value or a config for fetching a value
+                                from a dynamic source (e.g. a path pattern of authorization
+                                JSON)
                               properties:
                                 value:
+                                  description: Static value
                                   type: string
                                 valueFrom:
+                                  description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
                                         @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             verb:
+                              description: StaticOrDynamicValue is either a constant
+                                static string value or a config for fetching a value
+                                from a dynamic source (e.g. a path pattern of authorization
+                                JSON)
                               properties:
                                 value:
+                                  description: Static value
                                   type: string
                                 valueFrom:
+                                  description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from
-                                        the authorization JSON. Any patterns supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The value can be just the pattern
-                                        with the path to fetch from the authorization
-                                        JSON (e.g. ''context.request.http.host'')
-                                        or a string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                        The following string modifiers are available:
-                                        @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
                                         @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
@@ -297,20 +364,20 @@ spec:
                             any groups"
                           properties:
                             value:
+                              description: Static value
                               type: string
                             valueFrom:
+                              description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fill the value from the
-                                    authorization JSON. Any patterns supported by
-                                    https://pkg.go.dev/github.com/tidwall/gjson can
-                                    be used. The value can be just the pattern with
-                                    the path to fetch from the authorization JSON
-                                    (e.g. ''context.request.http.host'') or a string
-                                    template with variable placeholders that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!")
-                                    The following string modifiers are available:
-                                    @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  description: 'Selector to fetch a value from the
+                                    authorization JSON. It can be any path pattern
+                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                    or a string template with variable placeholders
+                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following string modifiers are
+                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
                                     @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
@@ -480,6 +547,29 @@ spec:
                   unauthenticated:
                     description: Denial status customization when the request is unauthenticated.
                     properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          value:
+                            description: Static value
+                            type: string
+                          valueFrom:
+                            description: Dynamic value
+                            properties:
+                              authJSON:
+                                description: 'Selector to fetch a value from the authorization
+                                  JSON. It can be any path pattern to fetch from the
+                                  authorization JSON (e.g. ''context.request.http.host'')
+                                  or a string template with variable placeholders
+                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following string modifiers are
+                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, and @base64:encode|decode.'
+                                type: string
+                            type: object
+                        type: object
                       code:
                         description: HTTP status code to override the default denial
                           status code.
@@ -493,25 +583,23 @@ spec:
                         items:
                           properties:
                             name:
-                              description: The name of the claim
+                              description: The name of the JSON property
                               type: string
                             value:
-                              description: Static value of the claim
+                              description: Static value of the JSON property
                               x-kubernetes-preserve-unknown-fields: true
                             valueFrom:
-                              description: Dynamic value of the claim
+                              description: Dynamic value of the JSON property
                               properties:
                                 authJSON:
-                                  description: 'Selector to fill the value from the
-                                    authorization JSON. Any patterns supported by
-                                    https://pkg.go.dev/github.com/tidwall/gjson can
-                                    be used. The value can be just the pattern with
-                                    the path to fetch from the authorization JSON
-                                    (e.g. ''context.request.http.host'') or a string
-                                    template with variable placeholders that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!")
-                                    The following string modifiers are available:
-                                    @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  description: 'Selector to fetch a value from the
+                                    authorization JSON. It can be any path pattern
+                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                    or a string template with variable placeholders
+                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following string modifiers are
+                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
                                     @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
@@ -521,11 +609,53 @@ spec:
                         type: array
                       message:
                         description: HTTP message to override the default denial message.
-                        type: string
+                        properties:
+                          value:
+                            description: Static value
+                            type: string
+                          valueFrom:
+                            description: Dynamic value
+                            properties:
+                              authJSON:
+                                description: 'Selector to fetch a value from the authorization
+                                  JSON. It can be any path pattern to fetch from the
+                                  authorization JSON (e.g. ''context.request.http.host'')
+                                  or a string template with variable placeholders
+                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following string modifiers are
+                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, and @base64:encode|decode.'
+                                type: string
+                            type: object
+                        type: object
                     type: object
                   unauthorized:
                     description: Denial status customization when the request is unauthorized.
                     properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          value:
+                            description: Static value
+                            type: string
+                          valueFrom:
+                            description: Dynamic value
+                            properties:
+                              authJSON:
+                                description: 'Selector to fetch a value from the authorization
+                                  JSON. It can be any path pattern to fetch from the
+                                  authorization JSON (e.g. ''context.request.http.host'')
+                                  or a string template with variable placeholders
+                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following string modifiers are
+                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, and @base64:encode|decode.'
+                                type: string
+                            type: object
+                        type: object
                       code:
                         description: HTTP status code to override the default denial
                           status code.
@@ -539,25 +669,23 @@ spec:
                         items:
                           properties:
                             name:
-                              description: The name of the claim
+                              description: The name of the JSON property
                               type: string
                             value:
-                              description: Static value of the claim
+                              description: Static value of the JSON property
                               x-kubernetes-preserve-unknown-fields: true
                             valueFrom:
-                              description: Dynamic value of the claim
+                              description: Dynamic value of the JSON property
                               properties:
                                 authJSON:
-                                  description: 'Selector to fill the value from the
-                                    authorization JSON. Any patterns supported by
-                                    https://pkg.go.dev/github.com/tidwall/gjson can
-                                    be used. The value can be just the pattern with
-                                    the path to fetch from the authorization JSON
-                                    (e.g. ''context.request.http.host'') or a string
-                                    template with variable placeholders that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!")
-                                    The following string modifiers are available:
-                                    @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  description: 'Selector to fetch a value from the
+                                    authorization JSON. It can be any path pattern
+                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                    or a string template with variable placeholders
+                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following string modifiers are
+                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
                                     @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
@@ -567,7 +695,26 @@ spec:
                         type: array
                       message:
                         description: HTTP message to override the default denial message.
-                        type: string
+                        properties:
+                          value:
+                            description: Static value
+                            type: string
+                          valueFrom:
+                            description: Dynamic value
+                            properties:
+                              authJSON:
+                                description: 'Selector to fetch a value from the authorization
+                                  JSON. It can be any path pattern to fetch from the
+                                  authorization JSON (e.g. ''context.request.http.host'')
+                                  or a string template with variable placeholders
+                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following string modifiers are
+                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, and @base64:encode|decode.'
+                                type: string
+                            type: object
+                        type: object
                     type: object
                 type: object
               hosts:
@@ -645,6 +792,43 @@ spec:
                       required:
                       - labelSelectors
                       type: object
+                    cache:
+                      description: Caching options for the identity resolved when
+                        applying this config. Omit it to avoid caching identity objects
+                        for this config.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. Cache
+                            entries from different metadata configs are stored and
+                            managed separately regardless of the key.
+                          properties:
+                            value:
+                              description: Static value
+                              type: string
+                            valueFrom:
+                              description: Dynamic value
+                              properties:
+                                authJSON:
+                                  description: 'Selector to fetch a value from the
+                                    authorization JSON. It can be any path pattern
+                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                    or a string template with variable placeholders
+                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following string modifiers are
+                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, and @base64:encode|decode.'
+                                  type: string
+                              type: object
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
                     credentials:
                       description: Defines where client credentials are required to
                         be passed in the request for this identity source/authentication
@@ -684,25 +868,24 @@ spec:
                       items:
                         properties:
                           name:
-                            description: The name of the claim
+                            description: The name of the JSON property
                             type: string
                           value:
-                            description: Static value of the claim
+                            description: Static value of the JSON property
                             x-kubernetes-preserve-unknown-fields: true
                           valueFrom:
-                            description: Dynamic value of the claim
+                            description: Dynamic value of the JSON property
                             properties:
                               authJSON:
-                                description: 'Selector to fill the value from the
-                                  authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                  can be used. The value can be just the pattern with
-                                  the path to fetch from the authorization JSON (e.g.
-                                  ''context.request.http.host'') or a string template
-                                  with variable placeholders that resolve to patterns
-                                  (e.g. "Hello, {auth.identity.name}!") The following
-                                  string modifiers are available: @extract:{sep:"
-                                  ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                                  and @base64:encode|decode.'
+                                description: 'Selector to fetch a value from the authorization
+                                  JSON. It can be any path pattern to fetch from the
+                                  authorization JSON (e.g. ''context.request.http.host'')
+                                  or a string template with variable placeholders
+                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following string modifiers are
+                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, and @base64:encode|decode.'
                                 type: string
                             type: object
                         required:
@@ -840,7 +1023,7 @@ spec:
                 items:
                   description: 'The metadata config. Apart from "name", one of the
                     following parameters is required and only one of the following
-                    parameters is allowed: "userInfo" or "uma".'
+                    parameters is allowed: "http", userInfo" or "uma".'
                   oneOf:
                   - properties:
                       name: {}
@@ -861,6 +1044,43 @@ spec:
                     - name
                     - http
                   properties:
+                    cache:
+                      description: Caching options for the external metadata fetched
+                        when applying this config. Omit it to avoid caching metadata
+                        from this source.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. Cache
+                            entries from different metadata configs are stored and
+                            managed separately regardless of the key.
+                          properties:
+                            value:
+                              description: Static value
+                              type: string
+                            valueFrom:
+                              description: Dynamic value
+                              properties:
+                                authJSON:
+                                  description: 'Selector to fetch a value from the
+                                    authorization JSON. It can be any path pattern
+                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                    or a string template with variable placeholders
+                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following string modifiers are
+                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, and @base64:encode|decode.'
+                                  type: string
+                              type: object
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
                     http:
                       description: Generic HTTP interface to obtain authorization
                         metadata from a HTTP service.
@@ -872,25 +1092,23 @@ spec:
                           items:
                             properties:
                               name:
-                                description: The name of the claim
+                                description: The name of the JSON property
                                 type: string
                               value:
-                                description: Static value of the claim
+                                description: Static value of the JSON property
                                 x-kubernetes-preserve-unknown-fields: true
                               valueFrom:
-                                description: Dynamic value of the claim
+                                description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from
-                                      the authorization JSON. Any patterns supported
-                                      by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The value can be just the pattern
-                                      with the path to fetch from the authorization
-                                      JSON (e.g. ''context.request.http.host'') or
-                                      a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                      The following string modifiers are available:
-                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    description: 'Selector to fetch a value from the
+                                      authorization JSON. It can be any path pattern
+                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                      or a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following string modifiers
+                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
                                       @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
@@ -947,25 +1165,23 @@ spec:
                           items:
                             properties:
                               name:
-                                description: The name of the claim
+                                description: The name of the JSON property
                                 type: string
                               value:
-                                description: Static value of the claim
+                                description: Static value of the JSON property
                                 x-kubernetes-preserve-unknown-fields: true
                               valueFrom:
-                                description: Dynamic value of the claim
+                                description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from
-                                      the authorization JSON. Any patterns supported
-                                      by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The value can be just the pattern
-                                      with the path to fetch from the authorization
-                                      JSON (e.g. ''context.request.http.host'') or
-                                      a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                      The following string modifiers are available:
-                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    description: 'Selector to fetch a value from the
+                                      authorization JSON. It can be any path pattern
+                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                      or a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following string modifiers
+                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
                                       @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
@@ -1053,10 +1269,10 @@ spec:
                       - identitySource
                       type: object
                     when:
-                      description: Conditions for Authorino to enforce this metadata
-                        config. If omitted, the config will be enforced for all requests.
+                      description: Conditions for Authorino to apply this metadata
+                        config. If omitted, the config will be applied for all requests.
                         If present, all conditions must match for the config to be
-                        enforced; otherwise, the config will be skipped.
+                        applied; otherwise, the config will be skipped.
                       items:
                         oneOf:
                         - properties:
@@ -1148,6 +1364,43 @@ spec:
                     "name", one of the following parameters is required and only one
                     of the following parameters is allowed: "wristband" or "json".'
                   properties:
+                    cache:
+                      description: Caching options for dynamic responses built when
+                        applying this config. Omit it to avoid caching dynamic responses
+                        for this config.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. Cache
+                            entries from different metadata configs are stored and
+                            managed separately regardless of the key.
+                          properties:
+                            value:
+                              description: Static value
+                              type: string
+                            valueFrom:
+                              description: Dynamic value
+                              properties:
+                                authJSON:
+                                  description: 'Selector to fetch a value from the
+                                    authorization JSON. It can be any path pattern
+                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                    or a string template with variable placeholders
+                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following string modifiers are
+                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, and @base64:encode|decode.'
+                                  type: string
+                              type: object
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
                     json:
                       properties:
                         properties:
@@ -1156,25 +1409,23 @@ spec:
                           items:
                             properties:
                               name:
-                                description: The name of the claim
+                                description: The name of the JSON property
                                 type: string
                               value:
-                                description: Static value of the claim
+                                description: Static value of the JSON property
                                 x-kubernetes-preserve-unknown-fields: true
                               valueFrom:
-                                description: Dynamic value of the claim
+                                description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from
-                                      the authorization JSON. Any patterns supported
-                                      by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The value can be just the pattern
-                                      with the path to fetch from the authorization
-                                      JSON (e.g. ''context.request.http.host'') or
-                                      a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                      The following string modifiers are available:
-                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    description: 'Selector to fetch a value from the
+                                      authorization JSON. It can be any path pattern
+                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                      or a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following string modifiers
+                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
                                       @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
@@ -1273,25 +1524,23 @@ spec:
                           items:
                             properties:
                               name:
-                                description: The name of the claim
+                                description: The name of the JSON property
                                 type: string
                               value:
-                                description: Static value of the claim
+                                description: Static value of the JSON property
                                 x-kubernetes-preserve-unknown-fields: true
                               valueFrom:
-                                description: Dynamic value of the claim
+                                description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from
-                                      the authorization JSON. Any patterns supported
-                                      by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The value can be just the pattern
-                                      with the path to fetch from the authorization
-                                      JSON (e.g. ''context.request.http.host'') or
-                                      a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!")
-                                      The following string modifiers are available:
-                                      @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    description: 'Selector to fetch a value from the
+                                      authorization JSON. It can be any path pattern
+                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                      or a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following string modifiers
+                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
                                       @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -91,6 +91,30 @@ spec:
                     - name
                     - kubernetes
                   properties:
+                    cache:
+                      description: Caching options for the policy evaluation results when enforcing this config. Omit it to avoid caching policy evaluation results for this config.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                          properties:
+                            value:
+                              description: Static value
+                              type: string
+                            valueFrom:
+                              description: Dynamic value
+                              properties:
+                                authJSON:
+                                  description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  type: string
+                              type: object
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
                     json:
                       description: JSON pattern matching authorization policy.
                       properties:
@@ -146,68 +170,86 @@ spec:
                           description: Use ResourceAttributes for checking permissions on Kubernetes resources If omitted, it performs a non-resource `SubjectAccessReview`, with verb and path inferred from the request.
                           properties:
                             group:
+                              description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
                               properties:
                                 value:
+                                  description: Static value
                                   type: string
                                 valueFrom:
+                                  description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             name:
+                              description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
                               properties:
                                 value:
+                                  description: Static value
                                   type: string
                                 valueFrom:
+                                  description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             namespace:
+                              description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
                               properties:
                                 value:
+                                  description: Static value
                                   type: string
                                 valueFrom:
+                                  description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             resource:
+                              description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
                               properties:
                                 value:
+                                  description: Static value
                                   type: string
                                 valueFrom:
+                                  description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             subresource:
+                              description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
                               properties:
                                 value:
+                                  description: Static value
                                   type: string
                                 valueFrom:
+                                  description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             verb:
+                              description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
                               properties:
                                 value:
+                                  description: Static value
                                   type: string
                                 valueFrom:
+                                  description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
@@ -216,11 +258,13 @@ spec:
                           description: User to test for. If without "Groups", then is it interpreted as "What if User were not a member of any groups"
                           properties:
                             value:
+                              description: Static value
                               type: string
                             valueFrom:
+                              description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           type: object
@@ -337,6 +381,20 @@ spec:
                   unauthenticated:
                     description: Denial status customization when the request is unauthenticated.
                     properties:
+                      body:
+                        description: HTTP response body to override the default denial body.
+                        properties:
+                          value:
+                            description: Static value
+                            type: string
+                          valueFrom:
+                            description: Dynamic value
+                            properties:
+                              authJSON:
+                                description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                type: string
+                            type: object
+                        type: object
                       code:
                         description: HTTP status code to override the default denial status code.
                         format: int64
@@ -348,16 +406,16 @@ spec:
                         items:
                           properties:
                             name:
-                              description: The name of the claim
+                              description: The name of the JSON property
                               type: string
                             value:
-                              description: Static value of the claim
+                              description: Static value of the JSON property
                               x-kubernetes-preserve-unknown-fields: true
                             valueFrom:
-                              description: Dynamic value of the claim
+                              description: Dynamic value of the JSON property
                               properties:
                                 authJSON:
-                                  description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           required:
@@ -366,11 +424,36 @@ spec:
                         type: array
                       message:
                         description: HTTP message to override the default denial message.
-                        type: string
+                        properties:
+                          value:
+                            description: Static value
+                            type: string
+                          valueFrom:
+                            description: Dynamic value
+                            properties:
+                              authJSON:
+                                description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                type: string
+                            type: object
+                        type: object
                     type: object
                   unauthorized:
                     description: Denial status customization when the request is unauthorized.
                     properties:
+                      body:
+                        description: HTTP response body to override the default denial body.
+                        properties:
+                          value:
+                            description: Static value
+                            type: string
+                          valueFrom:
+                            description: Dynamic value
+                            properties:
+                              authJSON:
+                                description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                type: string
+                            type: object
+                        type: object
                       code:
                         description: HTTP status code to override the default denial status code.
                         format: int64
@@ -382,16 +465,16 @@ spec:
                         items:
                           properties:
                             name:
-                              description: The name of the claim
+                              description: The name of the JSON property
                               type: string
                             value:
-                              description: Static value of the claim
+                              description: Static value of the JSON property
                               x-kubernetes-preserve-unknown-fields: true
                             valueFrom:
-                              description: Dynamic value of the claim
+                              description: Dynamic value of the JSON property
                               properties:
                                 authJSON:
-                                  description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           required:
@@ -400,7 +483,18 @@ spec:
                         type: array
                       message:
                         description: HTTP message to override the default denial message.
-                        type: string
+                        properties:
+                          value:
+                            description: Static value
+                            type: string
+                          valueFrom:
+                            description: Dynamic value
+                            properties:
+                              authJSON:
+                                description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                type: string
+                            type: object
+                        type: object
                     type: object
                 type: object
               hosts:
@@ -465,6 +559,30 @@ spec:
                       required:
                       - labelSelectors
                       type: object
+                    cache:
+                      description: Caching options for the identity resolved when applying this config. Omit it to avoid caching identity objects for this config.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                          properties:
+                            value:
+                              description: Static value
+                              type: string
+                            valueFrom:
+                              description: Dynamic value
+                              properties:
+                                authJSON:
+                                  description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  type: string
+                              type: object
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
                     credentials:
                       description: Defines where client credentials are required to be passed in the request for this identity source/authentication mode. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the credentials value (token, API key, etc).
                       properties:
@@ -488,16 +606,16 @@ spec:
                       items:
                         properties:
                           name:
-                            description: The name of the claim
+                            description: The name of the JSON property
                             type: string
                           value:
-                            description: Static value of the claim
+                            description: Static value of the JSON property
                             x-kubernetes-preserve-unknown-fields: true
                           valueFrom:
-                            description: Dynamic value of the claim
+                            description: Dynamic value of the JSON property
                             properties:
                               authJSON:
-                                description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                 type: string
                             type: object
                         required:
@@ -597,7 +715,7 @@ spec:
               metadata:
                 description: List of metadata source configs. Authorino fetches JSON content from sources on this list on every request.
                 items:
-                  description: 'The metadata config. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "userInfo" or "uma".'
+                  description: 'The metadata config. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "http", userInfo" or "uma".'
                   oneOf:
                   - properties:
                       name: {}
@@ -618,6 +736,30 @@ spec:
                     - name
                     - http
                   properties:
+                    cache:
+                      description: Caching options for the external metadata fetched when applying this config. Omit it to avoid caching metadata from this source.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                          properties:
+                            value:
+                              description: Static value
+                              type: string
+                            valueFrom:
+                              description: Dynamic value
+                              properties:
+                                authJSON:
+                                  description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  type: string
+                              type: object
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
                     http:
                       description: Generic HTTP interface to obtain authorization metadata from a HTTP service.
                       properties:
@@ -626,16 +768,16 @@ spec:
                           items:
                             properties:
                               name:
-                                description: The name of the claim
+                                description: The name of the JSON property
                                 type: string
                               value:
-                                description: Static value of the claim
+                                description: Static value of the JSON property
                                 x-kubernetes-preserve-unknown-fields: true
                               valueFrom:
-                                description: Dynamic value of the claim
+                                description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -675,16 +817,16 @@ spec:
                           items:
                             properties:
                               name:
-                                description: The name of the claim
+                                description: The name of the JSON property
                                 type: string
                               value:
-                                description: Static value of the claim
+                                description: Static value of the JSON property
                                 x-kubernetes-preserve-unknown-fields: true
                               valueFrom:
-                                description: Dynamic value of the claim
+                                description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -751,7 +893,7 @@ spec:
                       - identitySource
                       type: object
                     when:
-                      description: Conditions for Authorino to enforce this metadata config. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                      description: Conditions for Authorino to apply this metadata config. If omitted, the config will be applied for all requests. If present, all conditions must match for the config to be applied; otherwise, the config will be skipped.
                       items:
                         oneOf:
                         - properties:
@@ -819,6 +961,30 @@ spec:
                 items:
                   description: 'Dynamic response to return to the client. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "wristband" or "json".'
                   properties:
+                    cache:
+                      description: Caching options for dynamic responses built when applying this config. Omit it to avoid caching dynamic responses for this config.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                          properties:
+                            value:
+                              description: Static value
+                              type: string
+                            valueFrom:
+                              description: Dynamic value
+                              properties:
+                                authJSON:
+                                  description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  type: string
+                              type: object
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
                     json:
                       properties:
                         properties:
@@ -826,16 +992,16 @@ spec:
                           items:
                             properties:
                               name:
-                                description: The name of the claim
+                                description: The name of the JSON property
                                 type: string
                               value:
-                                description: Static value of the claim
+                                description: Static value of the JSON property
                                 x-kubernetes-preserve-unknown-fields: true
                               valueFrom:
-                                description: Dynamic value of the claim
+                                description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -910,16 +1076,16 @@ spec:
                           items:
                             properties:
                               name:
-                                description: The name of the claim
+                                description: The name of the JSON property
                                 type: string
                               value:
-                                description: Static value of the claim
+                                description: Static value of the JSON property
                                 x-kubernetes-preserve-unknown-fields: true
                               valueFrom:
-                                description: Dynamic value of the claim
+                                description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fill the value from the authorization JSON. Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The value can be just the pattern with the path to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!") The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:


### PR DESCRIPTION
Needed after the following PRs were merged in Authorino:
- Metadata caching ([#239](https://github.com/Kuadrant/authorino/pull/239))
- StaticOrDynamicValue ([#240](https://github.com/Kuadrant/authorino/pull/240))
- Possibility to set dynamic response messages to denied requests ([#241](https://github.com/Kuadrant/authorino/pull/241))
- Caching option for all evaluators of all phases ([#247](https://github.com/Kuadrant/authorino/pull/247))
- Adds custom response message body on request denial ([#248](https://github.com/Kuadrant/authorino/pull/248))