### PR TITLE
Removes resources limits from deployment object

### DIFF
--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -1807,13 +1807,6 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        resources:
-          limits:
-            cpu: 200m
-            memory: 100Mi
-          requests:
-            cpu: 100m
-            memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -45,12 +45,5 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        resources:
-          limits:
-            cpu: 200m
-            memory: 100Mi
-          requests:
-            cpu: 100m
-            memory: 20Mi
       serviceAccountName: authorino-operator
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
To avoid Authorino deployment from failing on large cluster we decided to remove the resources limit from the authorino operator deployment.

> We were considering to make the authorino operator to set the resources limit on every instances of authorino (https://github.com/Kuadrant/authorino-operator/issues/44) but as it can be manipulated on the deployment of each instance and we don't want to duplicate the deployment object we decided not to progress with the issue.