### PR TITLE
Fix default container image bundle annotation

### DIFF
--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/authorino-operator:v0.0.1
+    containerImage: quay.io/kuadrant/authorino-operator:latest
     createdAt: 2021-12-08T10-00-00Z
     operators.operatorframework.io/builder: operator-sdk-v1.14.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/authorino-operator:v0.0.1
+    containerImage: quay.io/kuadrant/authorino-operator:latest
     createdAt: 2021-12-08T10-00-00Z
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown


### PR DESCRIPTION
Default container image annotation of the bundle CSV should be equal to 'quay.io/kuadrant/authorino-operator:latest' in the main branch.