### PR TITLE
Wait until Deployment Status Ready

### DIFF
--- a/api/v1beta1/authorino_types.go
+++ b/api/v1beta1/authorino_types.go
@@ -87,6 +87,7 @@ const (
 	AuthorinoTlsSecretNotFound                       = "TlsSecretNotFound"
 	AuthorinoTlsSecretNotProvided                    = "TlsSecretNotProvided"
 	AuthorinoUnableToUpdateDeployment                = "UnableToUpdateDeployment"
+	AuthorinoDeploymentNotReady                      = "DeploymentNotReady"
 )
 
 type Condition struct {

--- a/controllers/authorino_controller.go
+++ b/controllers/authorino_controller.go
@@ -166,6 +166,7 @@ func (r *AuthorinoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 // SetupWithManager sets up the controller with the Manager.
 func (r *AuthorinoReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		Owns(&k8sapps.Deployment{}).
 		For(&api.Authorino{}).
 		Complete(r)
 }

--- a/controllers/authorino_controller.go
+++ b/controllers/authorino_controller.go
@@ -148,14 +148,14 @@ func (r *AuthorinoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				)
 			}
 
-			err = updateStatusConditions(logger, authorinoInstance,
-				r.Client, statusNotReady(api.AuthorinoUpdatedReason, "Authorino Deployment resource updated"))
-			return ctrl.Result{RequeueAfter: time.Minute}, err
+			err = updateStatusConditions(logger, authorinoInstance, r.Client, statusNotReady(api.AuthorinoUpdatedReason, "Authorino Deployment resource updated"))
+			return ctrl.Result{RequeueAfter: time.Second}, err
 		}
 
 		if !deploymentAvailable(existingDeployment) {
 			// Deployment not ready – return and requeue
-			return ctrl.Result{Requeue: true}, nil
+			err = updateStatusConditions(logger, authorinoInstance, r.Client, statusNotReady(api.AuthorinoDeploymentNotReady, "Authorino Deployment resource not ready"))
+			return ctrl.Result{RequeueAfter: time.Second}, err
 		}
 	}
 


### PR DESCRIPTION
Closes #63

### Verification steps

Deploy this branch:

```sh
kind create cluster --name authorino
make docker-build OPERATOR_IMAGE=authorino-operator:local
kind load docker-image authorino-operator:local --name authorino
kubectl create namespace authorino-operator
make install deploy OPERATOR_IMAGE=authorino-operator:localmake install deploy OPERATOR_IMAGE=authorino-operator:local
```

Create an Authorino instance whose Deployment will fail:

```sh
kubectl apply -f -<<EOF
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino
spec:
  clusterWide: true
  image: authorino:wrong
  listener:
    tls:
      enabled: false
  oidcServer:
    tls:
      enabled: false
EOF
```

Check the status of the Authorino CR:

```sh
kubectl get authorino/authorino -o jsonpath='{.status.conditions}'
# [{"lastTransitionTime":"2022-05-26T16:11:27Z","message":"Authorino Deployment resource not ready","reason":"DeploymentNotReady","status":"False","type":"Ready"}]
```

Fix the Deployment:

```sh
kubectl apply -f -<<EOF
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino
spec:
  clusterWide: true
  image: quay.io/kuadrant/authorino:latest
  listener:
    tls:
      enabled: false
  oidcServer:
    tls:
      enabled: false
EOF
```

Check the status of the Authorino CR again:

```sh
kubectl get authorino/authorino -o jsonpath='{.status.conditions}'
# [{"lastTransitionTime":"2022-05-26T16:11:50Z","reason":"Provisioned","status":"True","type":"Ready"}]
```