### PR TITLE
Require TLS config

### DIFF
--- a/api/v1beta1/authorino_types.go
+++ b/api/v1beta1/authorino_types.go
@@ -126,8 +126,8 @@ type AuthorinoSpec struct {
 	LogLevel                 string      `json:"logLevel,omitempty"`
 	LogMode                  string      `json:"logMode,omitempty"`
 	ClusterWide              bool        `json:"clusterWide,omitempty"`
-	Listener                 Listener    `json:"listener,omitempty"`
-	OIDCServer               OIDCServer  `json:"oidcServer,omitempty"`
+	Listener                 Listener    `json:"listener"`
+	OIDCServer               OIDCServer  `json:"oidcServer"`
 	AuthConfigLabelSelectors string      `json:"authConfigLabelSelectors,omitempty"`
 	SecretLabelSelectors     string      `json:"secretLabelSelectors,omitempty"`
 	EvaluatorCacheSize       *int        `json:"evaluatorCacheSize,omitempty"`
@@ -141,14 +141,14 @@ type Listener struct {
 	// Port numbers of the GRPC and HTTP auth interfaces.
 	Ports Ports `json:"ports,omitempty"`
 	// TLS configuration of the auth service (GRPC and HTTP interfaces).
-	Tls Tls `json:"tls,omitempty"`
+	Tls Tls `json:"tls"`
 	// Timeout of the auth service (GRPC and HTTP interfaces), in milliseconds.
 	Timeout *int `json:"timeout,omitempty"`
 }
 
 type OIDCServer struct {
 	Port *int32 `json:"port,omitempty"`
-	Tls  Tls    `json:"tls,omitempty"`
+	Tls  Tls    `json:"tls"`
 }
 
 type Ports struct {

--- a/bundle/manifests/operator.authorino.kuadrant.io_authorinos.yaml
+++ b/bundle/manifests/operator.authorino.kuadrant.io_authorinos.yaml
@@ -82,6 +82,8 @@ spec:
                       enabled:
                         type: boolean
                     type: object
+                required:
+                - tls
                 type: object
               logLevel:
                 type: string
@@ -115,6 +117,8 @@ spec:
                       enabled:
                         type: boolean
                     type: object
+                required:
+                - tls
                 type: object
               replicas:
                 format: int32
@@ -183,6 +187,9 @@ spec:
                       type: object
                     type: array
                 type: object
+            required:
+            - listener
+            - oidcServer
             type: object
           status:
             description: AuthorinoStatus defines the observed state of Authorino

--- a/config/crd/bases/operator.authorino.kuadrant.io_authorinos.yaml
+++ b/config/crd/bases/operator.authorino.kuadrant.io_authorinos.yaml
@@ -84,6 +84,8 @@ spec:
                       enabled:
                         type: boolean
                     type: object
+                required:
+                - tls
                 type: object
               logLevel:
                 type: string
@@ -117,6 +119,8 @@ spec:
                       enabled:
                         type: boolean
                     type: object
+                required:
+                - tls
                 type: object
               replicas:
                 format: int32
@@ -185,6 +189,9 @@ spec:
                       type: object
                     type: array
                 type: object
+            required:
+            - listener
+            - oidcServer
             type: object
           status:
             description: AuthorinoStatus defines the observed state of Authorino

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -1331,6 +1331,8 @@ spec:
                       enabled:
                         type: boolean
                     type: object
+                required:
+                - tls
                 type: object
               logLevel:
                 type: string
@@ -1361,6 +1363,8 @@ spec:
                       enabled:
                         type: boolean
                     type: object
+                required:
+                - tls
                 type: object
               replicas:
                 format: int32
@@ -1417,6 +1421,9 @@ spec:
                       type: object
                     type: array
                 type: object
+            required:
+            - listener
+            - oidcServer
             type: object
           status:
             description: AuthorinoStatus defines the observed state of Authorino

--- a/config/install/manifests.yaml
+++ b/config/install/manifests.yaml
@@ -72,6 +72,8 @@ spec:
                       enabled:
                         type: boolean
                     type: object
+                required:
+                - tls
                 type: object
               logLevel:
                 type: string
@@ -102,6 +104,8 @@ spec:
                       enabled:
                         type: boolean
                     type: object
+                required:
+                - tls
                 type: object
               replicas:
                 format: int32
@@ -158,6 +162,9 @@ spec:
                       type: object
                     type: array
                 type: object
+            required:
+            - listener
+            - oidcServer
             type: object
           status:
             description: AuthorinoStatus defines the observed state of Authorino


### PR DESCRIPTION
Makes `spec.listener.tls` and `spec.oidcServer.tls` required fields.

In practice those fields already are required, despite the OAS not specifying as such.

To enable TLS (default behaviour), a ref pointing to the secret storing the TLS server cert must be provided. E.g.:

```yaml
spec:
  listener:
    tls:
      certSecretRef:
        name: authorino-server-cert
```

To disable TLS on the other hand, `enabled: false` must be specified. E.g.:

```yaml
spec:
  listener:
    tls:
      enabled: false
```

Closes #57

### Verification steps

Build, install, deploy:

```sh
kind create cluster
make docker-build OPERATOR_IMAGE=authorino-operator:local
kind load docker-image authorino-operator:local --name kind
kubectl create namespace authorino-operator
make install deploy OPERATOR_IMAGE=authorino-operator:localmake install deploy OPERATOR_IMAGE=authorino-operator:local
```

Try with invalid CRs:

```sh
kubectl apply -f -<<EOF
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino
spec: {}
EOF
# error: error validating "STDIN": error validating data: [ValidationError(Authorino.spec): missing required field "listener" in io.kuadrant.authorino.operator.v1beta1.Authorino.spec, ValidationError(Authorino.spec): missing required field "oidcServer" in io.kuadrant.authorino.operator.v1beta1.Authorino.spec]; if you choose to ignore these errors, turn validation off with --validate=false
```

```sh
kubectl apply -f -<<EOF
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino
spec:
  listener: {}
EOF
# error: error validating "STDIN": error validating data: [ValidationError(Authorino.spec.listener): missing required field "tls" in io.kuadrant.authorino.operator.v1beta1.Authorino.spec.listener, ValidationError(Authorino.spec): missing required field "oidcServer" in io.kuadrant.authorino.operator.v1beta1.Authorino.spec]; if you choose to ignore these errors, turn validation off with --validate=false
```

Try with a valid CR:

```sh
kubectl apply -f -<<EOF
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino
spec:
  listener:
    tls:
      enabled: false
  oidcServer:
    tls:
      enabled: false
EOF
# 200
```

You can still bypass the OAS-level validation and create the CR with a listener stating an empty TLS spec. E.g.:

```sh
kubectl apply -f -<<EOF
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino
spec:
  listener:
    tls: {}
  oidcServer:
    tls: {}
EOF
# 200
```

In this case, the CR will be accepted by the Kube API server and persisted to etcd. TLS defaults to `enabled: true`. However, by missing the required secret ref, the installation preflight check will fail. The status of the CR will reflect the reason why the requested Authorino instance could not be created:

```sh
kubectl get authorino/authorino -o jsonpath='{.status.conditions}'
# [{"lastTransitionTime":"2022-06-20T15:45:17Z","message":"listener secret with tls cert not provided","reason":"TlsSecretNotProvided","status":"False","type":"Ready"}]%
```

### Note to reviewers

Validating that `spec.listener.tls` and `spec.oidcServer.tls` are not only present but also state semantically valid specs – i.e. presence of `certSecretRef` depending of the value of `enabled` –, to the point that an Authorino CR is not persisted unless it’s valid, cannot be achieved only in OAS. Either the behaviour would need to change (and possibly the API together, e.g. by making TLS disabled by default), or validation would have to be performed by a ValidatingWebhook. Both solutions are out of scope of this PR.