### PR TITLE
[GHA] Fix invocation of bundle/catalog-related targets for non main branch

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -5,7 +5,12 @@ on:
     branches:
       - 'main'
       - 'master'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      authorinoVersion:
+        description: Authorino version
+        required: true
+        default: latest
 
 env:
   IMG_TAGS: ${{ github.sha }}
@@ -61,6 +66,7 @@ jobs:
     needs: build
     name: Build and push bundle image
     runs-on: ubuntu-20.04
+    if: github.ref_name == env.MAIN_BRANCH_NAME || startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
@@ -74,7 +80,7 @@ jobs:
         id: add-latest-tag
         run: |
           echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
-      - name: Add branch tag
+      - name: Add release tag
         if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
         id: add-branch-tag
         run: |
@@ -83,17 +89,20 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
-      - name: Run make bundle
-        if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
-        run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.ref_name }}
       - name: Run make bundle (main)
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
-        run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=latest VERSION=0.0.0
+        run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }}
+      - name: Run make bundle (release)
+        if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
+        run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} VERSION=${${GITHUB_REF_NAME/\//-}/v/} AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }}
       - name: Git diff
         run: git diff
-      - name: Verify manifests and bundle
-        if: startsWith(github.ref, 'refs/tags/v') || github.ref_name == env.MAIN_BRANCH_NAME
-        run: make verify-manifests verify-bundle
+      - name: Verify manifests and bundle (main)
+        if: github.ref_name == env.MAIN_BRANCH_NAME
+        run: make verify-manifests verify-bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }}
+      - name: Verify manifests and bundle (release)
+        if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
+        run: make verify-manifests verify-bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} VERSION=${${GITHUB_REF_NAME/\//-}/v/} AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }}
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
@@ -120,6 +129,7 @@ jobs:
     name: Build and push catalog image
     needs: [build, build-bundle]
     runs-on: ubuntu-20.04
+    if: github.ref_name == env.MAIN_BRANCH_NAME || startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
@@ -133,7 +143,7 @@ jobs:
         id: add-latest-tag
         run: |
           echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
-      - name: Add branch tag
+      - name: Add release tag
         if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
         id: add-branch-tag
         run: |
@@ -142,12 +152,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
-      - name: Run make catalog-generate
-        if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
-        run: make catalog-generate REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.ref_name }}
       - name: Run make catalog-generate (main)
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
-        run: make catalog-generate REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=latest VERSION=0.0.0
+        run: make catalog-generate REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }}
+      - name: Run make catalog-generate (release)
+        if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
+        run: make catalog-generate REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${GITHUB_REF_NAME/\//-}
       - name: Git diff
         run: git diff
       - name: Build Image


### PR DESCRIPTION
Fixes invocations of make targets bundle, verify-manifests and generate-catalog for non main branch.

- Adds global condition for build-bundle and build-catalog to only run for main branch and release tags
- Ensures `VERSION` and `AUTHORINO_VERSION` params are supplied when non main branch (i.e. release tags)