### PR TITLE
Updating tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
+# go-get-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
 @[ -f $(1) ] || { \
@@ -160,7 +160,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.5)
 
 # go-get-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ deploy-manifest:
 	cd $(PROJECT_DIR)/config/manager && $(KUSTOMIZE) edit set image controller=${DEFAULT_OPERATOR_IMAGE}
 
 OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
-OPERATOR_SDK_VERSION = v1.15.0
+OPERATOR_SDK_VERSION = v1.22.0
 operator-sdk: ## Download operator-sdk locally if necessary.
 	./utils/install-operator-sdk.sh $(OPERATOR_SDK) $(OPERATOR_SDK_VERSION)
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=authorino-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.14.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.22.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/authorino-operator:latest
     createdAt: 2021-12-08T10-00-00Z
-    operators.operatorframework.io/builder: operator-sdk-v1.14.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.22.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/authorino-operator
     support: kuadrant
@@ -247,7 +247,9 @@ spec:
           - update
         serviceAccountName: authorino-operator
       deployments:
-      - name: authorino-operator
+      - label:
+          control-plane: authorino-operator
+        name: authorino-operator
         spec:
           replicas: 1
           selector:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: authorino-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.14.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.22.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -61,20 +61,30 @@ spec:
         description: AuthConfig is the schema for Authorino's AuthConfig API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: Specifies the desired state of the AuthConfig resource, i.e. the authencation/authorization scheme to be applied to protect the matching service hosts.
+            description: Specifies the desired state of the AuthConfig resource, i.e.
+              the authencation/authorization scheme to be applied to protect the matching
+              service hosts.
             properties:
               authorization:
-                description: Authorization is the list of authorization policies. All policies in this list MUST evaluate to "true" for a request be successful in the authorization phase.
+                description: Authorization is the list of authorization policies.
+                  All policies in this list MUST evaluate to "true" for a request
+                  be successful in the authorization phase.
                 items:
-                  description: 'Authorization policy to be enforced. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "opa", "json" or "kubernetes".'
+                  description: 'Authorization policy to be enforced. Apart from "name",
+                    one of the following parameters is required and only one of the
+                    following parameters is allowed: "opa", "json" or "kubernetes".'
                   oneOf:
                   - properties:
                       name: {}
@@ -96,10 +106,14 @@ spec:
                     - kubernetes
                   properties:
                     cache:
-                      description: Caching options for the policy evaluation results when enforcing this config. Omit it to avoid caching policy evaluation results for this config.
+                      description: Caching options for the policy evaluation results
+                        when enforcing this config. Omit it to avoid caching policy
+                        evaluation results for this config.
                       properties:
                         key:
-                          description: Key used to store the entry in the cache. Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                          description: Key used to store the entry in the cache. Cache
+                            entries from different metadata configs are stored and
+                            managed separately regardless of the key.
                           properties:
                             value:
                               description: Static value
@@ -108,13 +122,22 @@ spec:
                               description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fetch a value from the
+                                    authorization JSON. It can be any path pattern
+                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                    or a string template with variable placeholders
+                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following string modifiers are
+                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           type: object
                         ttl:
                           default: 60
-                          description: Duration (in seconds) of the external data in the cache before pulled again from the source.
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
                           type: integer
                       required:
                       - key
@@ -123,7 +146,8 @@ spec:
                       description: JSON pattern matching authorization policy.
                       properties:
                         rules:
-                          description: The rules that must all evaluate to "true" for the request to be authorized.
+                          description: The rules that must all evaluate to "true"
+                            for the request to be authorized.
                           items:
                             oneOf:
                             - properties:
@@ -140,7 +164,12 @@ spec:
                               - value
                             properties:
                               operator:
-                                description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                                description: 'The binary operator to be applied to
+                                  the content fetched from the authorization JSON,
+                                  for comparison with "value". Possible values are:
+                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
+                                  for arrays), "excl" (excludes; for arrays), "matches"
+                                  (regex)'
                                 enum:
                                 - eq
                                 - neq
@@ -152,10 +181,16 @@ spec:
                                 description: Name of a named pattern
                                 type: string
                               selector:
-                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                                  The value is used to fetch content from the input
+                                  authorization JSON built by Authorino along the
+                                  identity and metadata phases.
                                 type: string
                               value:
-                                description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                description: The value of reference for the comparison
+                                  with the content fetched from the authorization
+                                  JSON. If used with the "matches" operator, the value
+                                  must compile to a valid Golang regex.
                                 type: string
                             type: object
                           type: array
@@ -163,7 +198,8 @@ spec:
                       - rules
                       type: object
                     kubernetes:
-                      description: Kubernetes authorization policy based on `SubjectAccessReview` Path and Verb are inferred from the request.
+                      description: Kubernetes authorization policy based on `SubjectAccessReview`
+                        Path and Verb are inferred from the request.
                       properties:
                         groups:
                           description: Groups to test for.
@@ -171,10 +207,16 @@ spec:
                             type: string
                           type: array
                         resourceAttributes:
-                          description: Use ResourceAttributes for checking permissions on Kubernetes resources If omitted, it performs a non-resource `SubjectAccessReview`, with verb and path inferred from the request.
+                          description: Use ResourceAttributes for checking permissions
+                            on Kubernetes resources If omitted, it performs a non-resource
+                            `SubjectAccessReview`, with verb and path inferred from
+                            the request.
                           properties:
                             group:
-                              description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
+                              description: StaticOrDynamicValue is either a constant
+                                static string value or a config for fetching a value
+                                from a dynamic source (e.g. a path pattern of authorization
+                                JSON)
                               properties:
                                 value:
                                   description: Static value
@@ -183,12 +225,24 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             name:
-                              description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
+                              description: StaticOrDynamicValue is either a constant
+                                static string value or a config for fetching a value
+                                from a dynamic source (e.g. a path pattern of authorization
+                                JSON)
                               properties:
                                 value:
                                   description: Static value
@@ -197,12 +251,24 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             namespace:
-                              description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
+                              description: StaticOrDynamicValue is either a constant
+                                static string value or a config for fetching a value
+                                from a dynamic source (e.g. a path pattern of authorization
+                                JSON)
                               properties:
                                 value:
                                   description: Static value
@@ -211,12 +277,24 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             resource:
-                              description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
+                              description: StaticOrDynamicValue is either a constant
+                                static string value or a config for fetching a value
+                                from a dynamic source (e.g. a path pattern of authorization
+                                JSON)
                               properties:
                                 value:
                                   description: Static value
@@ -225,12 +303,24 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             subresource:
-                              description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
+                              description: StaticOrDynamicValue is either a constant
+                                static string value or a config for fetching a value
+                                from a dynamic source (e.g. a path pattern of authorization
+                                JSON)
                               properties:
                                 value:
                                   description: Static value
@@ -239,12 +329,24 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             verb:
-                              description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
+                              description: StaticOrDynamicValue is either a constant
+                                static string value or a config for fetching a value
+                                from a dynamic source (e.g. a path pattern of authorization
+                                JSON)
                               properties:
                                 value:
                                   description: Static value
@@ -253,13 +355,24 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                           type: object
                         user:
-                          description: User to test for. If without "Groups", then is it interpreted as "What if User were not a member of any groups"
+                          description: User to test for. If without "Groups", then
+                            is it interpreted as "What if User were not a member of
+                            any groups"
                           properties:
                             value:
                               description: Static value
@@ -268,7 +381,15 @@ spec:
                               description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fetch a value from the
+                                    authorization JSON. It can be any path pattern
+                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                    or a string template with variable placeholders
+                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following string modifiers are
+                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           type: object
@@ -277,27 +398,40 @@ spec:
                       type: object
                     metrics:
                       default: false
-                      description: Whether this authorization config should generate individual observability metrics
+                      description: Whether this authorization config should generate
+                        individual observability metrics
                       type: boolean
                     name:
-                      description: Name of the authorization policy. It can be used to refer to the resolved authorization object in other configs.
+                      description: Name of the authorization policy. It can be used
+                        to refer to the resolved authorization object in other configs.
                       type: string
                     opa:
                       description: Open Policy Agent (OPA) authorization policy.
                       properties:
                         allValues:
                           default: false
-                          description: Returns the value of all Rego rules in the virtual document. Values can be read in subsequent evaluators/phases of the Auth Pipeline. Otherwise, only the default `allow` rule will be exposed. Returning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.
+                          description: Returns the value of all Rego rules in the
+                            virtual document. Values can be read in subsequent evaluators/phases
+                            of the Auth Pipeline. Otherwise, only the default `allow`
+                            rule will be exposed. Returning all Rego rules can affect
+                            performance of OPA policies during reconciliation (policy
+                            precompile) and at runtime.
                           type: boolean
                         externalRegistry:
                           description: External registry of OPA policies.
                           properties:
                             credentials:
-                              description: Defines where client credentials will be passed in the request to the service. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                              description: Defines where client credentials will be
+                                passed in the request to the service. If omitted,
+                                it defaults to client credentials passed in the HTTP
+                                Authorization header and the "Bearer" prefix expected
+                                prepended to the secret value.
                               properties:
                                 in:
                                   default: authorization_header
-                                  description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
+                                  description: The location in the request where client
+                                    credentials shall be passed on requests authenticating
+                                    with this identity source/authentication mode.
                                   enum:
                                   - authorization_header
                                   - custom_header
@@ -305,41 +439,69 @@ spec:
                                   - cookie
                                   type: string
                                 keySelector:
-                                  description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
+                                  description: Used in conjunction with the `in` parameter.
+                                    When used with `authorization_header`, the value
+                                    is the prefix of the client credentials string,
+                                    separated by a white-space, in the HTTP Authorization
+                                    header (e.g. "Bearer", "Basic"). When used with
+                                    `custom_header`, `query` or `cookie`, the value
+                                    is the name of the HTTP header, query string parameter
+                                    or cookie key, respectively.
                                   type: string
                               required:
                               - keySelector
                               type: object
                             endpoint:
-                              description: Endpoint of the HTTP external registry. The endpoint must respond with either plain/text or application/json content-type. In the latter case, the JSON returned in the body must include a path `result.raw`, where the raw Rego policy will be extracted from. This complies with the specification of the OPA REST API (https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
+                              description: Endpoint of the HTTP external registry.
+                                The endpoint must respond with either plain/text or
+                                application/json content-type. In the latter case,
+                                the JSON returned in the body must include a path
+                                `result.raw`, where the raw Rego policy will be extracted
+                                from. This complies with the specification of the
+                                OPA REST API (https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
                               type: string
                             sharedSecretRef:
-                              description: Reference to a Secret key whose value will be passed by Authorino in the request. The HTTP service can use the shared secret to authenticate the origin of the request.
+                              description: Reference to a Secret key whose value will
+                                be passed by Authorino in the request. The HTTP service
+                                can use the shared secret to authenticate the origin
+                                of the request.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: The name of the secret in the Authorino's namespace to select from.
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
                                   type: string
                               required:
                               - key
                               - name
                               type: object
                             ttl:
-                              description: Duration (in seconds) of the external data in the cache before pulled again from the source.
+                              description: Duration (in seconds) of the external data
+                                in the cache before pulled again from the source.
                               type: integer
                           type: object
                         inlineRego:
-                          description: Authorization policy as a Rego language document. The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed). The Rego document must NOT include the "package" declaration in line 1.
+                          description: Authorization policy as a Rego language document.
+                            The Rego document must include the "allow" condition,
+                            set by Authorino to "false" by default (i.e. requests
+                            are unauthorized unless changed). The Rego document must
+                            NOT include the "package" declaration in line 1.
                           type: string
                       type: object
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
                       type: integer
                     when:
-                      description: Conditions for Authorino to enforce this authorization policy. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                      description: Conditions for Authorino to enforce this authorization
+                        policy. If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be
+                        enforced; otherwise, the config will be skipped.
                       items:
                         oneOf:
                         - properties:
@@ -356,7 +518,11 @@ spec:
                           - value
                         properties:
                           operator:
-                            description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                            description: 'The binary operator to be applied to the
+                              content fetched from the authorization JSON, for comparison
+                              with "value". Possible values are: "eq" (equal to),
+                              "neq" (not equal to), "incl" (includes; for arrays),
+                              "excl" (excludes; for arrays), "matches" (regex)'
                             enum:
                             - eq
                             - neq
@@ -368,10 +534,16 @@ spec:
                             description: Name of a named pattern
                             type: string
                           selector:
-                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                              The value is used to fetch content from the input authorization
+                              JSON built by Authorino along the identity and metadata
+                              phases.
                             type: string
                           value:
-                            description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            description: The value of reference for the comparison
+                              with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must
+                              compile to a valid Golang regex.
                             type: string
                         type: object
                       type: array
@@ -380,13 +552,15 @@ spec:
                   type: object
                 type: array
               denyWith:
-                description: Custom denial response codes, statuses and headers to override default 40x's.
+                description: Custom denial response codes, statuses and headers to
+                  override default 40x's.
                 properties:
                   unauthenticated:
                     description: Denial status customization when the request is unauthenticated.
                     properties:
                       body:
-                        description: HTTP response body to override the default denial body.
+                        description: HTTP response body to override the default denial
+                          body.
                         properties:
                           value:
                             description: Static value
@@ -395,18 +569,28 @@ spec:
                             description: Dynamic value
                             properties:
                               authJSON:
-                                description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                description: 'Selector to fetch a value from the authorization
+                                  JSON. It can be any path pattern to fetch from the
+                                  authorization JSON (e.g. ''context.request.http.host'')
+                                  or a string template with variable placeholders
+                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following string modifiers are
+                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, and @base64:encode|decode.'
                                 type: string
                             type: object
                         type: object
                       code:
-                        description: HTTP status code to override the default denial status code.
+                        description: HTTP status code to override the default denial
+                          status code.
                         format: int64
                         maximum: 599
                         minimum: 300
                         type: integer
                       headers:
-                        description: HTTP response headers to override the default denial headers.
+                        description: HTTP response headers to override the default
+                          denial headers.
                         items:
                           properties:
                             name:
@@ -419,7 +603,15 @@ spec:
                               description: Dynamic value of the JSON property
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fetch a value from the
+                                    authorization JSON. It can be any path pattern
+                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                    or a string template with variable placeholders
+                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following string modifiers are
+                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           required:
@@ -436,7 +628,15 @@ spec:
                             description: Dynamic value
                             properties:
                               authJSON:
-                                description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                description: 'Selector to fetch a value from the authorization
+                                  JSON. It can be any path pattern to fetch from the
+                                  authorization JSON (e.g. ''context.request.http.host'')
+                                  or a string template with variable placeholders
+                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following string modifiers are
+                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, and @base64:encode|decode.'
                                 type: string
                             type: object
                         type: object
@@ -445,7 +645,8 @@ spec:
                     description: Denial status customization when the request is unauthorized.
                     properties:
                       body:
-                        description: HTTP response body to override the default denial body.
+                        description: HTTP response body to override the default denial
+                          body.
                         properties:
                           value:
                             description: Static value
@@ -454,18 +655,28 @@ spec:
                             description: Dynamic value
                             properties:
                               authJSON:
-                                description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                description: 'Selector to fetch a value from the authorization
+                                  JSON. It can be any path pattern to fetch from the
+                                  authorization JSON (e.g. ''context.request.http.host'')
+                                  or a string template with variable placeholders
+                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following string modifiers are
+                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, and @base64:encode|decode.'
                                 type: string
                             type: object
                         type: object
                       code:
-                        description: HTTP status code to override the default denial status code.
+                        description: HTTP status code to override the default denial
+                          status code.
                         format: int64
                         maximum: 599
                         minimum: 300
                         type: integer
                       headers:
-                        description: HTTP response headers to override the default denial headers.
+                        description: HTTP response headers to override the default
+                          denial headers.
                         items:
                           properties:
                             name:
@@ -478,7 +689,15 @@ spec:
                               description: Dynamic value of the JSON property
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fetch a value from the
+                                    authorization JSON. It can be any path pattern
+                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                    or a string template with variable placeholders
+                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following string modifiers are
+                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           required:
@@ -495,21 +714,37 @@ spec:
                             description: Dynamic value
                             properties:
                               authJSON:
-                                description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                description: 'Selector to fetch a value from the authorization
+                                  JSON. It can be any path pattern to fetch from the
+                                  authorization JSON (e.g. ''context.request.http.host'')
+                                  or a string template with variable placeholders
+                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following string modifiers are
+                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, and @base64:encode|decode.'
                                 type: string
                             type: object
                         type: object
                     type: object
                 type: object
               hosts:
-                description: The list of public host names of the services protected by this authentication/authorization scheme. Authorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.
+                description: The list of public host names of the services protected
+                  by this authentication/authorization scheme. Authorino uses the
+                  requested host to lookup for the corresponding authentication/authorization
+                  configs to enforce.
                 items:
                   type: string
                 type: array
               identity:
-                description: List of identity sources/authentication modes. At least one config of this list MUST evaluate to a valid identity for a request to be successful in the identity verification phase.
+                description: List of identity sources/authentication modes. At least
+                  one config of this list MUST evaluate to a valid identity for a
+                  request to be successful in the identity verification phase.
                 items:
-                  description: 'The identity source/authentication mode config. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "oicd", "apiKey" or "kubernetes".'
+                  description: 'The identity source/authentication mode config. Apart
+                    from "name", one of the following parameters is required and only
+                    one of the following parameters is allowed: "oicd", "apiKey" or
+                    "kubernetes".'
                   oneOf:
                   - properties:
                       credentials: {}
@@ -567,21 +802,30 @@ spec:
                       properties:
                         allNamespaces:
                           default: false
-                          description: Whether Authorino should look for API key secrets in all namespaces or only in the same namespace as the AuthConfig. Enabling this option in namespaced Authorino instances has no effect.
+                          description: Whether Authorino should look for API key secrets
+                            in all namespaces or only in the same namespace as the
+                            AuthConfig. Enabling this option in namespaced Authorino
+                            instances has no effect.
                           type: boolean
                         labelSelectors:
                           additionalProperties:
                             type: string
-                          description: The map of label selectors used by Authorino to match secrets from the cluster storing valid credentials to authenticate to this service
+                          description: The map of label selectors used by Authorino
+                            to match secrets from the cluster storing valid credentials
+                            to authenticate to this service
                           type: object
                       required:
                       - labelSelectors
                       type: object
                     cache:
-                      description: Caching options for the identity resolved when applying this config. Omit it to avoid caching identity objects for this config.
+                      description: Caching options for the identity resolved when
+                        applying this config. Omit it to avoid caching identity objects
+                        for this config.
                       properties:
                         key:
-                          description: Key used to store the entry in the cache. Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                          description: Key used to store the entry in the cache. Cache
+                            entries from different metadata configs are stored and
+                            managed separately regardless of the key.
                           properties:
                             value:
                               description: Static value
@@ -590,23 +834,38 @@ spec:
                               description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fetch a value from the
+                                    authorization JSON. It can be any path pattern
+                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                    or a string template with variable placeholders
+                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following string modifiers are
+                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           type: object
                         ttl:
                           default: 60
-                          description: Duration (in seconds) of the external data in the cache before pulled again from the source.
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
                           type: integer
                       required:
                       - key
                       type: object
                     credentials:
-                      description: Defines where client credentials are required to be passed in the request for this identity source/authentication mode. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the credentials value (token, API key, etc).
+                      description: Defines where client credentials are required to
+                        be passed in the request for this identity source/authentication
+                        mode. If omitted, it defaults to client credentials passed
+                        in the HTTP Authorization header and the "Bearer" prefix expected
+                        prepended to the credentials value (token, API key, etc).
                       properties:
                         in:
                           default: authorization_header
-                          description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
+                          description: The location in the request where client credentials
+                            shall be passed on requests authenticating with this identity
+                            source/authentication mode.
                           enum:
                           - authorization_header
                           - custom_header
@@ -614,13 +873,23 @@ spec:
                           - cookie
                           type: string
                         keySelector:
-                          description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
+                          description: Used in conjunction with the `in` parameter.
+                            When used with `authorization_header`, the value is the
+                            prefix of the client credentials string, separated by
+                            a white-space, in the HTTP Authorization header (e.g.
+                            "Bearer", "Basic"). When used with `custom_header`, `query`
+                            or `cookie`, the value is the name of the HTTP header,
+                            query string parameter or cookie key, respectively.
                           type: string
                       required:
                       - keySelector
                       type: object
                     extendedProperties:
-                      description: Extends the resolved identity object with additional custom properties before appending to the authorization JSON. It requires the resolved identity object to always be of the JSON type 'object'. Other JSON types (array, string, etc) will break.
+                      description: Extends the resolved identity object with additional
+                        custom properties before appending to the authorization JSON.
+                        It requires the resolved identity object to always be of the
+                        JSON type 'object'. Other JSON types (array, string, etc)
+                        will break.
                       items:
                         properties:
                           name:
@@ -633,7 +902,15 @@ spec:
                             description: Dynamic value of the JSON property
                             properties:
                               authJSON:
-                                description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                description: 'Selector to fetch a value from the authorization
+                                  JSON. It can be any path pattern to fetch from the
+                                  authorization JSON (e.g. ''context.request.http.host'')
+                                  or a string template with variable placeholders
+                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following string modifiers are
+                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, and @base64:encode|decode.'
                                 type: string
                             type: object
                         required:
@@ -643,46 +920,63 @@ spec:
                     kubernetes:
                       properties:
                         audiences:
-                          description: The list of audiences (scopes) that must be claimed in a Kubernetes authentication token supplied in the request, and reviewed by Authorino. If omitted, Authorino will review tokens expecting the host name of the requested protected service amongst the audiences.
+                          description: The list of audiences (scopes) that must be
+                            claimed in a Kubernetes authentication token supplied
+                            in the request, and reviewed by Authorino. If omitted,
+                            Authorino will review tokens expecting the host name of
+                            the requested protected service amongst the audiences.
                           items:
                             type: string
                           type: array
                       type: object
                     metrics:
                       default: false
-                      description: Whether this identity config should generate individual observability metrics
+                      description: Whether this identity config should generate individual
+                        observability metrics
                       type: boolean
                     mtls:
                       properties:
                         allNamespaces:
                           default: false
-                          description: Whether Authorino should look for TLS secrets in all namespaces or only in the same namespace as the AuthConfig. Enabling this option in namespaced Authorino instances has no effect.
+                          description: Whether Authorino should look for TLS secrets
+                            in all namespaces or only in the same namespace as the
+                            AuthConfig. Enabling this option in namespaced Authorino
+                            instances has no effect.
                           type: boolean
                         labelSelectors:
                           additionalProperties:
                             type: string
-                          description: The map of label selectors used by Authorino to match secrets from the cluster storing trusted CA certificates to validate clients trying to authenticate to this service
+                          description: The map of label selectors used by Authorino
+                            to match secrets from the cluster storing trusted CA certificates
+                            to validate clients trying to authenticate to this service
                           type: object
                       required:
                       - labelSelectors
                       type: object
                     name:
-                      description: The name of this identity source/authentication mode. It usually identifies a source of identities or group of users/clients of the protected service. It can be used to refer to the resolved identity object in other configs.
+                      description: The name of this identity source/authentication
+                        mode. It usually identifies a source of identities or group
+                        of users/clients of the protected service. It can be used
+                        to refer to the resolved identity object in other configs.
                       type: string
                     oauth2:
                       properties:
                         credentialsRef:
-                          description: Reference to a Kubernetes secret in the same namespace, that stores client credentials to the OAuth2 server.
+                          description: Reference to a Kubernetes secret in the same
+                            namespace, that stores client credentials to the OAuth2
+                            server.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                         tokenIntrospectionUrl:
                           description: The full URL of the token introspection endpoint.
                           type: string
                         tokenTypeHint:
-                          description: The token type hint for the token introspection. If omitted, it defaults to "access_token".
+                          description: The token type hint for the token introspection.
+                            If omitted, it defaults to "access_token".
                           type: string
                       required:
                       - credentialsRef
@@ -691,10 +985,18 @@ spec:
                     oidc:
                       properties:
                         endpoint:
-                          description: Endpoint of the OIDC issuer. Authorino will append to this value the well-known path to the OpenID Connect discovery endpoint (i.e. "/.well-known/openid-configuration"), used to automatically discover the OpenID Connect configuration, whose set of claims is expected to include (among others) the "jkws_uri" claim. The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
+                          description: Endpoint of the OIDC issuer. Authorino will
+                            append to this value the well-known path to the OpenID
+                            Connect discovery endpoint (i.e. "/.well-known/openid-configuration"),
+                            used to automatically discover the OpenID Connect configuration,
+                            whose set of claims is expected to include (among others)
+                            the "jkws_uri" claim. The value must coincide with the
+                            value of  the "iss" (issuer) claim of the discovered OpenID
+                            Connect configuration.
                           type: string
                         ttl:
-                          description: Decides how long to wait before refreshing the OIDC configuration (in seconds).
+                          description: Decides how long to wait before refreshing
+                            the OIDC configuration (in seconds).
                           type: integer
                       required:
                       - endpoint
@@ -702,15 +1004,28 @@ spec:
                     plain:
                       properties:
                         authJSON:
-                          description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                          description: 'Selector to fetch a value from the authorization
+                            JSON. It can be any path pattern to fetch from the authorization
+                            JSON (e.g. ''context.request.http.host'') or a string
+                            template with variable placeholders that resolve to patterns
+                            (e.g. "Hello, {auth.identity.name}!"). Any patterns supported
+                            by https://pkg.go.dev/github.com/tidwall/gjson can be
+                            used. The following string modifiers are available: @extract:{sep:"
+                            ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                            and @base64:encode|decode.'
                           type: string
                       type: object
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
                       type: integer
                     when:
-                      description: Conditions for Authorino to enforce this identity config. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                      description: Conditions for Authorino to enforce this identity
+                        config. If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be
+                        enforced; otherwise, the config will be skipped.
                       items:
                         oneOf:
                         - properties:
@@ -727,7 +1042,11 @@ spec:
                           - value
                         properties:
                           operator:
-                            description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                            description: 'The binary operator to be applied to the
+                              content fetched from the authorization JSON, for comparison
+                              with "value". Possible values are: "eq" (equal to),
+                              "neq" (not equal to), "incl" (includes; for arrays),
+                              "excl" (excludes; for arrays), "matches" (regex)'
                             enum:
                             - eq
                             - neq
@@ -739,10 +1058,16 @@ spec:
                             description: Name of a named pattern
                             type: string
                           selector:
-                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                              The value is used to fetch content from the input authorization
+                              JSON built by Authorino along the identity and metadata
+                              phases.
                             type: string
                           value:
-                            description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            description: The value of reference for the comparison
+                              with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must
+                              compile to a valid Golang regex.
                             type: string
                         type: object
                       type: array
@@ -751,9 +1076,12 @@ spec:
                   type: object
                 type: array
               metadata:
-                description: List of metadata source configs. Authorino fetches JSON content from sources on this list on every request.
+                description: List of metadata source configs. Authorino fetches JSON
+                  content from sources on this list on every request.
                 items:
-                  description: 'The metadata config. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "http", userInfo" or "uma".'
+                  description: 'The metadata config. Apart from "name", one of the
+                    following parameters is required and only one of the following
+                    parameters is allowed: "http", userInfo" or "uma".'
                   oneOf:
                   - properties:
                       name: {}
@@ -775,10 +1103,14 @@ spec:
                     - http
                   properties:
                     cache:
-                      description: Caching options for the external metadata fetched when applying this config. Omit it to avoid caching metadata from this source.
+                      description: Caching options for the external metadata fetched
+                        when applying this config. Omit it to avoid caching metadata
+                        from this source.
                       properties:
                         key:
-                          description: Key used to store the entry in the cache. Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                          description: Key used to store the entry in the cache. Cache
+                            entries from different metadata configs are stored and
+                            managed separately regardless of the key.
                           properties:
                             value:
                               description: Static value
@@ -787,22 +1119,35 @@ spec:
                               description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fetch a value from the
+                                    authorization JSON. It can be any path pattern
+                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                    or a string template with variable placeholders
+                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following string modifiers are
+                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           type: object
                         ttl:
                           default: 60
-                          description: Duration (in seconds) of the external data in the cache before pulled again from the source.
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
                           type: integer
                       required:
                       - key
                       type: object
                     http:
-                      description: Generic HTTP interface to obtain authorization metadata from a HTTP service.
+                      description: Generic HTTP interface to obtain authorization
+                        metadata from a HTTP service.
                       properties:
                         body:
-                          description: Raw body of the HTTP request. Supersedes 'bodyParameters'; use either one or the other. Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                          description: Raw body of the HTTP request. Supersedes 'bodyParameters';
+                            use either one or the other. Use it with method=POST;
+                            for GET requests, set parameters as query string in the
+                            'endpoint' (placeholders can be used).
                           properties:
                             value:
                               description: Static value
@@ -811,12 +1156,24 @@ spec:
                               description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fetch a value from the
+                                    authorization JSON. It can be any path pattern
+                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                    or a string template with variable placeholders
+                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following string modifiers are
+                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           type: object
                         bodyParameters:
-                          description: Custom parameters to encode in the body of the HTTP request. Superseded by 'body'; use either one or the other. Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                          description: Custom parameters to encode in the body of
+                            the HTTP request. Superseded by 'body'; use either one
+                            or the other. Use it with method=POST; for GET requests,
+                            set parameters as query string in the 'endpoint' (placeholders
+                            can be used).
                           items:
                             properties:
                               name:
@@ -829,7 +1186,15 @@ spec:
                                 description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fetch a value from the
+                                      authorization JSON. It can be any path pattern
+                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                      or a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following string modifiers
+                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -838,17 +1203,26 @@ spec:
                           type: array
                         contentType:
                           default: application/x-www-form-urlencoded
-                          description: Content-Type of the request body. Shapes how 'bodyParameters' are encoded. Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                          description: Content-Type of the request body. Shapes how
+                            'bodyParameters' are encoded. Use it with method=POST;
+                            for GET requests, Content-Type is automatically set to
+                            'text/plain'.
                           enum:
                           - application/x-www-form-urlencoded
                           - application/json
                           type: string
                         credentials:
-                          description: Defines where client credentials will be passed in the request to the service. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                          description: Defines where client credentials will be passed
+                            in the request to the service. If omitted, it defaults
+                            to client credentials passed in the HTTP Authorization
+                            header and the "Bearer" prefix expected prepended to the
+                            secret value.
                           properties:
                             in:
                               default: authorization_header
-                              description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
+                              description: The location in the request where client
+                                credentials shall be passed on requests authenticating
+                                with this identity source/authentication mode.
                               enum:
                               - authorization_header
                               - custom_header
@@ -856,13 +1230,23 @@ spec:
                               - cookie
                               type: string
                             keySelector:
-                              description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
+                              description: Used in conjunction with the `in` parameter.
+                                When used with `authorization_header`, the value is
+                                the prefix of the client credentials string, separated
+                                by a white-space, in the HTTP Authorization header
+                                (e.g. "Bearer", "Basic"). When used with `custom_header`,
+                                `query` or `cookie`, the value is the name of the
+                                HTTP header, query string parameter or cookie key,
+                                respectively.
                               type: string
                           required:
                           - keySelector
                           type: object
                         endpoint:
-                          description: Endpoint of the HTTP service. The endpoint accepts variable placeholders in the format "{selector}", where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
+                          description: Endpoint of the HTTP service. The endpoint
+                            accepts variable placeholders in the format "{selector}",
+                            where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                            and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
                           type: string
                         headers:
                           description: Custom headers in the HTTP request.
@@ -878,7 +1262,15 @@ spec:
                                 description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fetch a value from the
+                                      authorization JSON. It can be any path pattern
+                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                      or a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following string modifiers
+                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -887,19 +1279,27 @@ spec:
                           type: array
                         method:
                           default: GET
-                          description: 'HTTP verb used in the request to the service. Accepted values: GET (default), POST. When the request method is POST, the authorization JSON is passed in the body of the request.'
+                          description: 'HTTP verb used in the request to the service.
+                            Accepted values: GET (default), POST. When the request
+                            method is POST, the authorization JSON is passed in the
+                            body of the request.'
                           enum:
                           - GET
                           - POST
                           type: string
                         sharedSecretRef:
-                          description: Reference to a Secret key whose value will be passed by Authorino in the request. The HTTP service can use the shared secret to authenticate the origin of the request.
+                          description: Reference to a Secret key whose value will
+                            be passed by Authorino in the request. The HTTP service
+                            can use the shared secret to authenticate the origin of
+                            the request.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must be a valid secret key.
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
-                              description: The name of the secret in the Authorino's namespace to select from.
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
                               type: string
                           required:
                           - key
@@ -910,43 +1310,58 @@ spec:
                       type: object
                     metrics:
                       default: false
-                      description: Whether this metadata config should generate individual observability metrics
+                      description: Whether this metadata config should generate individual
+                        observability metrics
                       type: boolean
                     name:
-                      description: The name of the metadata source. It can be used to refer to the resolved metadata object in other configs.
+                      description: The name of the metadata source. It can be used
+                        to refer to the resolved metadata object in other configs.
                       type: string
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
                       type: integer
                     uma:
                       description: User-Managed Access (UMA) source of resource data.
                       properties:
                         credentialsRef:
-                          description: Reference to a Kubernetes secret in the same namespace, that stores client credentials to the resource registration API of the UMA server.
+                          description: Reference to a Kubernetes secret in the same
+                            namespace, that stores client credentials to the resource
+                            registration API of the UMA server.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                         endpoint:
-                          description: The endpoint of the UMA server. The value must coincide with the "issuer" claim of the UMA config discovered from the well-known uma configuration endpoint.
+                          description: The endpoint of the UMA server. The value must
+                            coincide with the "issuer" claim of the UMA config discovered
+                            from the well-known uma configuration endpoint.
                           type: string
                       required:
                       - credentialsRef
                       - endpoint
                       type: object
                     userInfo:
-                      description: OpendID Connect UserInfo linked to an OIDC identity config of this same spec.
+                      description: OpendID Connect UserInfo linked to an OIDC identity
+                        config of this same spec.
                       properties:
                         identitySource:
-                          description: The name of an OIDC identity source included in the "identity" section and whose OpenID Connect configuration discovered includes the OIDC "userinfo_endpoint" claim.
+                          description: The name of an OIDC identity source included
+                            in the "identity" section and whose OpenID Connect configuration
+                            discovered includes the OIDC "userinfo_endpoint" claim.
                           type: string
                       required:
                       - identitySource
                       type: object
                     when:
-                      description: Conditions for Authorino to apply this metadata config. If omitted, the config will be applied for all requests. If present, all conditions must match for the config to be applied; otherwise, the config will be skipped.
+                      description: Conditions for Authorino to apply this metadata
+                        config. If omitted, the config will be applied for all requests.
+                        If present, all conditions must match for the config to be
+                        applied; otherwise, the config will be skipped.
                       items:
                         oneOf:
                         - properties:
@@ -963,7 +1378,11 @@ spec:
                           - value
                         properties:
                           operator:
-                            description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                            description: 'The binary operator to be applied to the
+                              content fetched from the authorization JSON, for comparison
+                              with "value". Possible values are: "eq" (equal to),
+                              "neq" (not equal to), "incl" (includes; for arrays),
+                              "excl" (excludes; for arrays), "matches" (regex)'
                             enum:
                             - eq
                             - neq
@@ -975,10 +1394,16 @@ spec:
                             description: Name of a named pattern
                             type: string
                           selector:
-                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                              The value is used to fetch content from the input authorization
+                              JSON built by Authorino along the identity and metadata
+                              phases.
                             type: string
                           value:
-                            description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            description: The value of reference for the comparison
+                              with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must
+                              compile to a valid Golang regex.
                             type: string
                         type: object
                       type: array
@@ -991,7 +1416,11 @@ spec:
                   items:
                     properties:
                       operator:
-                        description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                        description: 'The binary operator to be applied to the content
+                          fetched from the authorization JSON, for comparison with
+                          "value". Possible values are: "eq" (equal to), "neq" (not
+                          equal to), "incl" (includes; for arrays), "excl" (excludes;
+                          for arrays), "matches" (regex)'
                         enum:
                         - eq
                         - neq
@@ -1000,25 +1429,39 @@ spec:
                         - matches
                         type: string
                       selector:
-                        description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                        description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                          The value is used to fetch content from the input authorization
+                          JSON built by Authorino along the identity and metadata
+                          phases.
                         type: string
                       value:
-                        description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                        description: The value of reference for the comparison with
+                          the content fetched from the authorization JSON. If used
+                          with the "matches" operator, the value must compile to a
+                          valid Golang regex.
                         type: string
                     type: object
                   type: array
-                description: Named sets of JSON patterns that can be referred in `when` conditionals and in JSON-pattern matching policy rules.
+                description: Named sets of JSON patterns that can be referred in `when`
+                  conditionals and in JSON-pattern matching policy rules.
                 type: object
               response:
-                description: List of response configs. Authorino gathers data from the auth pipeline to build custom responses for the client.
+                description: List of response configs. Authorino gathers data from
+                  the auth pipeline to build custom responses for the client.
                 items:
-                  description: 'Dynamic response to return to the client. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "wristband" or "json".'
+                  description: 'Dynamic response to return to the client. Apart from
+                    "name", one of the following parameters is required and only one
+                    of the following parameters is allowed: "wristband" or "json".'
                   properties:
                     cache:
-                      description: Caching options for dynamic responses built when applying this config. Omit it to avoid caching dynamic responses for this config.
+                      description: Caching options for dynamic responses built when
+                        applying this config. Omit it to avoid caching dynamic responses
+                        for this config.
                       properties:
                         key:
-                          description: Key used to store the entry in the cache. Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                          description: Key used to store the entry in the cache. Cache
+                            entries from different metadata configs are stored and
+                            managed separately regardless of the key.
                           properties:
                             value:
                               description: Static value
@@ -1027,13 +1470,22 @@ spec:
                               description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                  description: 'Selector to fetch a value from the
+                                    authorization JSON. It can be any path pattern
+                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                    or a string template with variable placeholders
+                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following string modifiers are
+                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, and @base64:encode|decode.'
                                   type: string
                               type: object
                           type: object
                         ttl:
                           default: 60
-                          description: Duration (in seconds) of the external data in the cache before pulled again from the source.
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
                           type: integer
                       required:
                       - key
@@ -1041,7 +1493,8 @@ spec:
                     json:
                       properties:
                         properties:
-                          description: List of JSON property-value pairs to be added to the dynamic response.
+                          description: List of JSON property-value pairs to be added
+                            to the dynamic response.
                           items:
                             properties:
                               name:
@@ -1054,7 +1507,15 @@ spec:
                                 description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fetch a value from the
+                                      authorization JSON. It can be any path pattern
+                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                      or a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following string modifiers
+                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -1066,17 +1527,24 @@ spec:
                       type: object
                     metrics:
                       default: false
-                      description: Whether this response config should generate individual observability metrics
+                      description: Whether this response config should generate individual
+                        observability metrics
                       type: boolean
                     name:
-                      description: Name of the custom response. It can be used to refer to the resolved response object in other configs.
+                      description: Name of the custom response. It can be used to
+                        refer to the resolved response object in other configs.
                       type: string
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
                       type: integer
                     when:
-                      description: Conditions for Authorino to enforce this custom response config. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                      description: Conditions for Authorino to enforce this custom
+                        response config. If omitted, the config will be enforced for
+                        all requests. If present, all conditions must match for the
+                        config to be enforced; otherwise, the config will be skipped.
                       items:
                         oneOf:
                         - properties:
@@ -1093,7 +1561,11 @@ spec:
                           - value
                         properties:
                           operator:
-                            description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                            description: 'The binary operator to be applied to the
+                              content fetched from the authorization JSON, for comparison
+                              with "value". Possible values are: "eq" (equal to),
+                              "neq" (not equal to), "incl" (includes; for arrays),
+                              "excl" (excludes; for arrays), "matches" (regex)'
                             enum:
                             - eq
                             - neq
@@ -1105,27 +1577,39 @@ spec:
                             description: Name of a named pattern
                             type: string
                           selector:
-                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                              The value is used to fetch content from the input authorization
+                              JSON built by Authorino along the identity and metadata
+                              phases.
                             type: string
                           value:
-                            description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            description: The value of reference for the comparison
+                              with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must
+                              compile to a valid Golang regex.
                             type: string
                         type: object
                       type: array
                     wrapper:
                       default: httpHeader
-                      description: How Authorino wraps the response. Use "httpHeader" (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata" to wrap the response as Envoy Dynamic Metadata
+                      description: How Authorino wraps the response. Use "httpHeader"
+                        (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata"
+                        to wrap the response as Envoy Dynamic Metadata
                       enum:
                       - httpHeader
                       - envoyDynamicMetadata
                       type: string
                     wrapperKey:
-                      description: The name of key used in the wrapped response (name of the HTTP header or property of the Envoy Dynamic Metadata JSON). If omitted, it will be set to the name of the configuration.
+                      description: The name of key used in the wrapped response (name
+                        of the HTTP header or property of the Envoy Dynamic Metadata
+                        JSON). If omitted, it will be set to the name of the configuration.
                       type: string
                     wristband:
                       properties:
                         customClaims:
-                          description: Any claims to be added to the wristband token apart from the standard JWT claims (iss, iat, exp) added by default.
+                          description: Any claims to be added to the wristband token
+                            apart from the standard JWT claims (iss, iat, exp) added
+                            by default.
                           items:
                             properties:
                               name:
@@ -1138,7 +1622,15 @@ spec:
                                 description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fetch a value from the
+                                      authorization JSON. It can be any path pattern
+                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                      or a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following string modifiers
+                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -1146,14 +1638,20 @@ spec:
                             type: object
                           type: array
                         issuer:
-                          description: 'The endpoint to the Authorino service that issues the wristband (format: <scheme>://<host>:<port>/<realm>, where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                          description: 'The endpoint to the Authorino service that
+                            issues the wristband (format: <scheme>://<host>:<port>/<realm>,
+                            where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
                           type: string
                         signingKeyRefs:
-                          description: Reference by name to Kubernetes secrets and corresponding signing algorithms. The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                          description: Reference by name to Kubernetes secrets and
+                            corresponding signing algorithms. The secrets must contain
+                            a `key.pem` entry whose value is the signing key formatted
+                            as PEM.
                           items:
                             properties:
                               algorithm:
-                                description: Algorithm to sign the wristband token using the signing key provided
+                                description: Algorithm to sign the wristband token
+                                  using the signing key provided
                                 enum:
                                 - ES256
                                 - ES384
@@ -1163,7 +1661,10 @@ spec:
                                 - RS512
                                 type: string
                               name:
-                                description: Name of the signing key. The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                                description: Name of the signing key. The value is
+                                  used to reference the Kubernetes secret that stores
+                                  the key and in the `kid` claim of the wristband
+                                  token header.
                                 type: string
                             required:
                             - algorithm
@@ -1183,7 +1684,11 @@ spec:
                   type: object
                 type: array
               when:
-                description: Conditions for the AuthConfig to be enforced. If omitted, the AuthConfig will be enforced for all requests. If present, all conditions must match for the AuthConfig to be enforced; otherwise, Authorino skips the AuthConfig and returns immediately with status OK.
+                description: Conditions for the AuthConfig to be enforced. If omitted,
+                  the AuthConfig will be enforced for all requests. If present, all
+                  conditions must match for the AuthConfig to be enforced; otherwise,
+                  Authorino skips the AuthConfig and returns immediately with status
+                  OK.
                 items:
                   oneOf:
                   - properties:
@@ -1200,7 +1705,11 @@ spec:
                     - value
                   properties:
                     operator:
-                      description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                      description: 'The binary operator to be applied to the content
+                        fetched from the authorization JSON, for comparison with "value".
+                        Possible values are: "eq" (equal to), "neq" (not equal to),
+                        "incl" (includes; for arrays), "excl" (excludes; for arrays),
+                        "matches" (regex)'
                       enum:
                       - eq
                       - neq
@@ -1212,10 +1721,15 @@ spec:
                       description: Name of a named pattern
                       type: string
                     selector:
-                      description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                      description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                        The value is used to fetch content from the input authorization
+                        JSON built by Authorino along the identity and metadata phases.
                       type: string
                     value:
-                      description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                      description: The value of reference for the comparison with
+                        the content fetched from the authorization JSON. If used with
+                        the "matches" operator, the value must compile to a valid
+                        Golang regex.
                       type: string
                   type: object
                 type: array
@@ -1229,7 +1743,8 @@ spec:
                 items:
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transit from one status to another.
+                      description: Last time the condition transit from one status
+                        to another.
                       format: date-time
                       type: string
                     lastUpdatedTime:
@@ -1237,7 +1752,8 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human readable message indicating details about last transition.
+                      description: Human readable message indicating details about
+                        last transition.
                       type: string
                     reason:
                       description: (brief) reason for the condition's last transition.
@@ -1256,10 +1772,13 @@ spec:
               summary:
                 properties:
                   festivalWristbandEnabled:
-                    description: Indicator of whether the AuthConfig issues Festival Wristband tokens on successful evaluation of the AuthConfig (access granted)
+                    description: Indicator of whether the AuthConfig issues Festival
+                      Wristband tokens on successful evaluation of the AuthConfig
+                      (access granted)
                     type: boolean
                   hostsReady:
-                    description: Lists the hosts from spec.hosts linked to the resource in the cache
+                    description: Lists the hosts from spec.hosts linked to the resource
+                      in the cache
                     items:
                       type: string
                     type: array
@@ -1268,10 +1787,12 @@ spec:
                     format: int64
                     type: integer
                   numHostsReady:
-                    description: Number of hosts from spec.hosts linked to the resource in the cache, compared to the total number of hosts in spec.hosts
+                    description: Number of hosts from spec.hosts linked to the resource
+                      in the cache, compared to the total number of hosts in spec.hosts
                     type: string
                   numIdentitySources:
-                    description: Number of trusted sources of identity for authentication in the AuthConfig
+                    description: Number of trusted sources of identity for authentication
+                      in the AuthConfig
                     format: int64
                     type: integer
                   numMetadataSources:
@@ -1279,11 +1800,13 @@ spec:
                     format: int64
                     type: integer
                   numResponseItems:
-                    description: Number of custom authorization response items in the AuthConfig
+                    description: Number of custom authorization response items in
+                      the AuthConfig
                     format: int64
                     type: integer
                   ready:
-                    description: Whether all hosts from spec.hosts have been linked to the resource in the cache
+                    description: Whether all hosts from spec.hosts have been linked
+                      to the resource in the cache
                     type: boolean
                 required:
                 - festivalWristbandEnabled
@@ -1324,10 +1847,14 @@ spec:
         description: Authorino is the Schema for the authorinos API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -1347,7 +1874,8 @@ spec:
               listener:
                 properties:
                   port:
-                    description: 'Port number of the GRPC interface. DEPRECATED: use ''ports.grpc'' instead.'
+                    description: 'Port number of the GRPC interface. DEPRECATED: use
+                      ''ports.grpc'' instead.'
                     format: int32
                     type: integer
                   ports:
@@ -1361,16 +1889,21 @@ spec:
                         type: integer
                     type: object
                   timeout:
-                    description: Timeout of the auth service (GRPC and HTTP interfaces), in milliseconds.
+                    description: Timeout of the auth service (GRPC and HTTP interfaces),
+                      in milliseconds.
                     type: integer
                   tls:
-                    description: TLS configuration of the auth service (GRPC and HTTP interfaces).
+                    description: TLS configuration of the auth service (GRPC and HTTP
+                      interfaces).
                     properties:
                       certSecretRef:
-                        description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       enabled:
@@ -1399,10 +1932,13 @@ spec:
                   tls:
                     properties:
                       certSecretRef:
-                        description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       enabled:
@@ -1426,7 +1962,8 @@ spec:
                     items:
                       properties:
                         configMaps:
-                          description: Allow multiple configmaps to mount to the same directory
+                          description: Allow multiple configmaps to mount to the same
+                            directory
                           items:
                             type: string
                           type: array
@@ -1439,11 +1976,22 @@ spec:
                                 description: The key to project.
                                 type: string
                               mode:
-                                description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                description: 'Optional: mode bits used to set permissions
+                                  on this file. Must be an octal value between 0000
+                                  and 0777 or a decimal value between 0 and 511. YAML
+                                  accepts both octal and decimal values, JSON requires
+                                  decimal values for mode bits. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                description: The relative path of the file to map
+                                  the key to. May not be an absolute path. May not
+                                  contain the path element '..'. May not start with
+                                  the string '..'.
                                 type: string
                             required:
                             - key
@@ -1474,11 +2022,13 @@ spec:
             description: AuthorinoStatus defines the observed state of Authorino
             properties:
               conditions:
-                description: 'Conditions is an array of the current Authorino''s CR conditions Supported condition types: ConditionReady'
+                description: 'Conditions is an array of the current Authorino''s CR
+                  conditions Supported condition types: ConditionReady'
                 items:
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transit from one status to another.
+                      description: Last time the condition transit from one status
+                        to another.
                       format: date-time
                       type: string
                     lastUpdatedTime:
@@ -1486,7 +2036,8 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human readable message indicating details about last transition.
+                      description: Human readable message indicating details about
+                        last transition.
                       type: string
                     reason:
                       description: (brief) reason for the condition's last transition.

--- a/config/install/manifests.yaml
+++ b/config/install/manifests.yaml
@@ -20,10 +20,14 @@ spec:
         description: Authorino is the Schema for the authorinos API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -43,7 +47,8 @@ spec:
               listener:
                 properties:
                   port:
-                    description: 'Port number of the GRPC interface. DEPRECATED: use ''ports.grpc'' instead.'
+                    description: 'Port number of the GRPC interface. DEPRECATED: use
+                      ''ports.grpc'' instead.'
                     format: int32
                     type: integer
                   ports:
@@ -57,16 +62,21 @@ spec:
                         type: integer
                     type: object
                   timeout:
-                    description: Timeout of the auth service (GRPC and HTTP interfaces), in milliseconds.
+                    description: Timeout of the auth service (GRPC and HTTP interfaces),
+                      in milliseconds.
                     type: integer
                   tls:
-                    description: TLS configuration of the auth service (GRPC and HTTP interfaces).
+                    description: TLS configuration of the auth service (GRPC and HTTP
+                      interfaces).
                     properties:
                       certSecretRef:
-                        description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       enabled:
@@ -95,10 +105,13 @@ spec:
                   tls:
                     properties:
                       certSecretRef:
-                        description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       enabled:
@@ -122,7 +135,8 @@ spec:
                     items:
                       properties:
                         configMaps:
-                          description: Allow multiple configmaps to mount to the same directory
+                          description: Allow multiple configmaps to mount to the same
+                            directory
                           items:
                             type: string
                           type: array
@@ -135,11 +149,22 @@ spec:
                                 description: The key to project.
                                 type: string
                               mode:
-                                description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                description: 'Optional: mode bits used to set permissions
+                                  on this file. Must be an octal value between 0000
+                                  and 0777 or a decimal value between 0 and 511. YAML
+                                  accepts both octal and decimal values, JSON requires
+                                  decimal values for mode bits. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                description: The relative path of the file to map
+                                  the key to. May not be an absolute path. May not
+                                  contain the path element '..'. May not start with
+                                  the string '..'.
                                 type: string
                             required:
                             - key
@@ -170,11 +195,13 @@ spec:
             description: AuthorinoStatus defines the observed state of Authorino
             properties:
               conditions:
-                description: 'Conditions is an array of the current Authorino''s CR conditions Supported condition types: ConditionReady'
+                description: 'Conditions is an array of the current Authorino''s CR
+                  conditions Supported condition types: ConditionReady'
                 items:
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transit from one status to another.
+                      description: Last time the condition transit from one status
+                        to another.
                       format: date-time
                       type: string
                     lastUpdatedTime:
@@ -182,7 +209,8 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human readable message indicating details about last transition.
+                      description: Human readable message indicating details about
+                        last transition.
                       type: string
                     reason:
                       description: (brief) reason for the condition's last transition.

--- a/utils/install-operator-sdk.sh
+++ b/utils/install-operator-sdk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Install a version of the operator sdk.
 # https://sdk.operatorframework.io/docs/installation/#install-from-github-release


### PR DESCRIPTION
This PR fixes a couple of issues found on M1 macbooks (ARM arch) and some other misc ones:


* [x] Replacing `go get` by `go install`
Since go v1.16 `go install` is used for binary tool build and installation, while `go get` mainly for dependency mgmt.
* [x] Bumping kustomize version to v4
This update solves the following issue:
```
Downloading sigs.k8s.io/kustomize/kustomize/v3@v3.8.7
go: sigs.k8s.io/kustomize/kustomize/v3@v3.8.7 (in sigs.k8s.io/kustomize/kustomize/v3@v3.8.7):
	The go.mod file for the module providing named packages contains one or
	more exclude directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
make: *** [kustomize] Error 1
```
* [x]  Bumping `operator-sdk` to `v.1.22`
This update solves the following issue:
```
Downloading sigs.k8s.io/kustomize/kustomize/v3@v3.8.7
go: sigs.k8s.io/kustomize/kustomize/v3@v3.8.7 (in sigs.k8s.io/kustomize/kustomize/v3@v3.8.7):
	The go.mod file for the module providing named packages contains one or
	more exclude directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
make: *** [kustomize] Error 1
```
* [x] Replacing script shell
`#!/bin/bash` ---> `#!/usr/bin/env bash`
This fixes on macos old default bash, which differs with brew install one