### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,7 @@ jobs:
     name: Test Scripts
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
+        go-version: [1.17.x]
         platform: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.platform }}
     defaults:
@@ -59,3 +59,25 @@ jobs:
       - name: Run make operator-sdk
         run: |
           make operator-sdk
+
+  unit-tests:
+    name: Unit Tests
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        platform: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.platform }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run make test
+        run: |
+          make test

--- a/api/v1beta1/authorino_types.go
+++ b/api/v1beta1/authorino_types.go
@@ -207,6 +207,16 @@ type AuthorinoStatus struct {
 	Conditions []Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
+func (status *AuthorinoStatus) Ready() bool {
+	for _, condition := range status.Conditions {
+		switch condition.Type {
+		case ConditionReady:
+			return condition.Status == k8score.ConditionTrue
+		}
+	}
+	return false
+}
+
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:path="authorinos"

--- a/controllers/authorino_controller.go
+++ b/controllers/authorino_controller.go
@@ -101,7 +101,7 @@ func (r *AuthorinoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	logger.V(1).Info("Found an instance of authorino", "authorinoInstanceName", authorinoInstance.Name)
 
 	if err := r.installationPreflightCheck(authorinoInstance); err != nil {
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{Requeue: true}, err
 	}
 
 	// Creates services required by authorino

--- a/controllers/authorino_controller_test.go
+++ b/controllers/authorino_controller_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Authorino controller", func() {
 				err := k8sClient.Get(context.TODO(),
 					nsdName,
 					&authorino)
-				return err == nil && isAuthorinoInstanceReady(&authorino)
+				return err == nil && authorinoInstance.Status.Ready()
 			}, timeout, interval).Should(BeFalse())
 		})
 
@@ -316,16 +316,6 @@ func checkAuthorinoEnvVar(authorinoInstance *api.Authorino, envs []k8score.EnvVa
 			))
 		}
 	}
-}
-
-func isAuthorinoInstanceReady(authorino *api.Authorino) bool {
-	for _, condition := range authorino.Status.Conditions {
-		switch condition.Type {
-		case api.ConditionReady:
-			return condition.Status == k8score.ConditionTrue
-		}
-	}
-	return false
 }
 
 func newAuthorinoClusterRolebinding(roleBindingName string, clusterScoped bool, clusterRoleName string, serviceAccount k8score.ServiceAccount, authorino *api.Authorino) client.Object {

--- a/controllers/authorino_controller_test.go
+++ b/controllers/authorino_controller_test.go
@@ -38,8 +38,6 @@ var _ = Describe("Authorino controller", func() {
 		BeforeEach(func() {
 			_ = k8sClient.Create(context.TODO(), newExtServerConfigMap())
 
-			Expect(k8sClient.Create(context.TODO(), newCertSecret())).Should(Succeed())
-
 			authorinoInstance = newFullAuthorinoInstance()
 			Expect(k8sClient.Create(context.TODO(), authorinoInstance)).Should(Succeed())
 
@@ -85,6 +83,7 @@ var _ = Describe("Authorino controller", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
+			// Authorino ClusterRoleBinding
 			var binding client.Object
 			var bindingNsdName types.NamespacedName
 			if authorinoInstance.Spec.ClusterWide {
@@ -102,8 +101,9 @@ var _ = Describe("Authorino controller", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
+			// Authorino Auth ClusterRoleBinding
 			k8sAuthBinding := &k8srbac.ClusterRoleBinding{}
-			k8sAuthBindingNsdName := types.NamespacedName{Name: "authorino-k8s-auth"}
+			k8sAuthBindingNsdName := types.NamespacedName{Name: authorinoK8sAuthClusterRoleBindingName}
 
 			Eventually(func() bool {
 				err := k8sClient.Get(context.TODO(),
@@ -112,6 +112,7 @@ var _ = Describe("Authorino controller", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
+			// Authorino leaderElection ClusterRoleBinding
 			leaderElectionRole := &k8srbac.Role{}
 			leaderElectionNsdName := namespacedName(AuthorinoNamespace, authorinoLeaderElectionRoleName)
 			Eventually(func() bool {
@@ -203,15 +204,6 @@ func newExtServerConfigMap() *k8score.ConfigMap {
 		},
 		Data: map[string]string{
 			"tls.crt": "-----BEGIN CERTIFICATE-----\nMIIGwjCCBKqgAwIBAgIUc13V+5zSFtQhEdAzXhtVXXh3D3MwDQYJKoZIhvcNAQEL\nBQAwgaIxCzAJBgNVBAYTAkVTMRIwEAYDVQQIDAlCYXJjZWxvbmExEjAQBgNVBAcM\nCUJhcmNlbG9uYTEWMBQGA1UECgwNUmVkIEhhdCwgSW5jLjEXMBUGA1UECwwOUmVk\nIEhhdCAzc2NhbGUxOjA4BgNVBAMMMUtleWNsb2FrIFNlcnZlciBvbiAzc2NhbGUg\nT3BlblNoaWZ0IGRldmVsIGNsdXN0ZXIwHhcNMjExMjE2MTkyMDA3WhcNMzExMjE0\nMTkyMDA3WjCBojELMAkGA1UEBhMCRVMxEjAQBgNVBAgMCUJhcmNlbG9uYTESMBAG\nA1UEBwwJQmFyY2Vsb25hMRYwFAYDVQQKDA1SZWQgSGF0LCBJbmMuMRcwFQYDVQQL\nDA5SZWQgSGF0IDNzY2FsZTE6MDgGA1UEAwwxS2V5Y2xvYWsgU2VydmVyIG9uIDNz\nY2FsZSBPcGVuU2hpZnQgZGV2ZWwgY2x1c3RlcjCCAiIwDQYJKoZIhvcNAQEBBQAD\nggIPADCCAgoCggIBAL1aPyDtqDBNziWLA2AhYPlOq4VBtnSNZJYwxWb1PMzZDw2M\nQxcaN+2/TGrFELv9RLFmJTYd9yMXk6ASJnx513bEqcMp4le2lREF+hUNFVNjQcF7\n3peoJNe06NcZIbLmCwJ8lR7SQD+lhjqr7rqsr9/+q9ZxCAMuCIkhF4BcBQV9Q2uH\n7juhJ0fEUOofqXfdGlyhTLecqQzfw/ZWEDc+uJWFWMB5OdBYJAphwIpyu6dFh245\nInuIHkO17MmFEWJX1HjkTNgIS+JHfJNmlwUBEG9d5/Lwy/NmLMnif6zdHfyjhEHv\nb0GI9n9zu1n6tcOpXSRL9bhYWYY9jxnVxZ2ubsKT0BZe8KHJDGdU1sOX6TWSA8zL\nDN2mIxQvPjGPq36pX32fesg+jUb2Y1ZEbXlrCm25K3L/TNe5G8EolowCd9EwyuYk\nwf1JlU2wO1zd1Y3V7/b3kHyQ4xlr9hjwnc4xcbZV3FGVyasxvtykvsgT3XtHroE9\nrqXcT+Rh6hMSIUFSWqIyON1h6ft8VPZjVhu51JdYk7h2VWFPsEzGi7SSU+f7Zdzj\nZ/9hyDINbUlHbluCBJxiTJb7Ig4t+XPj5etL0yvBh3/MLSHO9CCF8auGCmbTPR2/\njNESuJAs18uRA15EqqHGa0hC4NHuQqxRGsVgIxLKGi9kdPFvWI8pcCYw199RAgMB\nAAGjge0wgeowHQYDVR0OBBYEFCHy/ieeCgOXZvGrM/Qhvp5+Jt7IMB8GA1UdIwQY\nMBaAFCHy/ieeCgOXZvGrM/Qhvp5+Jt7IMA8GA1UdEwEB/wQFMAMBAf8wgZYGA1Ud\nEQSBjjCBi4I7a2V5Y2xvYWstYXBpY3VyaW8tcmVnaXN0cnkuYXBwcy5kZXYtZW5n\nLW9jcDQtOC5kZXYuM3NjYS5uZXSCHmtleWNsb2FrLWFwaWN1cmlvLXJlZ2lzdHJ5\nLnN2Y4Isa2V5Y2xvYWstYXBpY3VyaW8tcmVnaXN0cnkuc3ZjLmNsdXN0ZXIubG9j\nYWwwDQYJKoZIhvcNAQELBQADggIBAG5Dim4JDcYWeLrLyFs6byyV641FIaIRUlcd\ndj7L61LfjCMC7kjhl7ynLjiMxCtRBB04h56xGtncDG8kFFOAT26caNSkWzNnDFXI\n026gMSaamioqXoEKlRjbp2Lf+cLzqpaMN0vXJxdHoBrg74h7uptWkyWMqHVmaFy8\nlLi6T2ET9q/vXDPzKHHjwaN4KynRKgYfShY/UE3G/WmvstrrHF8zWQz5JN0TPhuv\n31LuSJkq1yRA9HNrLpBK685WYZ9vyPs+KUcG84sjTf1aaO8beAppYJc94knO28PA\nObT6YGQW1RxjH1XiCHFGXF5KL9HXMFfOpLK/FlFt5gUxUlqCKncK1ilyiRtNaNKZ\npJsmBnqPVV/ZbgR/Y1l1ucUT9OoEsPOPC/nBzQj4nue7seACGD9HJlapQml75Ix6\n5Ypmq+KyDU8GX+ejbeTnFY84xNqZPQhE7/lbTHKPj6zLD98IQt4FvOmKzdfZUhIG\nP8iWHYvV5NQ4XQUxu0s0kWJhSuTDZmrg9HtlXD2x1zi8ilAKCoJ7nu/avLvHemO5\nBgNixHMHTILZrd2xZ9xjyNPGi92EDK+WG6BHD3JAgLvbcBqB4eAi9EONj7qmw3Ry\n6FlViwpQjDQf3Aj2JZvGgqtCrj5TlvMXiwTdE3p29JTSiY9JE8jJVuqv93Af/HZJ\njqr1zGh3\n-----END CERTIFICATE-----",
-		},
-	}
-}
-
-func newCertSecret() *k8score.Secret {
-	return &k8score.Secret{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "bkabk",
-			Namespace: AuthorinoNamespace,
 		},
 	}
 }
@@ -334,4 +326,16 @@ func isAuthorinoInstanceReady(authorino *api.Authorino) bool {
 		}
 	}
 	return false
+}
+
+func newAuthorinoClusterRolebinding(roleBindingName string, clusterScoped bool, clusterRoleName string, serviceAccount k8score.ServiceAccount, authorino *api.Authorino) client.Object {
+	var binding client.Object
+	if clusterScoped {
+		binding = authorinoResources.GetAuthorinoClusterRoleBinding(roleBindingName, clusterRoleName, serviceAccount)
+	} else {
+		binding = authorinoResources.GetAuthorinoRoleBinding(authorino.Namespace, authorino.Name, roleBindingName, "ClusterRole", clusterRoleName, serviceAccount)
+		binding.SetNamespace(authorino.Namespace)
+	}
+
+	return binding
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	k8score "k8s.io/api/core/v1"
 	k8srbac "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -85,8 +86,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	// creates authorino ClusterRole
-	clusterRole := getAuthorinoClusterRole()
-	Expect(k8sClient.Create(context.TODO(), clusterRole)).Should(Succeed())
+	Expect(k8sClient.Create(context.TODO(), getAuthorinoClusterRole(authorinoManagerClusterRoleName))).Should(Succeed())
+
+	Expect(k8sClient.Create(context.TODO(), getAuthorinoClusterRole(authorinoK8sAuthClusterRoleName))).Should(Succeed())
+
+	Expect(k8sClient.Create(context.TODO(), newCertSecret())).Should(Succeed())
 
 	err = (&AuthorinoReconciler{
 		Client: k8sClient,
@@ -109,10 +113,19 @@ var _ = AfterSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 })
 
-func getAuthorinoClusterRole() *k8srbac.ClusterRole {
+func getAuthorinoClusterRole(clusterRoleName string) *k8srbac.ClusterRole {
 	return &k8srbac.ClusterRole{
 		ObjectMeta: v1.ObjectMeta{
-			Name: authorinoManagerClusterRoleName,
+			Name: clusterRoleName,
+		},
+	}
+}
+
+func newCertSecret() *k8score.Secret {
+	return &k8score.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "bkabk",
+			Namespace: AuthorinoNamespace,
 		},
 	}
 }

--- a/pkg/resources/k8s_rbac.go
+++ b/pkg/resources/k8s_rbac.go
@@ -39,7 +39,7 @@ func getRoleRefAndSubject(roleName, roleKind string, serviceAccount k8score.Serv
 	}
 
 	var roleSubject = k8srbac.Subject{
-		Kind:      serviceAccount.Kind,
+		Kind:      "ServiceAccount",
 		Name:      serviceAccount.Name,
 		Namespace: serviceAccount.Namespace,
 	}
@@ -75,7 +75,7 @@ func appendSubjectToClusterRoleBinding(roleBinding client.Object, subject k8srba
 
 func GetSubjectForRoleBinding(serviceAccount k8score.ServiceAccount) k8srbac.Subject {
 	return k8srbac.Subject{
-		Kind:      serviceAccount.Kind,
+		Kind:      "ServiceAccount",
 		Name:      serviceAccount.Name,
 		Namespace: serviceAccount.Namespace,
 	}


### PR DESCRIPTION
Since the PR for [preflights checks](https://github.com/Kuadrant/authorino-operator/pull/22) was added as requirement for when TLS is enabled the unit tests were failing due to a mock of the TLS cert secret not being created. 

This PR addresses:

- [x] The creation of a mock TLS cert secret for unit tests
- [x] Fix an issue where errors were being returned when the pre-flight check fails