### PR TITLE
Red Hat Universal Base Image (UBI) 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-# Build the manager binary
-FROM golang:1.17 as builder
-
+# Build the operator binary
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.10 as builder
+USER root
 WORKDIR /workspace
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
-
 # Copy the go source
 COPY main.go main.go
 COPY api/ api/
@@ -17,11 +17,11 @@ COPY pkg/ pkg/
 
 RUN CGO_ENABLED=0 go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+# Use Red Hat minimal base image to package the binary
+# https://catalog.redhat.com/software/containers/ubi8-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER 65532:65532
+USER 1001
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Changes container base image to Red Hat UBI 8 images.

- **Builder:** [registry.access.redhat.com/ubi8/go-toolset:1.17.10](https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1?tag=1.17.10)
- **Runtime:** [registry.access.redhat.com/ubi8/ubi-minimal:latest](https://catalog.redhat.com/software/containers/ubi8-minimal/5c64772edd19c77a158ea216?tag=latest)

As a side effect, image size will grow from ~18-20 MB to ~53-56 MB (depending on the platform – linux/arm64 or linux/amd64, respectively).

On the good side, automated security scans in Quay.io will work (closes #72).