### PR TITLE
update security context to drop all capabilities & set seccomp 

### DIFF
--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -283,6 +283,12 @@ spec:
                 resources: {}
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  readOnlyRootFilesystem: true
+                  seccompProfile:
+                    type: RuntimeDefault
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: authorino-operator

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -2568,6 +2568,12 @@ spec:
           periodSeconds: 10
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
       securityContext:
         runAsNonRoot: true
       serviceAccountName: authorino-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,6 +33,12 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Fix:
Warning: would violate PodSecurity "restricted:v1.24": unrestricted capabilities (container "manager" must set securityContext.capabilities.drop=["ALL"]), seccompProfile (pod or container "manager" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")

* `container "manager" must set securityContext.capabilities.drop=["ALL"]`: Drop all capabilities and add only those required 

* https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-seccomp-profile-for-a-container