### PR TITLE
Propagating Authorino labels

### DIFF
--- a/pkg/resources/k8s_deployment.go
+++ b/pkg/resources/k8s_deployment.go
@@ -6,20 +6,20 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func GetDeployment(name, namespace, saName string, replicas *int32, containers []k8score.Container, vol []k8score.Volume) *k8sapps.Deployment {
-	objMeta := getObjectMeta(namespace, name)
-	labels := labelsForAuthorino(name)
+func GetDeployment(name, namespace, saName string, replicas *int32, containers []k8score.Container, vol []k8score.Volume, labels map[string]string) *k8sapps.Deployment {
+	objMeta := getObjectMeta(namespace, name, labels)
+	authorinoLabels := labelsForAuthorino(name)
 
 	return &k8sapps.Deployment{
 		ObjectMeta: objMeta,
 		Spec: k8sapps.DeploymentSpec{
 			Replicas: replicas,
 			Selector: &v1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: authorinoLabels,
 			},
 			Template: k8score.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels: labels,
+					Labels: authorinoLabels,
 				},
 				Spec: k8score.PodSpec{
 					ServiceAccountName: saName,

--- a/pkg/resources/k8s_rbac.go
+++ b/pkg/resources/k8s_rbac.go
@@ -7,10 +7,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetAuthorinoServiceAccount(namespace, crName string) *k8score.ServiceAccount {
+func GetAuthorinoServiceAccount(namespace, crName string, labels map[string]string) *k8score.ServiceAccount {
 	return &k8score.ServiceAccount{
 		TypeMeta:   k8smeta.TypeMeta{Kind: "ServiceAccount"},
-		ObjectMeta: getObjectMeta(namespace, authorinoServiceAccountName(crName)),
+		ObjectMeta: getObjectMeta(namespace, authorinoServiceAccountName(crName), labels),
 	}
 }
 
@@ -23,10 +23,10 @@ func GetAuthorinoClusterRoleBinding(roleBindingName, clusterRoleName string, ser
 	}
 }
 
-func GetAuthorinoRoleBinding(namespace, crName, roleBindingNameSuffix, roleKind, roleName string, serviceAccount k8score.ServiceAccount) *k8srbac.RoleBinding {
+func GetAuthorinoRoleBinding(namespace, crName, roleBindingNameSuffix, roleKind, roleName string, serviceAccount k8score.ServiceAccount, labels map[string]string) *k8srbac.RoleBinding {
 	roleRef, roleSubject := getRoleRefAndSubject(roleName, roleKind, serviceAccount)
 	return &k8srbac.RoleBinding{
-		ObjectMeta: getObjectMeta(namespace, authorinoRoleBindingName(crName, roleBindingNameSuffix)),
+		ObjectMeta: getObjectMeta(namespace, authorinoRoleBindingName(crName, roleBindingNameSuffix), labels),
 		RoleRef:    roleRef,
 		Subjects:   []k8srbac.Subject{roleSubject},
 	}

--- a/pkg/resources/k8s_services.go
+++ b/pkg/resources/k8s_services.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func NewAuthService(authorinoName, serviceNamespace string, grpcPort, httpPort int32) *k8score.Service {
+func NewAuthService(authorinoName, serviceNamespace string, grpcPort, httpPort int32, labels map[string]string) *k8score.Service {
 	var ports []k8score.ServicePort
 	if grpcPort != 0 {
 		ports = append(ports, newServicePort("grpc", grpcPort))
@@ -16,23 +16,23 @@ func NewAuthService(authorinoName, serviceNamespace string, grpcPort, httpPort i
 	if httpPort != 0 {
 		ports = append(ports, newServicePort("http", httpPort))
 	}
-	return newService("authorino-authorization", serviceNamespace, authorinoName, ports...)
+	return newService("authorino-authorization", serviceNamespace, authorinoName, labels, ports...)
 }
 
-func NewOIDCService(authorinoName, authorinoNamespace string, port int32) *k8score.Service {
+func NewOIDCService(authorinoName, authorinoNamespace string, port int32, labels map[string]string) *k8score.Service {
 	var ports []k8score.ServicePort
 	if port != 0 {
 		ports = append(ports, newServicePort("http", port))
 	}
-	return newService("authorino-oidc", authorinoNamespace, authorinoName, ports...)
+	return newService("authorino-oidc", authorinoNamespace, authorinoName, labels, ports...)
 }
 
-func NewMetricsService(authorinoName, serviceNamespace string, port int32) *k8score.Service {
+func NewMetricsService(authorinoName, serviceNamespace string, port int32, labels map[string]string) *k8score.Service {
 	var ports []k8score.ServicePort
 	if port != 0 {
 		ports = append(ports, newServicePort("http", port))
 	}
-	return newService("controller-metrics", serviceNamespace, authorinoName, ports...)
+	return newService("controller-metrics", serviceNamespace, authorinoName, labels, ports...)
 }
 
 func EqualServices(s1, s2 *k8score.Service) bool {
@@ -53,8 +53,8 @@ func EqualServices(s1, s2 *k8score.Service) bool {
 	return false
 }
 
-func newService(serviceName, serviceNamespace, authorinoName string, servicePorts ...k8score.ServicePort) *k8score.Service {
-	objMeta := getObjectMeta(serviceNamespace, authorinoName+"-"+serviceName)
+func newService(serviceName, serviceNamespace, authorinoName string, labels map[string]string, servicePorts ...k8score.ServicePort) *k8score.Service {
+	objMeta := getObjectMeta(serviceNamespace, authorinoName+"-"+serviceName, labels)
 	return &k8score.Service{
 		ObjectMeta: objMeta,
 		Spec:       newServiceSpec(labelsForAuthorino(authorinoName), servicePorts...),

--- a/pkg/resources/k8s_util.go
+++ b/pkg/resources/k8s_util.go
@@ -6,8 +6,8 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func getObjectMeta(namespace, name string) v1.ObjectMeta {
-	return v1.ObjectMeta{Name: name, Namespace: namespace}
+func getObjectMeta(namespace, name string, labels map[string]string) v1.ObjectMeta {
+	return v1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels}
 }
 
 func labelsForAuthorino(name string) map[string]string {


### PR DESCRIPTION
This PR makes it possible to propagate the labels defined in the Custom Resource `Authorino` to all the Kubernetes objects the operator creates.

Closes https://github.com/Kuadrant/authorino-operator/issues/82

## Verification Steps

1. Create cluster
```bash
kind create cluster
```

2. Create namespace for the operator
```bash
kubectl create namespace authorino-operator
```

3. Install manifests 
```bash
make install
```

4. Run the operator
```bash
make run
```

5. In another terminal apply the following `Authorino` CR
```bash
kubectl apply  -f -<<EOF
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino
  labels:
    lola: mento
spec:
  image: quay.io/kuadrant/authorino:latest
  replicas: 1
  clusterWide: true
  listener:
    tls:
      enabled: false
  oidcServer:
    tls:
      enabled: false
EOF
```

6. Find the Kubernetes objects created by filtering that level
```bash
kubectl get services -l 'lola in (mento)'

NAME                                TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)              AGE
authorino-authorino-authorization   ClusterIP   10.96.134.186   <none>        50051/TCP,5001/TCP   5m2s
authorino-authorino-oidc            ClusterIP   10.96.142.39    <none>        8083/TCP             5m2s
authorino-controller-metrics        ClusterIP   10.96.140.39    <none>        8080/TCP             5m2s

```

```bash
kubectl get deployments -l 'lola in (mento)'

NAME        READY   UP-TO-DATE   AVAILABLE   AGE
authorino   1/1     1            1           6m43s
```

7. PROFIT! Now you can delete the cluster
```bash
kind delete cluster
```
