### PR TITLE
Embed Authorino Operator version info into the binary

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -36,6 +36,14 @@ jobs:
         id: add-branch-tag
         run: |
           echo "IMG_TAGS=${GITHUB_REF_NAME/\//-} ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+      - name: Set Operator version
+        id: operator-version
+        run: |
+          if [[ ${GITHUB_REF_NAME/\//-} =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
+          echo "VERSION=${GITHUB_REF_NAME/\//-}" >> $GITHUB_ENV
+          else
+          echo "VERSION=${{ github.sha }}" >> $GITHUB_ENV
+          fi
       - name: Install qemu dependency
         run: |
           sudo apt-get update
@@ -47,6 +55,8 @@ jobs:
           image: ${{ env.OPERATOR_NAME }}
           tags: ${{ env.IMG_TAGS }}
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            version=${{ env.VERSION }}
           containerfiles: |
             ./Dockerfile
       - name: Push Image
@@ -87,6 +97,14 @@ jobs:
           TAG_NAME=${GITHUB_REF_NAME/\//-}
           echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_ENV
           echo "IMG_TAGS=${TAG_NAME} ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+      - name: Set Operator version
+        id: operator-version
+        run: |
+          if [[ ${GITHUB_REF_NAME/\//-} =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
+          echo "VERSION=${GITHUB_REF_NAME/\//-}" >> $GITHUB_ENV
+          else
+          echo "VERSION=${{ github.sha }}" >> $GITHUB_ENV
+          fi
       - name: Install qemu dependency
         run: |
           sudo apt-get update
@@ -112,6 +130,8 @@ jobs:
           image: ${{ env.OPERATOR_NAME }}-bundle
           tags: ${{ env.IMG_TAGS }}
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            version=${{ env.VERSION }}
           containerfiles: |
             ./bundle.Dockerfile
       - name: Push Image
@@ -152,6 +172,14 @@ jobs:
           TAG_NAME=${GITHUB_REF_NAME/\//-}
           echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_ENV
           echo "IMG_TAGS=${TAG_NAME} ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+      - name: Set Operator version
+        id: operator-version
+        run: |
+          if [[ ${GITHUB_REF_NAME/\//-} =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
+          echo "VERSION=${GITHUB_REF_NAME/\//-}" >> $GITHUB_ENV
+          else
+          echo "VERSION=${{ github.sha }}" >> $GITHUB_ENV
+          fi
       - name: Install qemu dependency
         run: |
           sudo apt-get update
@@ -171,6 +199,8 @@ jobs:
           image: ${{ env.OPERATOR_NAME }}-catalog
           tags: ${{ env.IMG_TAGS }}
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            version=${{ env.VERSION }}
           containerfiles: |
             ./index.Dockerfile
       - name: Push Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
-RUN CGO_ENABLED=0 go build -a -o manager main.go
+ARG version=latest
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "-X main.version=${version}" -o manager main.go
 
 # Use Red Hat minimal base image to package the binary
 # https://catalog.redhat.com/software/containers/ubi8-minimal

--- a/main.go
+++ b/main.go
@@ -39,6 +39,8 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+
+	version string // value injected in compilation-time
 )
 
 func init() {
@@ -64,6 +66,8 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	setupLog.Info("botting up authorino operator", "version", version)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
The Authorino Operator version info can be specified by setting an ldflag `main.version` in the `go build` command. E.g.
```sh
go build -ldflags "-X main.version=0.4.0" -o bin/manager main.go
```

When using the Makefile:
```sh
make build VERSION=0.4.0
```

1. If the _makefile parameter_ `VERSION` is not specified, it defaults to the Git ref (SHA-1) of HEAD;
2. The image tag (`IMAGE_TAG`) is inferred from the value of `VERSION` (user-defined or set to default):
  - When it matches `^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$` (e.g. '0.10.0-pre'), the tag is set to `v$VERSION` (e.g. 'v0.10.0-pre');
  - otherwise, the tag is set to fixed value 'latest'.

To build a container image:
1. Pass the _build argument_ `VERSION`. E.g.
    ```sh
    docker build --build-args version=0.4.0-pre -t registry/org/repo:v0.4.0-pre .
    ```
    -- OR --
2. Use the Makefile:
    ```sh
    make docker-build VERSION=0.4.0-pre REGISTRY=registry ORG=org REPO=repo -t
    ```

In CI, the `VERSION` (build argument) is inferred based on `GITHUB_REF_NAME`:
- When the Git ref (branch/tag name) matches `^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$`, `VERSION` is set to `GITHUB_REF_NAME` (with all slashes replaced with dashes);
- otherwise, `VERSION` is set to the actual Git ref (i.e. `github.sha`)

## Verification steps

Setup a cluster to target the operator to:

```sh
kind create cluster
kubectl create namespace authorino-operator
make install
```

For each scenario below, build and run the operator. In all the cases, you should spot a message 'booting up authorino operator' in the Authorino Operator logs, with a label `version` set accordingly.

### Scenario: Build and run the binary locally

Run the binary locally:
```sh
make run
```
```
[…]
go run -ldflags "-X main.version=fff12b68926ddf72646a7ba9653cd7ed426c0816" ./main.go
1.6615074731805818e+09	INFO	setup	botting up authorino operator	{"version": "fff12b68926ddf72646a7ba9653cd7ed426c0816"}
```

Try with a version number:

```sh
make run VERSION=0.4.0-pre
```
```
[…]
go run -ldflags "-X main.version=0.4.0-pre" ./main.go
1.661507509064471e+09	INFO	setup	botting up authorino operator	{"version": "0.4.0-pre"}
```

### Scenario: Build and run container image in docker

Setup a cluster to target the operator to:

```sh
kind create cluster
kubectl create namespace authorino-operator
make install
```

Build and run container image in docker:

```sh
make docker-build
docker run \
  -v $HOME/.kube/config:/home/.kube/config \
  --env KUBECONFIG=/home/.kube/config \
  --network=host \
  quay.io/kuadrant/authorino-operator:latest
```

Try with a version number:

```sh
make docker-build VERSION=0.4.0-pre
docker run \
  -v $HOME/.kube/config:/home/.kube/config \
  --env KUBECONFIG=/home/.kube/config \
  --network=host \
  quay.io/kuadrant/authorino-operator:v0.4.0-pre
```