### PR TITLE
Use bash as shell in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Use bash as shell
+SHELL = /bin/bash
+
 # VERSION defines the project version for the bundle.
 VERSION ?= $(shell git rev-parse HEAD)
 


### PR DESCRIPTION
It fixes the following error raised when running make targets on Ubuntu, where by default `/bin/sh` is dash, a shell designed for fast startup and execution with only standard features.

```
/bin/sh: 1: Syntax error: "(" unexpected
```

The failure happens in the regex used to check the `VERSION` argument to fail. 