### PR TITLE
Minimal example of the Authorino CR in the ClusterServiceVersion

### DIFF
--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -13,18 +13,12 @@ metadata:
           "spec": {
             "listener": {
               "tls": {
-                "certSecretRef": {
-                  "name": "authorino-server-cert"
-                },
-                "enabled": true
+                "enabled": false
               }
             },
             "oidcServer": {
               "tls": {
-                "certSecretRef": {
-                  "name": "authorino-oidc-server-cert"
-                },
-                "enabled": true
+                "enabled": false
               }
             }
           }

--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -8,32 +8,25 @@ metadata:
           "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
           "kind": "Authorino",
           "metadata": {
-            "name": "authorino-sample",
-            "namespace": "authorino-operator"
+            "name": "authorino-sample"
           },
           "spec": {
-            "clusterWide": true,
-            "image": "quay.io/kuadrant/authorino:latest",
-            "imagePullPolicy": "Always",
             "listener": {
-              "port": null,
               "tls": {
                 "certSecretRef": {
-                  "name": "authorino-cert"
+                  "name": "authorino-server-cert"
                 },
                 "enabled": true
               }
             },
             "oidcServer": {
-              "port": null,
               "tls": {
                 "certSecretRef": {
-                  "name": "authorino-cert"
+                  "name": "authorino-oidc-server-cert"
                 },
                 "enabled": true
               }
-            },
-            "replicas": 1
+            }
           }
         }
       ]

--- a/config/samples/authorino-operator_v1beta1_authorino.yaml
+++ b/config/samples/authorino-operator_v1beta1_authorino.yaml
@@ -2,21 +2,14 @@ apiVersion: operator.authorino.kuadrant.io/v1beta1
 kind: Authorino
 metadata:
   name: authorino-sample
-  namespace: authorino-operator
 spec:
-  image: quay.io/kuadrant/authorino:latest
-  replicas: 1
-  imagePullPolicy: Always
-  clusterWide: true
   listener:
-    port:
     tls:
       enabled: true
       certSecretRef:
-        name: authorino-cert # secret must contain `tls.crt` and `tls.key` entries
+        name: authorino-server-cert # kubernetes secret must contain 'tls.crt' and 'tls.key' entries
   oidcServer:
-    port:
     tls:
       enabled: true
       certSecretRef:
-        name: authorino-cert # secret must contain `tls.crt` and `tls.key` entries
+        name: authorino-oidc-server-cert # kubernetes secret must contain 'tls.crt' and 'tls.key' entries

--- a/config/samples/authorino-operator_v1beta1_authorino.yaml
+++ b/config/samples/authorino-operator_v1beta1_authorino.yaml
@@ -5,11 +5,7 @@ metadata:
 spec:
   listener:
     tls:
-      enabled: true
-      certSecretRef:
-        name: authorino-server-cert # kubernetes secret must contain 'tls.crt' and 'tls.key' entries
+      enabled: false
   oidcServer:
     tls:
-      enabled: true
-      certSecretRef:
-        name: authorino-oidc-server-cert # kubernetes secret must contain 'tls.crt' and 'tls.key' entries
+      enabled: false


### PR DESCRIPTION
So we show no more than what's strictly needed. ~The only exception is `tls.enabled: true`.~

```yaml
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino-sample
spec:
  listener:
    tls:
      enabled: false
  oidcServer:
    tls:
      enabled: false
```