### PR TITLE
Revert "update security context to drop all capabilities & set seccomp "

### DIFF
--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -276,12 +276,6 @@ spec:
                     memory: 200Mi
                 securityContext:
                   allowPrivilegeEscalation: false
-                  capabilities:
-                    drop:
-                    - ALL
-                  readOnlyRootFilesystem: true
-                  seccompProfile:
-                    type: RuntimeDefault
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: authorino-operator

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -2575,12 +2575,6 @@ spec:
             memory: 200Mi
         securityContext:
           allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          seccompProfile:
-            type: RuntimeDefault
       securityContext:
         runAsNonRoot: true
       serviceAccountName: authorino-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,12 +33,6 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          seccompProfile:
-            type: RuntimeDefault
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Reverts Kuadrant/authorino-operator#88

Sadly, this security upgrade is not compatible with OpenShift versions lower than `4.11`. 