### PR TITLE
Tighten API group specification for RBAC

### DIFF
--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -58,27 +58,7 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
-          - '*'
-          resources:
-          - clusterrolebindings
-          verbs:
-          - create
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - '*'
-          resources:
-          - clusterroles
-          verbs:
-          - create
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - '*'
+          - ""
           resources:
           - configmaps
           verbs:
@@ -90,7 +70,7 @@ spec:
           - update
           - watch
         - apiGroups:
-          - '*'
+          - ""
           resources:
           - configmaps/status
           verbs:
@@ -99,34 +79,14 @@ spec:
           - patch
           - update
         - apiGroups:
-          - '*'
+          - ""
           resources:
           - events
           verbs:
           - create
           - patch
         - apiGroups:
-          - '*'
-          resources:
-          - rolebindings
-          verbs:
-          - create
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - '*'
-          resources:
-          - roles
-          verbs:
-          - create
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - '*'
+          - ""
           resources:
           - secrets
           verbs:
@@ -134,7 +94,7 @@ spec:
           - list
           - watch
         - apiGroups:
-          - '*'
+          - ""
           resources:
           - serviceaccounts
           verbs:
@@ -144,7 +104,7 @@ spec:
           - update
           - watch
         - apiGroups:
-          - '*'
+          - ""
           resources:
           - services
           verbs:
@@ -153,18 +113,6 @@ spec:
           - list
           - update
           - watch
-        - apiGroups:
-          - '*'
-          resources:
-          - subjectaccessreviews
-          verbs:
-          - create
-        - apiGroups:
-          - '*'
-          resources:
-          - tokenreviews
-          verbs:
-          - create
         - apiGroups:
           - apps
           resources:
@@ -177,6 +125,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
         - apiGroups:
           - authorino.kuadrant.io
           resources:
@@ -197,6 +151,12 @@ spec:
           - get
           - patch
           - update
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
         - apiGroups:
           - coordination.k8s.io
           resources:
@@ -232,6 +192,46 @@ spec:
           - get
           - patch
           - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
         serviceAccountName: authorino-operator
       deployments:
       - label:

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -2848,27 +2848,7 @@ metadata:
   name: authorino-operator-manager
 rules:
 - apiGroups:
-  - '*'
-  resources:
-  - clusterrolebindings
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - '*'
-  resources:
-  - clusterroles
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - '*'
+  - ""
   resources:
   - configmaps
   verbs:
@@ -2880,7 +2860,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - '*'
+  - ""
   resources:
   - configmaps/status
   verbs:
@@ -2889,34 +2869,14 @@ rules:
   - patch
   - update
 - apiGroups:
-  - '*'
+  - ""
   resources:
   - events
   verbs:
   - create
   - patch
 - apiGroups:
-  - '*'
-  resources:
-  - rolebindings
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - '*'
-  resources:
-  - roles
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - '*'
+  - ""
   resources:
   - secrets
   verbs:
@@ -2924,7 +2884,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - '*'
+  - ""
   resources:
   - serviceaccounts
   verbs:
@@ -2934,7 +2894,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - '*'
+  - ""
   resources:
   - services
   verbs:
@@ -2943,18 +2903,6 @@ rules:
   - list
   - update
   - watch
-- apiGroups:
-  - '*'
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
-- apiGroups:
-  - '*'
-  resources:
-  - tokenreviews
-  verbs:
-  - create
 - apiGroups:
   - apps
   resources:
@@ -2967,6 +2915,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
 - apiGroups:
   - authorino.kuadrant.io
   resources:
@@ -2987,6 +2941,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -3022,6 +2982,46 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/config/install/manifests.yaml
+++ b/config/install/manifests.yaml
@@ -315,27 +315,7 @@ metadata:
   name: authorino-operator-manager
 rules:
 - apiGroups:
-  - '*'
-  resources:
-  - clusterrolebindings
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - '*'
-  resources:
-  - clusterroles
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - '*'
+  - ""
   resources:
   - configmaps
   verbs:
@@ -347,7 +327,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - '*'
+  - ""
   resources:
   - configmaps/status
   verbs:
@@ -356,34 +336,14 @@ rules:
   - patch
   - update
 - apiGroups:
-  - '*'
+  - ""
   resources:
   - events
   verbs:
   - create
   - patch
 - apiGroups:
-  - '*'
-  resources:
-  - rolebindings
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - '*'
-  resources:
-  - roles
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - '*'
+  - ""
   resources:
   - secrets
   verbs:
@@ -391,7 +351,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - '*'
+  - ""
   resources:
   - serviceaccounts
   verbs:
@@ -401,7 +361,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - '*'
+  - ""
   resources:
   - services
   verbs:
@@ -410,18 +370,6 @@ rules:
   - list
   - update
   - watch
-- apiGroups:
-  - '*'
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
-- apiGroups:
-  - '*'
-  resources:
-  - tokenreviews
-  verbs:
-  - create
 - apiGroups:
   - apps
   resources:
@@ -434,6 +382,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
 - apiGroups:
   - authorino.kuadrant.io
   resources:
@@ -454,6 +408,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -489,6 +449,46 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,27 +7,7 @@ metadata:
   name: authorino-operator-manager
 rules:
 - apiGroups:
-  - '*'
-  resources:
-  - clusterrolebindings
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - '*'
-  resources:
-  - clusterroles
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - '*'
+  - ""
   resources:
   - configmaps
   verbs:
@@ -39,7 +19,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - '*'
+  - ""
   resources:
   - configmaps/status
   verbs:
@@ -48,34 +28,14 @@ rules:
   - patch
   - update
 - apiGroups:
-  - '*'
+  - ""
   resources:
   - events
   verbs:
   - create
   - patch
 - apiGroups:
-  - '*'
-  resources:
-  - rolebindings
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - '*'
-  resources:
-  - roles
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - '*'
+  - ""
   resources:
   - secrets
   verbs:
@@ -83,7 +43,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - '*'
+  - ""
   resources:
   - serviceaccounts
   verbs:
@@ -93,7 +53,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - '*'
+  - ""
   resources:
   - services
   verbs:
@@ -102,18 +62,6 @@ rules:
   - list
   - update
   - watch
-- apiGroups:
-  - '*'
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
-- apiGroups:
-  - '*'
-  resources:
-  - tokenreviews
-  verbs:
-  - create
 - apiGroups:
   - apps
   resources:
@@ -126,6 +74,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
 - apiGroups:
   - authorino.kuadrant.io
   resources:
@@ -146,6 +100,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -181,3 +141,43 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch

--- a/controllers/authorino_controller.go
+++ b/controllers/authorino_controller.go
@@ -52,18 +52,18 @@ type AuthorinoReconciler struct {
 //+kubebuilder:rbac:groups=operator.authorino.kuadrant.io,resources=authorinos/finalizers,verbs=update
 
 // +kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="*",resources=services,verbs=get;list;watch;create;update;
-// +kubebuilder:rbac:groups="*",resources=clusterroles,verbs=get;list;watch;create;update;
-// +kubebuilder:rbac:groups="*",resources=rolebindings,verbs=get;list;watch;create;update;
-// +kubebuilder:rbac:groups="*",resources=clusterrolebindings,verbs=get;list;watch;create;update;
-// +kubebuilder:rbac:groups="*",resources=serviceaccounts,verbs=get;list;watch;create;update;
-// +kubebuilder:rbac:groups="*",resources=roles,verbs=get;list;watch;create;update;
-// +kubebuilder:rbac:groups="*",resources=tokenreviews,verbs=create;
-// +kubebuilder:rbac:groups="*",resources=subjectaccessreviews,verbs=create;
-// +kubebuilder:rbac:groups="*",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="*",resources=configmaps/status,verbs=get;update;delete;patch
-// +kubebuilder:rbac:groups="*",resources=events,verbs=create;patch;
-// +kubebuilder:rbac:groups="*",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles,verbs=get;list;watch;create;update;
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterrolebindings,verbs=get;list;watch;create;update;
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;
+// +kubebuilder:rbac:groups="authentication.k8s.io",resources=tokenreviews,verbs=create;
+// +kubebuilder:rbac:groups="authorization.k8s.io",resources=subjectaccessreviews,verbs=create;
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;delete;patch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="authorino.kuadrant.io",resources=authconfigs,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="authorino.kuadrant.io",resources=authconfigs,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="authorino.kuadrant.io",resources=authconfigs/status,verbs=get;patch;update

--- a/pkg/resources/k8s_rbac.go
+++ b/pkg/resources/k8s_rbac.go
@@ -93,17 +93,17 @@ func subjectIncluded(subjects []k8srbac.Subject, subject k8srbac.Subject) bool {
 func GetLeaderElectionRules() []k8srbac.PolicyRule {
 	return []k8srbac.PolicyRule{
 		{
-			APIGroups: []string{"*"},
+			APIGroups: []string{""},
 			Resources: []string{"configmaps"},
 			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 		},
 		{
-			APIGroups: []string{"*"},
+			APIGroups: []string{""},
 			Resources: []string{"configmaps/status"},
 			Verbs:     []string{"get", "update", "patch"},
 		},
 		{
-			APIGroups: []string{"*"},
+			APIGroups: []string{""},
 			Resources: []string{"events"},
 			Verbs:     []string{"create", "patch"},
 		},


### PR DESCRIPTION
When possible it's much better to explicitly specify RBAC constraints, in particular for APIGroups, Resources and Verbs where the set of possibilities is limited to start with

Specify the API group for all RBAC permission requirements.