### PR TITLE
worklow: use go1.19 for verify-manifests & verify-fmt

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,10 +12,10 @@ jobs:
     name: Verify manifests
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.19.x
         id: go
       - name: Check out code
         uses: actions/checkout@v2
@@ -27,10 +27,10 @@ jobs:
     name: Verify fmt
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.19.x
         id: go
       - name: Check out code
         uses: actions/checkout@v2


### PR DESCRIPTION
* Use go1.19 in verify-manifests & verify-fmt workflows to align the go versions used