### PR TITLE
codecov: do not fail ci on error

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,3 +87,4 @@ jobs:
           flags: unit
           verbose: true
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,5 +86,5 @@ jobs:
         with:
           flags: unit
           verbose: true
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
* Prevent codecov from failing ci on error due to flakiness with codecov upload
* Use `CODECOV_TOKEN` for upload that should at least prevent upload issue when PRs come from branches from this repo