### PR TITLE
Remove unused branch

### DIFF
--- a/controllers/authorino_controller.go
+++ b/controllers/authorino_controller.go
@@ -540,10 +540,6 @@ func (r *AuthorinoReconciler) authorinoDeploymentChanges(existingDeployment, des
 		return true
 	}
 
-	if len(desiredDeployment.Spec.Template.Spec.Containers) != 1 {
-		// error
-	}
-
 	existingContainer := existingDeployment.Spec.Template.Spec.Containers[0]
 	desiredContainer := desiredDeployment.Spec.Template.Spec.Containers[0]
 


### PR DESCRIPTION
Minor change to remove an unused `if` branch. The `desiredDeployment` is created with a single container prior to this so I believe the check should just be removed.