### PR TITLE
Set commit sha in bundle/catalog

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -115,7 +115,7 @@ jobs:
           sudo apt-get install -y qemu-user-static
       - name: Run make bundle (main)
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
-        run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }}
+        run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.sha }}
       - name: Run make bundle (release)
         if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
         run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} VERSION=${TAG_NAME/v/} AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }}
@@ -123,7 +123,7 @@ jobs:
         run: git diff
       - name: Verify manifests and bundle (main)
         if: github.ref_name == env.MAIN_BRANCH_NAME
-        run: make verify-manifests verify-bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }}
+        run: make verify-manifests verify-bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.sha }}
       - name: Verify manifests and bundle (release)
         if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
         run: make verify-manifests verify-bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} VERSION=${TAG_NAME/v/} AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }}
@@ -190,7 +190,7 @@ jobs:
           sudo apt-get install -y qemu-user-static
       - name: Run make catalog-generate (main)
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
-        run: make catalog-generate REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }}
+        run: make catalog-generate REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.sha }}
       - name: Run make catalog-generate (release)
         if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
         run: make catalog-generate REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ env.TAG_NAME }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,21 @@ jobs:
         run: |
           make verify-manifests
 
+  verify-bundle:
+    name: Verify bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.19.x
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.19.x
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Run make verify-bundle
+        run: |
+          make verify-bundle
+
   verify-fmt:
     name: Verify fmt
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -296,12 +296,12 @@ catalog-push: ## Push a catalog image.
 
 .PHONY: verify-manifests
 verify-manifests: manifests ## Verify manifests update.
-	git diff --exit-code ./config
+	git diff -I'^    containerImage:' -I'^        image:' --exit-code ./config
 	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./config)" ]
 
 .PHONY: verify-bundle
 verify-bundle: bundle ## Verify bundle update.
-	git diff --exit-code ./bundle
+	git diff -I'^    containerImage:' -I'^                image:' --exit-code ./bundle
 	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./bundle)" ]
 
 .PHONY: verify-fmt

--- a/Makefile
+++ b/Makefile
@@ -295,14 +295,18 @@ catalog-push: ## Push a catalog image.
 ## Targets to verify actions that generate/modify code have been executed and output committed
 
 .PHONY: verify-manifests
-verify-manifests: manifests ## Verify manifests update.
+verify-manifests: manifests $(YQ) ## Verify manifests update.
 	git diff -I'^    containerImage:' -I'^        image:' --exit-code ./config
 	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./config)" ]
+	yq ea -e 'select([.][].kind == "Deployment").spec.template.spec.containers[0].image | . == "$(OPERATOR_IMAGE)"' config/deploy/manifests.yaml
+	yq e -e '.metadata.annotations.containerImage == "$(OPERATOR_IMAGE)"' config/manifests/bases/authorino-operator.clusterserviceversion.yaml
 
 .PHONY: verify-bundle
-verify-bundle: bundle ## Verify bundle update.
+verify-bundle: bundle $(YQ) ## Verify bundle update.
 	git diff -I'^    containerImage:' -I'^                image:' --exit-code ./bundle
 	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./bundle)" ]
+	yq e -e '.metadata.annotations.containerImage == "$(OPERATOR_IMAGE)"' bundle/manifests/authorino-operator.clusterserviceversion.yaml
+	yq e -e '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image == "$(OPERATOR_IMAGE)"' bundle/manifests/authorino-operator.clusterserviceversion.yaml
 
 .PHONY: verify-fmt
 verify-fmt: fmt ## Verify fmt update.


### PR DESCRIPTION
Updated the default flow to set the commit sha in the bundle manifests and in the catalog. This makes it so that the `relatedImages` and the bundle in the catalog are pointing to the commit sha variant of the images. As the workflow pushes duplicate images for both the `latest` and commit sha, this means that the latest images will also be pointing to specific commit sha tagged images.

Due to the pipeline modifying the manifests to set the image to the commit sha variant, the `verify-manifests` and `verify-bundle` make targets will fail. These checks are verifying that there are no uncommitted changes in the local git repo which does not make sense given the changes, and so the check was removed for the `main` flow.

Verified this on our own branch [here](https://github.com/adam-cattermole/authorino-operator/actions/runs/5807542022). Example output from the render:


```
opm render quay.io/acatterm/authorino-operator-catalog:d350f6a0f8f4e705a3fc9ac5b048967479a6503a --output=yaml
```
```yaml
---
image: quay.io/acatterm/authorino-operator-bundle:d350f6a0f8f4e705a3fc9ac5b048967479a6503a
name: authorino-operator.v0.0.0
package: authorino-operator
...

relatedImages:
- image: quay.io/acatterm/authorino-operator:d350f6a0f8f4e705a3fc9ac5b048967479a6503a
  name: ""
schema: olm.bundle
```

Looking for thoughts on this approach.

Resolves #121