### PR TITLE
AuthConfig conversion webhook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ manifests: controller-gen kustomize authorino-manifests ## Generate WebhookConfi
 
 .PHONY: authorino-manifests
 authorino-manifests: export AUTHORINO_GITREF := $(AUTHORINO_BRANCH)
+authorino-manifests: export AUTHORINO_VERSION := $(AUTHORINO_VERSION)
 authorino-manifests: ## Update authorino manifests.
 	envsubst \
         < config/authorino/kustomization.template.yaml \

--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -43,6 +43,9 @@ spec:
       kind: AuthConfig
       name: authconfigs.authorino.kuadrant.io
       version: v1beta1
+    - kind: AuthConfig
+      name: authconfigs.authorino.kuadrant.io
+      version: v1beta2
     - description: API to create instances of authorino
       displayName: Authorino
       kind: Authorino

--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -280,6 +280,45 @@ spec:
                 runAsNonRoot: true
               serviceAccountName: authorino-operator
               terminationGracePeriodSeconds: 10
+      - label:
+          app: authorino
+          authorino-component: authorino-webhooks
+        name: authorino-webhooks
+        spec:
+          selector:
+            matchLabels:
+              app: authorino
+              authorino-component: authorino-webhooks
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app: authorino
+                authorino-component: authorino-webhooks
+            spec:
+              containers:
+              - command:
+                - authorino
+                - webhooks
+                image: quay.io/kuadrant/authorino:latest
+                name: webhooks
+                ports:
+                - containerPort: 9443
+                  name: webhooks
+                - containerPort: 8080
+                  name: metrics
+                - containerPort: 8081
+                  name: healthz
+                resources: {}
+                volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                  name: cert
+                  readOnly: true
+              volumes:
+              - name: cert
+                secret:
+                  defaultMode: 420
+                  secretName: authorino-webhook-server-cert
       permissions:
       - rules:
         - apiGroups:
@@ -314,6 +353,47 @@ spec:
           - create
           - patch
         serviceAccountName: authorino-operator
+      - rules:
+        - apiGroups:
+          - authorino.kuadrant.io
+          resources:
+          - authconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authorino.kuadrant.io
+          resources:
+          - authconfigs/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - create
+          - get
+          - list
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - events
+          verbs:
+          - create
+          - get
+          - list
+          - update
+        serviceAccountName: default
     strategy: deployment
   installModes:
   - supported: false
@@ -347,3 +427,16 @@ spec:
   provider:
     name: Red Hat
   version: 0.0.0
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1beta1
+    - v1beta2
+    containerPort: 443
+    conversionCRDs:
+    - authconfigs.authorino.kuadrant.io
+    deploymentName: authorino-webhooks
+    generateName: cauthconfigs.kb.io
+    sideEffects: None
+    targetPort: 9443
+    type: ConversionWebhook
+    webhookPath: /convert

--- a/bundle/manifests/authorino-webhooks_v1_service.yaml
+++ b/bundle/manifests/authorino-webhooks_v1_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: authorino
+    authorino-component: authorino-webhooks
+  name: authorino-webhooks
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: authorino
+    authorino-component: authorino-webhooks
+status:
+  loadBalancer: {}

--- a/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
+++ b/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
@@ -3161,7 +3161,7 @@ spec:
                           type: boolean
                         externalPolicy:
                           description: 'Settings for fetching the OPA policy from
-                            an external registry. Use it alternatively to ''inlineRego''.
+                            an external registry. Use it alternatively to ''rego''.
                             For the configurations of the HTTP request, the following
                             options are not implemented: ''method'', ''body'', ''bodyParameters'',
                             ''contentType'', ''headers'', ''oauth2''. Use it only

--- a/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
+++ b/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
@@ -2,10 +2,22 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    cert-manager.io/inject-ca-from: authorino-operator/authorino-webhook-server-cert
     controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: authconfigs.authorino.kuadrant.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: authorino-webhooks
+          namespace: authorino-operator
+          path: /convert
+      conversionReviewVersions:
+      - v1beta1
+      - v1beta2
   group: authorino.kuadrant.io
   names:
     kind: AuthConfig

--- a/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
+++ b/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
@@ -2251,6 +2251,8 @@ spec:
                       description: The name of key used in the wrapped response (name
                         of the HTTP header or property of the Envoy Dynamic Metadata
                         JSON). If omitted, it will be set to the name of the configuration.
+                        [DEPRECATED] Starting in v1beta2, use the name of the response
+                        config instead.
                       type: string
                     wristband:
                       properties:
@@ -2686,8 +2688,6 @@ spec:
                           properties:
                             name:
                               type: string
-                            prefix:
-                              type: string
                           required:
                           - name
                           type: object
@@ -2735,11 +2735,6 @@ spec:
                             to obtain the "jkws_uri" claim from. The value must coincide
                             with the value of  the "iss" (issuer) claim of the discovered
                             OpenID Connect configuration.
-                          type: string
-                        jwksUrl:
-                          description: URL of the JSON Web Ket Set (JWKS) endpoint.
-                            Use this if the issuer of the JWT tokens is not an OIDC
-                            provider or does not implement OIDC Discovery.
                           type: string
                         ttl:
                           description: Decides how long to wait before refreshing
@@ -3167,7 +3162,12 @@ spec:
                             precompile) and at runtime.
                           type: boolean
                         externalPolicy:
-                          description: External registry of OPA policies.
+                          description: 'Settings for fetching the OPA policy from
+                            an external registry. Use it alternatively to ''inlineRego''.
+                            For the configurations of the HTTP request, the following
+                            options are not implemented: ''method'', ''body'', ''bodyParameters'',
+                            ''contentType'', ''headers'', ''oauth2''. Use it only
+                            with: ''url'', ''sharedSecret'', ''credentials''.'
                           properties:
                             body:
                               description: Raw body of the HTTP request. Supersedes
@@ -3247,8 +3247,6 @@ spec:
                                   properties:
                                     name:
                                       type: string
-                                    prefix:
-                                      type: string
                                   required:
                                   - name
                                   type: object
@@ -3280,10 +3278,6 @@ spec:
                                 type: object
                               description: Custom headers in the HTTP request.
                               type: object
-                            insecure:
-                              description: Insecure HTTP connection (i.e. disables
-                                TLS verification)
-                              type: boolean
                             method:
                               default: GET
                               description: 'HTTP verb used in the request to the service.
@@ -3742,8 +3736,6 @@ spec:
                               properties:
                                 name:
                                   type: string
-                                prefix:
-                                  type: string
                               required:
                               - name
                               type: object
@@ -3774,10 +3766,6 @@ spec:
                             type: object
                           description: Custom headers in the HTTP request.
                           type: object
-                        insecure:
-                          description: Insecure HTTP connection (i.e. disables TLS
-                            verification)
-                          type: boolean
                         method:
                           default: GET
                           description: 'HTTP verb used in the request to the service.
@@ -4062,8 +4050,6 @@ spec:
                               properties:
                                 name:
                                   type: string
-                                prefix:
-                                  type: string
                               required:
                               - name
                               type: object
@@ -4094,10 +4080,6 @@ spec:
                             type: object
                           description: Custom headers in the HTTP request.
                           type: object
-                        insecure:
-                          description: Insecure HTTP connection (i.e. disables TLS
-                            verification)
-                          type: boolean
                         method:
                           default: GET
                           description: 'HTTP verb used in the request to the service.

--- a/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
+++ b/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
@@ -2251,8 +2251,6 @@ spec:
                       description: The name of key used in the wrapped response (name
                         of the HTTP header or property of the Envoy Dynamic Metadata
                         JSON). If omitted, it will be set to the name of the configuration.
-                        [DEPRECATED] Starting in v1beta2, use the name of the response
-                        config instead.
                       type: string
                     wristband:
                       properties:
@@ -4397,6 +4395,12 @@ spec:
                               required:
                               - properties
                               type: object
+                            key:
+                              description: The key used to add the custom response
+                                item (name of the HTTP header or root property of
+                                the Dynamic Metadata object). If omitted, it will
+                                be set to the name of the response config.
+                              type: string
                             metrics:
                               default: false
                               description: Whether this config should generate individual
@@ -4632,6 +4636,12 @@ spec:
                               required:
                               - properties
                               type: object
+                            key:
+                              description: The key used to add the custom response
+                                item (name of the HTTP header or root property of
+                                the Dynamic Metadata object). If omitted, it will
+                                be set to the name of the response config.
+                              type: string
                             metrics:
                               default: false
                               description: Whether this config should generate individual
@@ -4654,10 +4664,6 @@ spec:
                                   description: Static value
                                   x-kubernetes-preserve-unknown-fields: true
                               type: object
-                            prefix:
-                              description: Prefix of the value to be added to the
-                                HTTP header
-                              type: string
                             priority:
                               default: 0
                               description: Priority group of the config. All configs

--- a/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
+++ b/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
@@ -343,7 +343,6 @@ spec:
                               required:
                               - operator
                               - selector
-                              - value
                             properties:
                               operator:
                                 description: 'The binary operator to be applied to
@@ -703,7 +702,6 @@ spec:
                           required:
                           - operator
                           - selector
-                          - value
                         properties:
                           operator:
                             description: 'The binary operator to be applied to the
@@ -1596,7 +1594,6 @@ spec:
                           required:
                           - operator
                           - selector
-                          - value
                         properties:
                           operator:
                             description: 'The binary operator to be applied to the
@@ -1984,7 +1981,6 @@ spec:
                           required:
                           - operator
                           - selector
-                          - value
                         properties:
                           operator:
                             description: 'The binary operator to be applied to the
@@ -2211,7 +2207,6 @@ spec:
                           required:
                           - operator
                           - selector
-                          - value
                         properties:
                           operator:
                             description: 'The binary operator to be applied to the
@@ -2356,7 +2351,6 @@ spec:
                     required:
                     - operator
                     - selector
-                    - value
                   properties:
                     operator:
                       description: 'The binary operator to be applied to the content
@@ -2476,6 +2470,2624 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Ready for all hosts
+      jsonPath: .status.summary.ready
+      name: Ready
+      type: string
+    - description: Number of hosts ready
+      jsonPath: .status.summary.numHostsReady
+      name: Hosts
+      type: string
+    - description: Number of trusted identity sources
+      jsonPath: .status.summary.numIdentitySources
+      name: Authentication
+      priority: 2
+      type: integer
+    - description: Number of external metadata sources
+      jsonPath: .status.summary.numMetadataSources
+      name: Metadata
+      priority: 2
+      type: integer
+    - description: Number of authorization policies
+      jsonPath: .status.summary.numAuthorizationPolicies
+      name: Authorization
+      priority: 2
+      type: integer
+    - description: Number of items added to the authorization response
+      jsonPath: .status.summary.numResponseItems
+      name: Response
+      priority: 2
+      type: integer
+    - description: Whether issuing Festival Wristbands
+      jsonPath: .status.summary.festivalWristbandEnabled
+      name: Wristband
+      priority: 2
+      type: boolean
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: AuthConfig is the schema for Authorino's AuthConfig API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specifies the desired state of the AuthConfig resource, i.e.
+              the authencation/authorization scheme to be applied to protect the matching
+              service hosts.
+            properties:
+              authentication:
+                additionalProperties:
+                  oneOf:
+                  - properties:
+                      credentials: {}
+                      oauth2Introspection: {}
+                    required:
+                    - oauth2Introspection
+                  - properties:
+                      credentials: {}
+                      jwt: {}
+                    required:
+                    - jwt
+                  - properties:
+                      apiKey: {}
+                      credentials: {}
+                    required:
+                    - apiKey
+                  - properties:
+                      credentials: {}
+                      x509: {}
+                    required:
+                    - x509
+                  - properties:
+                      credentials: {}
+                      kubernetesTokenReview: {}
+                    required:
+                    - kubernetesTokenReview
+                  - properties:
+                      anonymous: {}
+                      credentials: {}
+                    required:
+                    - anonymous
+                  - properties:
+                      credentials: {}
+                      plain: {}
+                    required:
+                    - plain
+                  properties:
+                    anonymous:
+                      description: Anonymous access.
+                      type: object
+                    apiKey:
+                      description: Authentication based on API keys stored in Kubernetes
+                        secrets.
+                      properties:
+                        allNamespaces:
+                          default: false
+                          description: Whether Authorino should look for API key secrets
+                            in all namespaces or only in the same namespace as the
+                            AuthConfig. Enabling this option in namespaced Authorino
+                            instances has no effect.
+                          type: boolean
+                        selector:
+                          description: Label selector used by Authorino to match secrets
+                            from the cluster storing valid credentials to authenticate
+                            to this service
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - selector
+                      type: object
+                    cache:
+                      description: Caching options for the resolved object returned
+                        when applying this config. Omit it to avoid caching objects
+                        for this config.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. The
+                            resolved key must be unique within the scope of this particular
+                            config.
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    credentials:
+                      description: Defines where credentials are required to be passed
+                        in the request for authentication based on this config. If
+                        omitted, it defaults to credentials passed in the HTTP Authorization
+                        header and the "Bearer" prefix prepended to the secret credential
+                        value.
+                      properties:
+                        authorizationHeader:
+                          properties:
+                            prefix:
+                              type: string
+                          type: object
+                        cookie:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        customHeader:
+                          properties:
+                            name:
+                              type: string
+                            prefix:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        queryString:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      type: object
+                    defaults:
+                      additionalProperties:
+                        properties:
+                          selector:
+                            description: 'Simple path selector to fetch content from
+                              the authorization JSON (e.g. ''request.method'') or
+                              a string template with variables that resolve to patterns
+                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. The following Authorino custom modifiers are supported:
+                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                              @base64:encode|decode and @strip.'
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      description: Set default property values (claims) for the resolved
+                        identity object, that are set before appending the object
+                        to the authorization JSON. If the property is already present
+                        in the resolved identity object, the default value is ignored.
+                        It requires the resolved identity object to always be a JSON
+                        object. Do not use this option with identity objects of other
+                        JSON types (array, string, etc).
+                      type: object
+                    jwt:
+                      description: Authentication based on JWT tokens.
+                      properties:
+                        issuerUrl:
+                          description: URL of the issuer of the JWT. If `jwksUrl`
+                            is omitted, Authorino will append the path to the OpenID
+                            Connect Well-Known Discovery endpoint (i.e. "/.well-known/openid-configuration")
+                            to this URL, to discover the OIDC configuration where
+                            to obtain the "jkws_uri" claim from. The value must coincide
+                            with the value of  the "iss" (issuer) claim of the discovered
+                            OpenID Connect configuration.
+                          type: string
+                        jwksUrl:
+                          description: URL of the JSON Web Ket Set (JWKS) endpoint.
+                            Use this if the issuer of the JWT tokens is not an OIDC
+                            provider or does not implement OIDC Discovery.
+                          type: string
+                        ttl:
+                          description: Decides how long to wait before refreshing
+                            the JWKS (in seconds). If omitted, Authorino will never
+                            refresh the JWKS.
+                          type: integer
+                      type: object
+                    kubernetesTokenReview:
+                      description: Authentication by Kubernetes token review.
+                      properties:
+                        audiences:
+                          description: The list of audiences (scopes) that must be
+                            claimed in a Kubernetes authentication token supplied
+                            in the request, and reviewed by Authorino. If omitted,
+                            Authorino will review tokens expecting the host name of
+                            the requested protected service amongst the audiences.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
+                    oauth2Introspection:
+                      description: Authentication by OAuth2 token introspection.
+                      properties:
+                        credentialsRef:
+                          description: Reference to a Kubernetes secret in the same
+                            namespace, that stores client credentials to the OAuth2
+                            server.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        endpoint:
+                          description: The full URL of the token introspection endpoint.
+                          type: string
+                        tokenTypeHint:
+                          description: The token type hint for the token introspection.
+                            If omitted, it defaults to "access_token".
+                          type: string
+                      required:
+                      - credentialsRef
+                      - endpoint
+                      type: object
+                    overrides:
+                      additionalProperties:
+                        properties:
+                          selector:
+                            description: 'Simple path selector to fetch content from
+                              the authorization JSON (e.g. ''request.method'') or
+                              a string template with variables that resolve to patterns
+                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. The following Authorino custom modifiers are supported:
+                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                              @base64:encode|decode and @strip.'
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      description: Overrides the resolved identity object by setting
+                        the additional properties (claims) specified in this config,
+                        before appending the object to the authorization JSON. It
+                        requires the resolved identity object to always be a JSON
+                        object. Do not use this option with identity objects of other
+                        JSON types (array, string, etc).
+                      type: object
+                    plain:
+                      description: Identity object extracted from the context. Use
+                        this method when authentication is performed beforehand by
+                        a proxy and the resulting object passed to Authorino as JSON
+                        in the auth request.
+                      properties:
+                        selector:
+                          description: 'Simple path selector to fetch content from
+                            the authorization JSON (e.g. ''request.method'') or a
+                            string template with variables that resolve to patterns
+                            (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
+                            by https://pkg.go.dev/github.com/tidwall/gjson can be
+                            used. The following Authorino custom modifiers are supported:
+                            @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                            @base64:encode|decode and @strip.'
+                          type: string
+                      required:
+                      - selector
+                      type: object
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
+                    when:
+                      description: Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be
+                        enforced; otherwise, the config will be skipped.
+                      items:
+                        oneOf:
+                        - properties:
+                            patternRef: {}
+                          required:
+                          - patternRef
+                        - properties:
+                            operator: {}
+                            selector: {}
+                            value: {}
+                          required:
+                          - operator
+                          - selector
+                        properties:
+                          operator:
+                            description: 'The binary operator to be applied to the
+                              content fetched from the authorization JSON, for comparison
+                              with "value". Possible values are: "eq" (equal to),
+                              "neq" (not equal to), "incl" (includes; for arrays),
+                              "excl" (excludes; for arrays), "matches" (regex)'
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: Path selector to fetch content from the authorization
+                              JSON (e.g. 'request.method'). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. Authorino custom JSON path modifiers are also
+                              supported.
+                            type: string
+                          value:
+                            description: The value of reference for the comparison
+                              with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must
+                              compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                    x509:
+                      description: Authentication based on client X.509 certificates.
+                        The certificates presented by the clients must be signed by
+                        a trusted CA whose certificates are stored in Kubernetes secrets.
+                      properties:
+                        allNamespaces:
+                          default: false
+                          description: Whether Authorino should look for TLS secrets
+                            in all namespaces or only in the same namespace as the
+                            AuthConfig. Enabling this option in namespaced Authorino
+                            instances has no effect.
+                          type: boolean
+                        selector:
+                          description: Label selector used by Authorino to match secrets
+                            from the cluster storing trusted CA certificates to validate
+                            clients trying to authenticate to this service
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - selector
+                      type: object
+                  type: object
+                description: Authentication configs. At least one config MUST evaluate
+                  to a valid identity object for the auth request to be successful.
+                type: object
+              authorization:
+                additionalProperties:
+                  oneOf:
+                  - properties:
+                      opa: {}
+                    required:
+                    - opa
+                  - properties:
+                      patternMatching: {}
+                    required:
+                    - patternMatching
+                  - properties:
+                      kubernetesSubjectAccessReview: {}
+                    required:
+                    - kubernetesSubjectAccessReview
+                  - properties:
+                      spicedb: {}
+                    required:
+                    - spicedb
+                  properties:
+                    cache:
+                      description: Caching options for the resolved object returned
+                        when applying this config. Omit it to avoid caching objects
+                        for this config.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. The
+                            resolved key must be unique within the scope of this particular
+                            config.
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    kubernetesSubjectAccessReview:
+                      description: Authorization by Kubernetes SubjectAccessReview
+                      properties:
+                        groups:
+                          description: Groups the user must be a member of or, if
+                            `user` is omitted, the groups to check for authorization
+                            in the Kubernetes RBAC.
+                          items:
+                            type: string
+                          type: array
+                        resourceAttributes:
+                          description: Use resourceAttributes to check permissions
+                            on Kubernetes resources. If omitted, it performs a non-resource
+                            SubjectAccessReview, with verb and path inferred from
+                            the request.
+                          properties:
+                            group:
+                              description: API group of the resource. Use '*' for
+                                all API groups.
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            name:
+                              description: Resource name Omit it to check for authorization
+                                on all resources of the specified kind.
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            namespace:
+                              description: Namespace where the user must have permissions
+                                on the resource.
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            resource:
+                              description: Resource kind Use '*' for all resource
+                                kinds.
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            subresource:
+                              description: Subresource kind
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            verb:
+                              description: Verb to check for authorization on the
+                                resource. Use '*' for all verbs.
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                        user:
+                          description: User to check for authorization in the Kubernetes
+                            RBAC. Omit it to check for group authorization only.
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
+                    opa:
+                      description: Open Policy Agent (OPA) Rego policy.
+                      properties:
+                        allValues:
+                          default: false
+                          description: Returns the value of all Rego rules in the
+                            virtual document. Values can be read in subsequent evaluators/phases
+                            of the Auth Pipeline. Otherwise, only the default `allow`
+                            rule will be exposed. Returning all Rego rules can affect
+                            performance of OPA policies during reconciliation (policy
+                            precompile) and at runtime.
+                          type: boolean
+                        externalPolicy:
+                          description: External registry of OPA policies.
+                          properties:
+                            body:
+                              description: Raw body of the HTTP request. Supersedes
+                                'bodyParameters'; use either one or the other. Use
+                                it with method=POST; for GET requests, set parameters
+                                as query string in the 'endpoint' (placeholders can
+                                be used).
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            bodyParameters:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: 'Simple path selector to fetch content
+                                      from the authorization JSON (e.g. ''request.method'')
+                                      or a string template with variables that resolve
+                                      to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following Authorino custom
+                                      modifiers are supported: @extract:{sep:" ",pos:0},
+                                      @replace{old:"",new:""}, @case:upper|lower,
+                                      @base64:encode|decode and @strip.'
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: Custom parameters to encode in the body
+                                of the HTTP request. Superseded by 'body'; use either
+                                one or the other. Use it with method=POST; for GET
+                                requests, set parameters as query string in the 'endpoint'
+                                (placeholders can be used).
+                              type: object
+                            contentType:
+                              default: application/x-www-form-urlencoded
+                              description: Content-Type of the request body. Shapes
+                                how 'bodyParameters' are encoded. Use it with method=POST;
+                                for GET requests, Content-Type is automatically set
+                                to 'text/plain'.
+                              enum:
+                              - application/x-www-form-urlencoded
+                              - application/json
+                              type: string
+                            credentials:
+                              description: Defines where client credentials will be
+                                passed in the request to the service. If omitted,
+                                it defaults to client credentials passed in the HTTP
+                                Authorization header and the "Bearer" prefix expected
+                                prepended to the secret value.
+                              properties:
+                                authorizationHeader:
+                                  properties:
+                                    prefix:
+                                      type: string
+                                  type: object
+                                cookie:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                customHeader:
+                                  properties:
+                                    name:
+                                      type: string
+                                    prefix:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                queryString:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                              type: object
+                            headers:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: 'Simple path selector to fetch content
+                                      from the authorization JSON (e.g. ''request.method'')
+                                      or a string template with variables that resolve
+                                      to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following Authorino custom
+                                      modifiers are supported: @extract:{sep:" ",pos:0},
+                                      @replace{old:"",new:""}, @case:upper|lower,
+                                      @base64:encode|decode and @strip.'
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: Custom headers in the HTTP request.
+                              type: object
+                            insecure:
+                              description: Insecure HTTP connection (i.e. disables
+                                TLS verification)
+                              type: boolean
+                            method:
+                              default: GET
+                              description: 'HTTP verb used in the request to the service.
+                                Accepted values: GET (default), POST. When the request
+                                method is POST, the authorization JSON is passed in
+                                the body of the request.'
+                              enum:
+                              - GET
+                              - POST
+                              - PUT
+                              - PATCH
+                              - DELETE
+                              - HEAD
+                              - OPTIONS
+                              - CONNECT
+                              - TRACE
+                              type: string
+                            oauth2:
+                              description: Authentication with the HTTP service by
+                                OAuth2 Client Credentials grant.
+                              properties:
+                                cache:
+                                  default: true
+                                  description: Caches and reuses the token until expired.
+                                    Set it to false to force fetch the token at every
+                                    authorization request regardless of expiration.
+                                  type: boolean
+                                clientId:
+                                  description: OAuth2 Client ID.
+                                  type: string
+                                clientSecretRef:
+                                  description: Reference to a Kuberentes Secret key
+                                    that stores that OAuth2 Client Secret.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: The name of the secret in the Authorino's
+                                        namespace to select from.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                extraParams:
+                                  additionalProperties:
+                                    type: string
+                                  description: Optional extra parameters for the requests
+                                    to the token URL.
+                                  type: object
+                                scopes:
+                                  description: Optional scopes for the client credentials
+                                    grant, if supported by he OAuth2 server.
+                                  items:
+                                    type: string
+                                  type: array
+                                tokenUrl:
+                                  description: Token endpoint URL of the OAuth2 resource
+                                    server.
+                                  type: string
+                              required:
+                              - clientId
+                              - clientSecretRef
+                              - tokenUrl
+                              type: object
+                            sharedSecretRef:
+                              description: Reference to a Secret key whose value will
+                                be passed by Authorino in the request. The HTTP service
+                                can use the shared secret to authenticate the origin
+                                of the request. Ignored if used together with oauth2.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            ttl:
+                              description: Duration (in seconds) of the external data
+                                in the cache before pulled again from the source.
+                              type: integer
+                            url:
+                              description: Endpoint URL of the HTTP service. The value
+                                can include variable placeholders in the format "{selector}",
+                                where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                and selects value from the authorization JSON. E.g.
+                                https://ext-auth-server.io/metadata?p={request.path}
+                              type: string
+                          required:
+                          - url
+                          type: object
+                        rego:
+                          description: Authorization policy as a Rego language document.
+                            The Rego document must include the "allow" condition,
+                            set by Authorino to "false" by default (i.e. requests
+                            are unauthorized unless changed). The Rego document must
+                            NOT include the "package" declaration in line 1.
+                          type: string
+                      type: object
+                    patternMatching:
+                      description: Pattern-matching authorization rules.
+                      properties:
+                        patterns:
+                          items:
+                            oneOf:
+                            - properties:
+                                patternRef: {}
+                              required:
+                              - patternRef
+                            - properties:
+                                operator: {}
+                                selector: {}
+                                value: {}
+                              required:
+                              - operator
+                              - selector
+                            properties:
+                              operator:
+                                description: 'The binary operator to be applied to
+                                  the content fetched from the authorization JSON,
+                                  for comparison with "value". Possible values are:
+                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
+                                  for arrays), "excl" (excludes; for arrays), "matches"
+                                  (regex)'
+                                enum:
+                                - eq
+                                - neq
+                                - incl
+                                - excl
+                                - matches
+                                type: string
+                              patternRef:
+                                description: Reference to a named set of pattern expressions
+                                type: string
+                              selector:
+                                description: Path selector to fetch content from the
+                                  authorization JSON (e.g. 'request.method'). Any
+                                  pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. Authorino custom JSON path modifiers
+                                  are also supported.
+                                type: string
+                              value:
+                                description: The value of reference for the comparison
+                                  with the content fetched from the authorization
+                                  JSON. If used with the "matches" operator, the value
+                                  must compile to a valid Golang regex.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - patterns
+                      type: object
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
+                    spicedb:
+                      description: Authorization decision delegated to external Authzed/SpiceDB
+                        server.
+                      properties:
+                        endpoint:
+                          description: Hostname and port number to the GRPC interface
+                            of the SpiceDB server (e.g. spicedb:50051).
+                          type: string
+                        insecure:
+                          description: Insecure HTTP connection (i.e. disables TLS
+                            verification)
+                          type: boolean
+                        permission:
+                          description: The name of the permission (or relation) on
+                            which to execute the check.
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        resource:
+                          description: The resource on which to check the permission
+                            or relation.
+                          properties:
+                            kind:
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            name:
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                        sharedSecretRef:
+                          description: Reference to a Secret key whose value will
+                            be used by Authorino to authenticate with the Authzed
+                            service.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        subject:
+                          description: The subject that will be checked for the permission
+                            or relation.
+                          properties:
+                            kind:
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            name:
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                      required:
+                      - endpoint
+                      type: object
+                    when:
+                      description: Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be
+                        enforced; otherwise, the config will be skipped.
+                      items:
+                        oneOf:
+                        - properties:
+                            patternRef: {}
+                          required:
+                          - patternRef
+                        - properties:
+                            operator: {}
+                            selector: {}
+                            value: {}
+                          required:
+                          - operator
+                          - selector
+                        properties:
+                          operator:
+                            description: 'The binary operator to be applied to the
+                              content fetched from the authorization JSON, for comparison
+                              with "value". Possible values are: "eq" (equal to),
+                              "neq" (not equal to), "incl" (includes; for arrays),
+                              "excl" (excludes; for arrays), "matches" (regex)'
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: Path selector to fetch content from the authorization
+                              JSON (e.g. 'request.method'). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. Authorino custom JSON path modifiers are also
+                              supported.
+                            type: string
+                          value:
+                            description: The value of reference for the comparison
+                              with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must
+                              compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                description: Authorization policies. All policies MUST evaluate to
+                  "allowed = true" for the auth request be successful.
+                type: object
+              callbacks:
+                additionalProperties:
+                  properties:
+                    cache:
+                      description: Caching options for the resolved object returned
+                        when applying this config. Omit it to avoid caching objects
+                        for this config.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. The
+                            resolved key must be unique within the scope of this particular
+                            config.
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    http:
+                      description: Settings of the external HTTP request
+                      properties:
+                        body:
+                          description: Raw body of the HTTP request. Supersedes 'bodyParameters';
+                            use either one or the other. Use it with method=POST;
+                            for GET requests, set parameters as query string in the
+                            'endpoint' (placeholders can be used).
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        bodyParameters:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: 'Simple path selector to fetch content
+                                  from the authorization JSON (e.g. ''request.method'')
+                                  or a string template with variables that resolve
+                                  to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following Authorino custom modifiers
+                                  are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: Custom parameters to encode in the body of
+                            the HTTP request. Superseded by 'body'; use either one
+                            or the other. Use it with method=POST; for GET requests,
+                            set parameters as query string in the 'endpoint' (placeholders
+                            can be used).
+                          type: object
+                        contentType:
+                          default: application/x-www-form-urlencoded
+                          description: Content-Type of the request body. Shapes how
+                            'bodyParameters' are encoded. Use it with method=POST;
+                            for GET requests, Content-Type is automatically set to
+                            'text/plain'.
+                          enum:
+                          - application/x-www-form-urlencoded
+                          - application/json
+                          type: string
+                        credentials:
+                          description: Defines where client credentials will be passed
+                            in the request to the service. If omitted, it defaults
+                            to client credentials passed in the HTTP Authorization
+                            header and the "Bearer" prefix expected prepended to the
+                            secret value.
+                          properties:
+                            authorizationHeader:
+                              properties:
+                                prefix:
+                                  type: string
+                              type: object
+                            cookie:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            customHeader:
+                              properties:
+                                name:
+                                  type: string
+                                prefix:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            queryString:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          type: object
+                        headers:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: 'Simple path selector to fetch content
+                                  from the authorization JSON (e.g. ''request.method'')
+                                  or a string template with variables that resolve
+                                  to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following Authorino custom modifiers
+                                  are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: Custom headers in the HTTP request.
+                          type: object
+                        insecure:
+                          description: Insecure HTTP connection (i.e. disables TLS
+                            verification)
+                          type: boolean
+                        method:
+                          default: GET
+                          description: 'HTTP verb used in the request to the service.
+                            Accepted values: GET (default), POST. When the request
+                            method is POST, the authorization JSON is passed in the
+                            body of the request.'
+                          enum:
+                          - GET
+                          - POST
+                          - PUT
+                          - PATCH
+                          - DELETE
+                          - HEAD
+                          - OPTIONS
+                          - CONNECT
+                          - TRACE
+                          type: string
+                        oauth2:
+                          description: Authentication with the HTTP service by OAuth2
+                            Client Credentials grant.
+                          properties:
+                            cache:
+                              default: true
+                              description: Caches and reuses the token until expired.
+                                Set it to false to force fetch the token at every
+                                authorization request regardless of expiration.
+                              type: boolean
+                            clientId:
+                              description: OAuth2 Client ID.
+                              type: string
+                            clientSecretRef:
+                              description: Reference to a Kuberentes Secret key that
+                                stores that OAuth2 Client Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            extraParams:
+                              additionalProperties:
+                                type: string
+                              description: Optional extra parameters for the requests
+                                to the token URL.
+                              type: object
+                            scopes:
+                              description: Optional scopes for the client credentials
+                                grant, if supported by he OAuth2 server.
+                              items:
+                                type: string
+                              type: array
+                            tokenUrl:
+                              description: Token endpoint URL of the OAuth2 resource
+                                server.
+                              type: string
+                          required:
+                          - clientId
+                          - clientSecretRef
+                          - tokenUrl
+                          type: object
+                        sharedSecretRef:
+                          description: Reference to a Secret key whose value will
+                            be passed by Authorino in the request. The HTTP service
+                            can use the shared secret to authenticate the origin of
+                            the request. Ignored if used together with oauth2.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        url:
+                          description: Endpoint URL of the HTTP service. The value
+                            can include variable placeholders in the format "{selector}",
+                            where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                            and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={request.path}
+                          type: string
+                      required:
+                      - url
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
+                    when:
+                      description: Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be
+                        enforced; otherwise, the config will be skipped.
+                      items:
+                        properties:
+                          operator:
+                            description: 'The binary operator to be applied to the
+                              content fetched from the authorization JSON, for comparison
+                              with "value". Possible values are: "eq" (equal to),
+                              "neq" (not equal to), "incl" (includes; for arrays),
+                              "excl" (excludes; for arrays), "matches" (regex)'
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: Path selector to fetch content from the authorization
+                              JSON (e.g. 'request.method'). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. Authorino custom JSON path modifiers are also
+                              supported.
+                            type: string
+                          value:
+                            description: The value of reference for the comparison
+                              with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must
+                              compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - http
+                  type: object
+                description: Callback functions. Authorino sends callbacks at the
+                  end of the auth pipeline to the endpoints specified in this config.
+                type: object
+              hosts:
+                description: The list of public host names of the services protected
+                  by this authentication/authorization scheme. Authorino uses the
+                  requested host to lookup for the corresponding authentication/authorization
+                  configs to enforce.
+                items:
+                  type: string
+                type: array
+              metadata:
+                additionalProperties:
+                  oneOf:
+                  - properties:
+                      userInfo: {}
+                    required:
+                    - userInfo
+                  - properties:
+                      uma: {}
+                    required:
+                    - uma
+                  - properties:
+                      http: {}
+                    required:
+                    - http
+                  properties:
+                    cache:
+                      description: Caching options for the resolved object returned
+                        when applying this config. Omit it to avoid caching objects
+                        for this config.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. The
+                            resolved key must be unique within the scope of this particular
+                            config.
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    http:
+                      description: External source of auth metadata via HTTP request
+                      properties:
+                        body:
+                          description: Raw body of the HTTP request. Supersedes 'bodyParameters';
+                            use either one or the other. Use it with method=POST;
+                            for GET requests, set parameters as query string in the
+                            'endpoint' (placeholders can be used).
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        bodyParameters:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: 'Simple path selector to fetch content
+                                  from the authorization JSON (e.g. ''request.method'')
+                                  or a string template with variables that resolve
+                                  to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following Authorino custom modifiers
+                                  are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: Custom parameters to encode in the body of
+                            the HTTP request. Superseded by 'body'; use either one
+                            or the other. Use it with method=POST; for GET requests,
+                            set parameters as query string in the 'endpoint' (placeholders
+                            can be used).
+                          type: object
+                        contentType:
+                          default: application/x-www-form-urlencoded
+                          description: Content-Type of the request body. Shapes how
+                            'bodyParameters' are encoded. Use it with method=POST;
+                            for GET requests, Content-Type is automatically set to
+                            'text/plain'.
+                          enum:
+                          - application/x-www-form-urlencoded
+                          - application/json
+                          type: string
+                        credentials:
+                          description: Defines where client credentials will be passed
+                            in the request to the service. If omitted, it defaults
+                            to client credentials passed in the HTTP Authorization
+                            header and the "Bearer" prefix expected prepended to the
+                            secret value.
+                          properties:
+                            authorizationHeader:
+                              properties:
+                                prefix:
+                                  type: string
+                              type: object
+                            cookie:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            customHeader:
+                              properties:
+                                name:
+                                  type: string
+                                prefix:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            queryString:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          type: object
+                        headers:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: 'Simple path selector to fetch content
+                                  from the authorization JSON (e.g. ''request.method'')
+                                  or a string template with variables that resolve
+                                  to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following Authorino custom modifiers
+                                  are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: Custom headers in the HTTP request.
+                          type: object
+                        insecure:
+                          description: Insecure HTTP connection (i.e. disables TLS
+                            verification)
+                          type: boolean
+                        method:
+                          default: GET
+                          description: 'HTTP verb used in the request to the service.
+                            Accepted values: GET (default), POST. When the request
+                            method is POST, the authorization JSON is passed in the
+                            body of the request.'
+                          enum:
+                          - GET
+                          - POST
+                          - PUT
+                          - PATCH
+                          - DELETE
+                          - HEAD
+                          - OPTIONS
+                          - CONNECT
+                          - TRACE
+                          type: string
+                        oauth2:
+                          description: Authentication with the HTTP service by OAuth2
+                            Client Credentials grant.
+                          properties:
+                            cache:
+                              default: true
+                              description: Caches and reuses the token until expired.
+                                Set it to false to force fetch the token at every
+                                authorization request regardless of expiration.
+                              type: boolean
+                            clientId:
+                              description: OAuth2 Client ID.
+                              type: string
+                            clientSecretRef:
+                              description: Reference to a Kuberentes Secret key that
+                                stores that OAuth2 Client Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            extraParams:
+                              additionalProperties:
+                                type: string
+                              description: Optional extra parameters for the requests
+                                to the token URL.
+                              type: object
+                            scopes:
+                              description: Optional scopes for the client credentials
+                                grant, if supported by he OAuth2 server.
+                              items:
+                                type: string
+                              type: array
+                            tokenUrl:
+                              description: Token endpoint URL of the OAuth2 resource
+                                server.
+                              type: string
+                          required:
+                          - clientId
+                          - clientSecretRef
+                          - tokenUrl
+                          type: object
+                        sharedSecretRef:
+                          description: Reference to a Secret key whose value will
+                            be passed by Authorino in the request. The HTTP service
+                            can use the shared secret to authenticate the origin of
+                            the request. Ignored if used together with oauth2.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        url:
+                          description: Endpoint URL of the HTTP service. The value
+                            can include variable placeholders in the format "{selector}",
+                            where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                            and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={request.path}
+                          type: string
+                      required:
+                      - url
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
+                    uma:
+                      description: User-Managed Access (UMA) source of resource data.
+                      properties:
+                        credentialsRef:
+                          description: Reference to a Kubernetes secret in the same
+                            namespace, that stores client credentials to the resource
+                            registration API of the UMA server.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        endpoint:
+                          description: The endpoint of the UMA server. The value must
+                            coincide with the "issuer" claim of the UMA config discovered
+                            from the well-known uma configuration endpoint.
+                          type: string
+                      required:
+                      - credentialsRef
+                      - endpoint
+                      type: object
+                    userInfo:
+                      description: OpendID Connect UserInfo linked to an OIDC authentication
+                        config specified in this same AuthConfig.
+                      properties:
+                        identitySource:
+                          description: The name of an OIDC-enabled JWT authentication
+                            config whose OpenID Connect configuration discovered includes
+                            the OIDC "userinfo_endpoint" claim.
+                          type: string
+                      required:
+                      - identitySource
+                      type: object
+                    when:
+                      description: Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be
+                        enforced; otherwise, the config will be skipped.
+                      items:
+                        oneOf:
+                        - properties:
+                            patternRef: {}
+                          required:
+                          - patternRef
+                        - properties:
+                            operator: {}
+                            selector: {}
+                            value: {}
+                          required:
+                          - operator
+                          - selector
+                        properties:
+                          operator:
+                            description: 'The binary operator to be applied to the
+                              content fetched from the authorization JSON, for comparison
+                              with "value". Possible values are: "eq" (equal to),
+                              "neq" (not equal to), "incl" (includes; for arrays),
+                              "excl" (excludes; for arrays), "matches" (regex)'
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: Path selector to fetch content from the authorization
+                              JSON (e.g. 'request.method'). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. Authorino custom JSON path modifiers are also
+                              supported.
+                            type: string
+                          value:
+                            description: The value of reference for the comparison
+                              with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must
+                              compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                description: Metadata sources. Authorino fetches auth metadata as
+                  JSON from sources specified in this config.
+                type: object
+              patterns:
+                additionalProperties:
+                  items:
+                    properties:
+                      operator:
+                        description: 'The binary operator to be applied to the content
+                          fetched from the authorization JSON, for comparison with
+                          "value". Possible values are: "eq" (equal to), "neq" (not
+                          equal to), "incl" (includes; for arrays), "excl" (excludes;
+                          for arrays), "matches" (regex)'
+                        enum:
+                        - eq
+                        - neq
+                        - incl
+                        - excl
+                        - matches
+                        type: string
+                      selector:
+                        description: Path selector to fetch content from the authorization
+                          JSON (e.g. 'request.method'). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                          can be used. Authorino custom JSON path modifiers are also
+                          supported.
+                        type: string
+                      value:
+                        description: The value of reference for the comparison with
+                          the content fetched from the authorization JSON. If used
+                          with the "matches" operator, the value must compile to a
+                          valid Golang regex.
+                        type: string
+                    type: object
+                  type: array
+                description: Named sets of patterns that can be referred in `when`
+                  conditions and in pattern-matching authorization policy rules.
+                type: object
+              response:
+                description: Response items. Authorino builds custom responses to
+                  the client of the auth request.
+                properties:
+                  success:
+                    description: Response items to be included in the auth response
+                      when the request is authenticated and authorized. For integration
+                      of Authorino via proxy, the proxy must use these settings to
+                      propagate dynamic metadata and/or inject data in the request.
+                    properties:
+                      dynamicMetadata:
+                        additionalProperties:
+                          description: Settings of the success custom response item.
+                          oneOf:
+                          - properties:
+                              wristband: {}
+                            required:
+                            - wristband
+                          - properties:
+                              json: {}
+                            required:
+                            - json
+                          - properties:
+                              plain: {}
+                            required:
+                            - plain
+                          properties:
+                            cache:
+                              description: Caching options for the resolved object
+                                returned when applying this config. Omit it to avoid
+                                caching objects for this config.
+                              properties:
+                                key:
+                                  description: Key used to store the entry in the
+                                    cache. The resolved key must be unique within
+                                    the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: 'Simple path selector to fetch
+                                        content from the authorization JSON (e.g.
+                                        ''request.method'') or a string template with
+                                        variables that resolve to patterns (e.g. "Hello,
+                                        {auth.identity.name}!"). Any pattern supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following Authorino custom
+                                        modifiers are supported: @extract:{sep:" ",pos:0},
+                                        @replace{old:"",new:""}, @case:upper|lower,
+                                        @base64:encode|decode and @strip.'
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            json:
+                              description: JSON object Specify it as the list of properties
+                                of the object, whose values can combine static values
+                                and values selected from the authorization JSON.
+                              properties:
+                                properties:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: 'Simple path selector to fetch
+                                          content from the authorization JSON (e.g.
+                                          ''request.method'') or a string template
+                                          with variables that resolve to patterns
+                                          (e.g. "Hello, {auth.identity.name}!"). Any
+                                          pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                          can be used. The following Authorino custom
+                                          modifiers are supported: @extract:{sep:"
+                                          ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                                          @base64:encode|decode and @strip.'
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: object
+                              required:
+                              - properties
+                              type: object
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            plain:
+                              description: Plain text content
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            priority:
+                              default: 0
+                              description: Priority group of the config. All configs
+                                in the same priority group are evaluated concurrently;
+                                consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            when:
+                              description: Conditions for Authorino to enforce this
+                                config. If omitted, the config will be enforced for
+                                all requests. If present, all conditions must match
+                                for the config to be enforced; otherwise, the config
+                                will be skipped.
+                              items:
+                                oneOf:
+                                - properties:
+                                    patternRef: {}
+                                  required:
+                                  - patternRef
+                                - properties:
+                                    operator: {}
+                                    selector: {}
+                                    value: {}
+                                  required:
+                                  - operator
+                                  - selector
+                                properties:
+                                  operator:
+                                    description: 'The binary operator to be applied
+                                      to the content fetched from the authorization
+                                      JSON, for comparison with "value". Possible
+                                      values are: "eq" (equal to), "neq" (not equal
+                                      to), "incl" (includes; for arrays), "excl" (excludes;
+                                      for arrays), "matches" (regex)'
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: Path selector to fetch content from
+                                      the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. Authorino custom JSON path modifiers
+                                      are also supported.
+                                    type: string
+                                  value:
+                                    description: The value of reference for the comparison
+                                      with the content fetched from the authorization
+                                      JSON. If used with the "matches" operator, the
+                                      value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                            wristband:
+                              description: Authorino Festival Wristband token
+                              properties:
+                                customClaims:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: 'Simple path selector to fetch
+                                          content from the authorization JSON (e.g.
+                                          ''request.method'') or a string template
+                                          with variables that resolve to patterns
+                                          (e.g. "Hello, {auth.identity.name}!"). Any
+                                          pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                          can be used. The following Authorino custom
+                                          modifiers are supported: @extract:{sep:"
+                                          ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                                          @base64:encode|decode and @strip.'
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Any claims to be added to the wristband
+                                    token apart from the standard JWT claims (iss,
+                                    iat, exp) added by default.
+                                  type: object
+                                issuer:
+                                  description: 'The endpoint to the Authorino service
+                                    that issues the wristband (format: <scheme>://<host>:<port>/<realm>,
+                                    where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                  type: string
+                                signingKeyRefs:
+                                  description: Reference by name to Kubernetes secrets
+                                    and corresponding signing algorithms. The secrets
+                                    must contain a `key.pem` entry whose value is
+                                    the signing key formatted as PEM.
+                                  items:
+                                    properties:
+                                      algorithm:
+                                        description: Algorithm to sign the wristband
+                                          token using the signing key provided
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - ES512
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      name:
+                                        description: Name of the signing key. The
+                                          value is used to reference the Kubernetes
+                                          secret that stores the key and in the `kid`
+                                          claim of the wristband token header.
+                                        type: string
+                                    required:
+                                    - algorithm
+                                    - name
+                                    type: object
+                                  type: array
+                                tokenDuration:
+                                  description: Time span of the wristband token, in
+                                    seconds.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - issuer
+                              - signingKeyRefs
+                              type: object
+                          type: object
+                        description: Custom success response items wrapped as HTTP
+                          headers. For integration of Authorino via proxy, the proxy
+                          must use these settings to propagate dynamic metadata. See
+                          https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata
+                        type: object
+                      headers:
+                        additionalProperties:
+                          oneOf:
+                          - properties:
+                              wristband: {}
+                            required:
+                            - wristband
+                          - properties:
+                              json: {}
+                            required:
+                            - json
+                          - properties:
+                              plain: {}
+                            required:
+                            - plain
+                          properties:
+                            cache:
+                              description: Caching options for the resolved object
+                                returned when applying this config. Omit it to avoid
+                                caching objects for this config.
+                              properties:
+                                key:
+                                  description: Key used to store the entry in the
+                                    cache. The resolved key must be unique within
+                                    the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: 'Simple path selector to fetch
+                                        content from the authorization JSON (e.g.
+                                        ''request.method'') or a string template with
+                                        variables that resolve to patterns (e.g. "Hello,
+                                        {auth.identity.name}!"). Any pattern supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following Authorino custom
+                                        modifiers are supported: @extract:{sep:" ",pos:0},
+                                        @replace{old:"",new:""}, @case:upper|lower,
+                                        @base64:encode|decode and @strip.'
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            json:
+                              description: JSON object Specify it as the list of properties
+                                of the object, whose values can combine static values
+                                and values selected from the authorization JSON.
+                              properties:
+                                properties:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: 'Simple path selector to fetch
+                                          content from the authorization JSON (e.g.
+                                          ''request.method'') or a string template
+                                          with variables that resolve to patterns
+                                          (e.g. "Hello, {auth.identity.name}!"). Any
+                                          pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                          can be used. The following Authorino custom
+                                          modifiers are supported: @extract:{sep:"
+                                          ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                                          @base64:encode|decode and @strip.'
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: object
+                              required:
+                              - properties
+                              type: object
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            plain:
+                              description: Plain text content
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            prefix:
+                              description: Prefix of the value to be added to the
+                                HTTP header
+                              type: string
+                            priority:
+                              default: 0
+                              description: Priority group of the config. All configs
+                                in the same priority group are evaluated concurrently;
+                                consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            when:
+                              description: Conditions for Authorino to enforce this
+                                config. If omitted, the config will be enforced for
+                                all requests. If present, all conditions must match
+                                for the config to be enforced; otherwise, the config
+                                will be skipped.
+                              items:
+                                oneOf:
+                                - properties:
+                                    patternRef: {}
+                                  required:
+                                  - patternRef
+                                - properties:
+                                    operator: {}
+                                    selector: {}
+                                    value: {}
+                                  required:
+                                  - operator
+                                  - selector
+                                properties:
+                                  operator:
+                                    description: 'The binary operator to be applied
+                                      to the content fetched from the authorization
+                                      JSON, for comparison with "value". Possible
+                                      values are: "eq" (equal to), "neq" (not equal
+                                      to), "incl" (includes; for arrays), "excl" (excludes;
+                                      for arrays), "matches" (regex)'
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: Path selector to fetch content from
+                                      the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. Authorino custom JSON path modifiers
+                                      are also supported.
+                                    type: string
+                                  value:
+                                    description: The value of reference for the comparison
+                                      with the content fetched from the authorization
+                                      JSON. If used with the "matches" operator, the
+                                      value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                            wristband:
+                              description: Authorino Festival Wristband token
+                              properties:
+                                customClaims:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: 'Simple path selector to fetch
+                                          content from the authorization JSON (e.g.
+                                          ''request.method'') or a string template
+                                          with variables that resolve to patterns
+                                          (e.g. "Hello, {auth.identity.name}!"). Any
+                                          pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                          can be used. The following Authorino custom
+                                          modifiers are supported: @extract:{sep:"
+                                          ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                                          @base64:encode|decode and @strip.'
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Any claims to be added to the wristband
+                                    token apart from the standard JWT claims (iss,
+                                    iat, exp) added by default.
+                                  type: object
+                                issuer:
+                                  description: 'The endpoint to the Authorino service
+                                    that issues the wristband (format: <scheme>://<host>:<port>/<realm>,
+                                    where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                  type: string
+                                signingKeyRefs:
+                                  description: Reference by name to Kubernetes secrets
+                                    and corresponding signing algorithms. The secrets
+                                    must contain a `key.pem` entry whose value is
+                                    the signing key formatted as PEM.
+                                  items:
+                                    properties:
+                                      algorithm:
+                                        description: Algorithm to sign the wristband
+                                          token using the signing key provided
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - ES512
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      name:
+                                        description: Name of the signing key. The
+                                          value is used to reference the Kubernetes
+                                          secret that stores the key and in the `kid`
+                                          claim of the wristband token header.
+                                        type: string
+                                    required:
+                                    - algorithm
+                                    - name
+                                    type: object
+                                  type: array
+                                tokenDuration:
+                                  description: Time span of the wristband token, in
+                                    seconds.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - issuer
+                              - signingKeyRefs
+                              type: object
+                          type: object
+                        description: Custom success response items wrapped as HTTP
+                          headers. For integration of Authorino via proxy, the proxy
+                          must use these settings to inject data in the request.
+                        type: object
+                    type: object
+                  unauthenticated:
+                    description: 'Customizations on the denial status attributes when
+                      the request is unauthenticated. For integration of Authorino
+                      via proxy, the proxy must honour the response status attributes
+                      specified in this config. Default: 401 Unauthorized'
+                    properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          selector:
+                            description: 'Simple path selector to fetch content from
+                              the authorization JSON (e.g. ''request.method'') or
+                              a string template with variables that resolve to patterns
+                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. The following Authorino custom modifiers are supported:
+                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                              @base64:encode|decode and @strip.'
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      code:
+                        description: HTTP status code to override the default denial
+                          status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        additionalProperties:
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        description: HTTP response headers to override the default
+                          denial headers.
+                        type: object
+                      message:
+                        description: HTTP message to override the default denial message.
+                        properties:
+                          selector:
+                            description: 'Simple path selector to fetch content from
+                              the authorization JSON (e.g. ''request.method'') or
+                              a string template with variables that resolve to patterns
+                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. The following Authorino custom modifiers are supported:
+                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                              @base64:encode|decode and @strip.'
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                  unauthorized:
+                    description: 'Customizations on the denial status attributes when
+                      the request is unauthorized. For integration of Authorino via
+                      proxy, the proxy must honour the response status attributes
+                      specified in this config. Default: 403 Forbidden'
+                    properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          selector:
+                            description: 'Simple path selector to fetch content from
+                              the authorization JSON (e.g. ''request.method'') or
+                              a string template with variables that resolve to patterns
+                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. The following Authorino custom modifiers are supported:
+                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                              @base64:encode|decode and @strip.'
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      code:
+                        description: HTTP status code to override the default denial
+                          status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        additionalProperties:
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        description: HTTP response headers to override the default
+                          denial headers.
+                        type: object
+                      message:
+                        description: HTTP message to override the default denial message.
+                        properties:
+                          selector:
+                            description: 'Simple path selector to fetch content from
+                              the authorization JSON (e.g. ''request.method'') or
+                              a string template with variables that resolve to patterns
+                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. The following Authorino custom modifiers are supported:
+                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                              @base64:encode|decode and @strip.'
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                type: object
+              when:
+                description: Overall conditions for the AuthConfig to be enforced.
+                  If omitted, the AuthConfig will be enforced at all requests. If
+                  present, all conditions must match for the AuthConfig to be enforced;
+                  otherwise, Authorino skips the AuthConfig and returns to the auth
+                  request with status OK.
+                items:
+                  oneOf:
+                  - properties:
+                      patternRef: {}
+                    required:
+                    - patternRef
+                  - properties:
+                      operator: {}
+                      selector: {}
+                      value: {}
+                    required:
+                    - operator
+                    - selector
+                  properties:
+                    operator:
+                      description: 'The binary operator to be applied to the content
+                        fetched from the authorization JSON, for comparison with "value".
+                        Possible values are: "eq" (equal to), "neq" (not equal to),
+                        "incl" (includes; for arrays), "excl" (excludes; for arrays),
+                        "matches" (regex)'
+                      enum:
+                      - eq
+                      - neq
+                      - incl
+                      - excl
+                      - matches
+                      type: string
+                    patternRef:
+                      description: Reference to a named set of pattern expressions
+                      type: string
+                    selector:
+                      description: Path selector to fetch content from the authorization
+                        JSON (e.g. 'request.method'). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                        can be used. Authorino custom JSON path modifiers are also
+                        supported.
+                      type: string
+                    value:
+                      description: The value of reference for the comparison with
+                        the content fetched from the authorization JSON. If used with
+                        the "matches" operator, the value must compile to a valid
+                        Golang regex.
+                      type: string
+                  type: object
+                type: array
+            required:
+            - hosts
+            type: object
+          status:
+            description: AuthConfigStatus defines the observed state of AuthConfig
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transit from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdatedTime:
+                      description: Last time the condition was updated
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: (brief) reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              summary:
+                properties:
+                  festivalWristbandEnabled:
+                    description: Indicator of whether the AuthConfig issues Festival
+                      Wristband tokens on successful evaluation of the AuthConfig
+                      (access granted)
+                    type: boolean
+                  hostsReady:
+                    description: Lists the hosts from spec.hosts linked to the resource
+                      in the index
+                    items:
+                      type: string
+                    type: array
+                  numAuthorizationPolicies:
+                    description: Number of authorization policies in the AuthConfig
+                    format: int64
+                    type: integer
+                  numHostsReady:
+                    description: Number of hosts from spec.hosts linked to the resource
+                      in the index, compared to the total number of hosts in spec.hosts
+                    type: string
+                  numIdentitySources:
+                    description: Number of trusted sources of identity for authentication
+                      in the AuthConfig
+                    format: int64
+                    type: integer
+                  numMetadataSources:
+                    description: Number of sources of external metadata in the AuthConfig
+                    format: int64
+                    type: integer
+                  numResponseItems:
+                    description: Number of custom authorization response items in
+                      the AuthConfig
+                    format: int64
+                    type: integer
+                  ready:
+                    description: Whether all hosts from spec.hosts have been linked
+                      to the resource in the index
+                    type: boolean
+                required:
+                - festivalWristbandEnabled
+                - hostsReady
+                - numAuthorizationPolicies
+                - numHostsReady
+                - numIdentitySources
+                - numMetadataSources
+                - numResponseItems
+                - ready
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
     subresources:
       status: {}
 status:

--- a/config/authorino/kustomization.template.yaml
+++ b/config/authorino/kustomization.template.yaml
@@ -1,2 +1,74 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - github.com/Kuadrant/authorino/install?ref=${AUTHORINO_GITREF}
+- webhook
+
+# Configures the conversion webhook
+images:
+- name: AUTHORINO_IMAGE
+  newName: quay.io/kuadrant/authorino
+  newTag: ${AUTHORINO_VERSION}
+
+patchesStrategicMerge:
+- webhook/patches/webhook_in_authconfigs.yaml
+
+replacements:
+- source:
+    fieldPath: .metadata.namespace
+    group: cert-manager.io
+    kind: Certificate
+    name: authorino-webhook-server-cert
+    version: v1
+  targets:
+  - fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      create: true
+      delimiter: /
+    select:
+      kind: CustomResourceDefinition
+      name: authconfigs.authorino.kuadrant.io
+- source:
+    fieldPath: .metadata.name
+    group: cert-manager.io
+    kind: Certificate
+    name: authorino-webhook-server-cert
+    version: v1
+  targets:
+  - fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      create: true
+      delimiter: /
+      index: 1
+    select:
+      kind: CustomResourceDefinition
+      name: authconfigs.authorino.kuadrant.io
+- source:
+    fieldPath: .metadata.name
+    kind: Service
+    name: authorino-webhooks
+    version: v1
+  targets:
+  - fieldPaths:
+    - .spec.conversion.webhook.clientConfig.service.name
+    options:
+      create: true
+    select:
+      kind: CustomResourceDefinition
+      name: authconfigs.authorino.kuadrant.io
+- source:
+    fieldPath: .metadata.namespace
+    kind: Service
+    name: authorino-webhooks
+    version: v1
+  targets:
+  - fieldPaths:
+    - .spec.conversion.webhook.clientConfig.service.namespace
+    options:
+      create: true
+    select:
+      kind: CustomResourceDefinition
+      name: authconfigs.authorino.kuadrant.io

--- a/config/authorino/kustomization.yaml
+++ b/config/authorino/kustomization.yaml
@@ -1,2 +1,74 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - github.com/Kuadrant/authorino/install?ref=main
+- webhook
+
+# Configures the conversion webhook
+images:
+- name: AUTHORINO_IMAGE
+  newName: quay.io/kuadrant/authorino
+  newTag: latest
+
+patchesStrategicMerge:
+- webhook/patches/webhook_in_authconfigs.yaml
+
+replacements:
+- source:
+    fieldPath: .metadata.namespace
+    group: cert-manager.io
+    kind: Certificate
+    name: authorino-webhook-server-cert
+    version: v1
+  targets:
+  - fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      create: true
+      delimiter: /
+    select:
+      kind: CustomResourceDefinition
+      name: authconfigs.authorino.kuadrant.io
+- source:
+    fieldPath: .metadata.name
+    group: cert-manager.io
+    kind: Certificate
+    name: authorino-webhook-server-cert
+    version: v1
+  targets:
+  - fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      create: true
+      delimiter: /
+      index: 1
+    select:
+      kind: CustomResourceDefinition
+      name: authconfigs.authorino.kuadrant.io
+- source:
+    fieldPath: .metadata.name
+    kind: Service
+    name: authorino-webhooks
+    version: v1
+  targets:
+  - fieldPaths:
+    - .spec.conversion.webhook.clientConfig.service.name
+    options:
+      create: true
+    select:
+      kind: CustomResourceDefinition
+      name: authconfigs.authorino.kuadrant.io
+- source:
+    fieldPath: .metadata.namespace
+    kind: Service
+    name: authorino-webhooks
+    version: v1
+  targets:
+  - fieldPaths:
+    - .spec.conversion.webhook.clientConfig.service.namespace
+    options:
+      create: true
+    select:
+      kind: CustomResourceDefinition
+      name: authconfigs.authorino.kuadrant.io

--- a/config/authorino/webhook/certificate.yaml
+++ b/config/authorino/webhook/certificate.yaml
@@ -1,0 +1,21 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  namespace: system
+  name: webhooks-ca
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  namespace: system
+  name: webhook-server-cert
+spec:
+  dnsNames:
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: authorino-webhooks-ca
+  secretName: authorino-webhook-server-cert

--- a/config/authorino/webhook/deployment.yaml
+++ b/config/authorino/webhook/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: system
+  name: webhooks
+spec:
+  selector: {}
+  template:
+    spec:
+      containers:
+      - name: webhooks
+        image: AUTHORINO_IMAGE
+        command:
+        - authorino
+        - webhooks
+        ports:
+        - name: webhooks
+          containerPort: 9443
+        - name: metrics
+          containerPort: 8080
+        - name: healthz
+          containerPort: 8081
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        resources: {}
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: authorino-webhook-server-cert

--- a/config/authorino/webhook/kustomization.yaml
+++ b/config/authorino/webhook/kustomization.yaml
@@ -1,0 +1,59 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- certificate.yaml
+- deployment.yaml
+- service.yaml
+- rbac.yaml
+
+commonLabels:
+  app: authorino
+  authorino-component: authorino-webhooks
+
+namespace: authorino-operator
+
+namePrefix: authorino-
+
+replacements:
+- source:
+    fieldPath: .metadata.name
+    kind: Service
+    name: authorino-webhooks
+    version: v1
+  targets:
+  - fieldPaths:
+    - .spec.dnsNames.0
+    - .spec.dnsNames.1
+    options:
+      create: true
+      delimiter: .
+    select:
+      group: cert-manager.io
+      kind: Certificate
+      name: authorino-webhook-server-cert
+      version: v1
+- source:
+    fieldPath: .metadata.namespace
+    kind: Service
+    name: authorino-webhooks
+    version: v1
+  targets:
+  - fieldPaths:
+    - .spec.dnsNames.0
+    - .spec.dnsNames.1
+    options:
+      create: true
+      delimiter: .
+      index: 1
+    select:
+      group: cert-manager.io
+      kind: Certificate
+      name: authorino-webhook-server-cert
+      version: v1
+  - fieldPaths:
+    - subjects.0.namespace
+    select:
+      group: rbac.authorization.k8s.io
+      kind: RoleBinding
+      name: authorino-webhooks-manager

--- a/config/authorino/webhook/patches/webhook_in_authconfigs.yaml
+++ b/config/authorino/webhook/patches/webhook_in_authconfigs.yaml
@@ -1,0 +1,19 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: authconfigs.authorino.kuadrant.io
+  annotations:
+    cert-manager.io/inject-ca-from: WEBHOOK_CERTIFICATE_NAMESPACE/WEBHOOK_CERTIFICATE_NAME
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: WEBHOOK_SERVICE_NAMESPACE
+          name: WEBHOOK_SERVICE_NAME
+          path: /convert
+      conversionReviewVersions:
+      - v1beta1
+      - v1beta2

--- a/config/authorino/webhook/rbac.yaml
+++ b/config/authorino/webhook/rbac.yaml
@@ -1,0 +1,58 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: webhooks-manager-role
+rules:
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: system
+  name: webhooks-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: authorino-webhooks-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: SERVICE_NAMESPACE

--- a/config/authorino/webhook/service.yaml
+++ b/config/authorino/webhook/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: system
+  name: webhooks
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector: {}

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -2257,8 +2257,6 @@ spec:
                       description: The name of key used in the wrapped response (name
                         of the HTTP header or property of the Envoy Dynamic Metadata
                         JSON). If omitted, it will be set to the name of the configuration.
-                        [DEPRECATED] Starting in v1beta2, use the name of the response
-                        config instead.
                       type: string
                     wristband:
                       properties:
@@ -4403,6 +4401,12 @@ spec:
                               required:
                               - properties
                               type: object
+                            key:
+                              description: The key used to add the custom response
+                                item (name of the HTTP header or root property of
+                                the Dynamic Metadata object). If omitted, it will
+                                be set to the name of the response config.
+                              type: string
                             metrics:
                               default: false
                               description: Whether this config should generate individual
@@ -4638,6 +4642,12 @@ spec:
                               required:
                               - properties
                               type: object
+                            key:
+                              description: The key used to add the custom response
+                                item (name of the HTTP header or root property of
+                                the Dynamic Metadata object). If omitted, it will
+                                be set to the name of the response config.
+                              type: string
                             metrics:
                               default: false
                               description: Whether this config should generate individual
@@ -4660,10 +4670,6 @@ spec:
                                   description: Static value
                                   x-kubernetes-preserve-unknown-fields: true
                               type: object
-                            prefix:
-                              description: Prefix of the value to be added to the
-                                HTTP header
-                              type: string
                             priority:
                               default: 0
                               description: Priority group of the config. All configs

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -9,10 +9,21 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    cert-manager.io/inject-ca-from: authorino-operator/authorino-webhook-server-cert
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: authconfigs.authorino.kuadrant.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: authorino-webhooks
+          namespace: authorino-operator
+          path: /convert
+      conversionReviewVersions:
+      - v1beta1
+      - v1beta2
   group: authorino.kuadrant.io
   names:
     kind: AuthConfig
@@ -3072,6 +3083,54 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: authorino
+    authorino-component: authorino-webhooks
+  name: authorino-webhooks-manager-role
+rules:
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: authorino-operator-leader-election
@@ -3083,6 +3142,23 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: authorino-operator
+  namespace: authorino-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: authorino
+    authorino-component: authorino-webhooks
+  name: authorino-webhooks-manager
+  namespace: authorino-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: authorino-webhooks-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
   namespace: authorino-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3116,6 +3192,23 @@ kind: ConfigMap
 metadata:
   name: manager-config
   namespace: authorino-operator
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: authorino
+    authorino-component: authorino-webhooks
+  name: authorino-webhooks
+  namespace: authorino-operator
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: authorino
+    authorino-component: authorino-webhooks
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -3166,3 +3259,74 @@ spec:
         runAsNonRoot: true
       serviceAccountName: authorino-operator
       terminationGracePeriodSeconds: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: authorino
+    authorino-component: authorino-webhooks
+  name: authorino-webhooks
+  namespace: authorino-operator
+spec:
+  selector:
+    matchLabels:
+      app: authorino
+      authorino-component: authorino-webhooks
+  template:
+    metadata:
+      labels:
+        app: authorino
+        authorino-component: authorino-webhooks
+    spec:
+      containers:
+      - command:
+        - authorino
+        - webhooks
+        image: quay.io/kuadrant/authorino:latest
+        name: webhooks
+        ports:
+        - containerPort: 9443
+          name: webhooks
+        - containerPort: 8080
+          name: metrics
+        - containerPort: 8081
+          name: healthz
+        resources: {}
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: authorino-webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: authorino
+    authorino-component: authorino-webhooks
+  name: authorino-webhook-server-cert
+  namespace: authorino-operator
+spec:
+  dnsNames:
+  - authorino-webhooks.authorino-operator.svc
+  - authorino-webhooks.authorino-operator.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: authorino-webhooks-ca
+  secretName: authorino-webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app: authorino
+    authorino-component: authorino-webhooks
+  name: authorino-webhooks-ca
+  namespace: authorino-operator
+spec:
+  selfSigned: {}

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -349,7 +349,6 @@ spec:
                               required:
                               - operator
                               - selector
-                              - value
                             properties:
                               operator:
                                 description: 'The binary operator to be applied to
@@ -709,7 +708,6 @@ spec:
                           required:
                           - operator
                           - selector
-                          - value
                         properties:
                           operator:
                             description: 'The binary operator to be applied to the
@@ -1602,7 +1600,6 @@ spec:
                           required:
                           - operator
                           - selector
-                          - value
                         properties:
                           operator:
                             description: 'The binary operator to be applied to the
@@ -1990,7 +1987,6 @@ spec:
                           required:
                           - operator
                           - selector
-                          - value
                         properties:
                           operator:
                             description: 'The binary operator to be applied to the
@@ -2217,7 +2213,6 @@ spec:
                           required:
                           - operator
                           - selector
-                          - value
                         properties:
                           operator:
                             description: 'The binary operator to be applied to the
@@ -2362,7 +2357,6 @@ spec:
                     required:
                     - operator
                     - selector
-                    - value
                   properties:
                     operator:
                       description: 'The binary operator to be applied to the content
@@ -2482,6 +2476,2624 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Ready for all hosts
+      jsonPath: .status.summary.ready
+      name: Ready
+      type: string
+    - description: Number of hosts ready
+      jsonPath: .status.summary.numHostsReady
+      name: Hosts
+      type: string
+    - description: Number of trusted identity sources
+      jsonPath: .status.summary.numIdentitySources
+      name: Authentication
+      priority: 2
+      type: integer
+    - description: Number of external metadata sources
+      jsonPath: .status.summary.numMetadataSources
+      name: Metadata
+      priority: 2
+      type: integer
+    - description: Number of authorization policies
+      jsonPath: .status.summary.numAuthorizationPolicies
+      name: Authorization
+      priority: 2
+      type: integer
+    - description: Number of items added to the authorization response
+      jsonPath: .status.summary.numResponseItems
+      name: Response
+      priority: 2
+      type: integer
+    - description: Whether issuing Festival Wristbands
+      jsonPath: .status.summary.festivalWristbandEnabled
+      name: Wristband
+      priority: 2
+      type: boolean
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: AuthConfig is the schema for Authorino's AuthConfig API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specifies the desired state of the AuthConfig resource, i.e.
+              the authencation/authorization scheme to be applied to protect the matching
+              service hosts.
+            properties:
+              authentication:
+                additionalProperties:
+                  oneOf:
+                  - properties:
+                      credentials: {}
+                      oauth2Introspection: {}
+                    required:
+                    - oauth2Introspection
+                  - properties:
+                      credentials: {}
+                      jwt: {}
+                    required:
+                    - jwt
+                  - properties:
+                      apiKey: {}
+                      credentials: {}
+                    required:
+                    - apiKey
+                  - properties:
+                      credentials: {}
+                      x509: {}
+                    required:
+                    - x509
+                  - properties:
+                      credentials: {}
+                      kubernetesTokenReview: {}
+                    required:
+                    - kubernetesTokenReview
+                  - properties:
+                      anonymous: {}
+                      credentials: {}
+                    required:
+                    - anonymous
+                  - properties:
+                      credentials: {}
+                      plain: {}
+                    required:
+                    - plain
+                  properties:
+                    anonymous:
+                      description: Anonymous access.
+                      type: object
+                    apiKey:
+                      description: Authentication based on API keys stored in Kubernetes
+                        secrets.
+                      properties:
+                        allNamespaces:
+                          default: false
+                          description: Whether Authorino should look for API key secrets
+                            in all namespaces or only in the same namespace as the
+                            AuthConfig. Enabling this option in namespaced Authorino
+                            instances has no effect.
+                          type: boolean
+                        selector:
+                          description: Label selector used by Authorino to match secrets
+                            from the cluster storing valid credentials to authenticate
+                            to this service
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - selector
+                      type: object
+                    cache:
+                      description: Caching options for the resolved object returned
+                        when applying this config. Omit it to avoid caching objects
+                        for this config.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. The
+                            resolved key must be unique within the scope of this particular
+                            config.
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    credentials:
+                      description: Defines where credentials are required to be passed
+                        in the request for authentication based on this config. If
+                        omitted, it defaults to credentials passed in the HTTP Authorization
+                        header and the "Bearer" prefix prepended to the secret credential
+                        value.
+                      properties:
+                        authorizationHeader:
+                          properties:
+                            prefix:
+                              type: string
+                          type: object
+                        cookie:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        customHeader:
+                          properties:
+                            name:
+                              type: string
+                            prefix:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        queryString:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      type: object
+                    defaults:
+                      additionalProperties:
+                        properties:
+                          selector:
+                            description: 'Simple path selector to fetch content from
+                              the authorization JSON (e.g. ''request.method'') or
+                              a string template with variables that resolve to patterns
+                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. The following Authorino custom modifiers are supported:
+                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                              @base64:encode|decode and @strip.'
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      description: Set default property values (claims) for the resolved
+                        identity object, that are set before appending the object
+                        to the authorization JSON. If the property is already present
+                        in the resolved identity object, the default value is ignored.
+                        It requires the resolved identity object to always be a JSON
+                        object. Do not use this option with identity objects of other
+                        JSON types (array, string, etc).
+                      type: object
+                    jwt:
+                      description: Authentication based on JWT tokens.
+                      properties:
+                        issuerUrl:
+                          description: URL of the issuer of the JWT. If `jwksUrl`
+                            is omitted, Authorino will append the path to the OpenID
+                            Connect Well-Known Discovery endpoint (i.e. "/.well-known/openid-configuration")
+                            to this URL, to discover the OIDC configuration where
+                            to obtain the "jkws_uri" claim from. The value must coincide
+                            with the value of  the "iss" (issuer) claim of the discovered
+                            OpenID Connect configuration.
+                          type: string
+                        jwksUrl:
+                          description: URL of the JSON Web Ket Set (JWKS) endpoint.
+                            Use this if the issuer of the JWT tokens is not an OIDC
+                            provider or does not implement OIDC Discovery.
+                          type: string
+                        ttl:
+                          description: Decides how long to wait before refreshing
+                            the JWKS (in seconds). If omitted, Authorino will never
+                            refresh the JWKS.
+                          type: integer
+                      type: object
+                    kubernetesTokenReview:
+                      description: Authentication by Kubernetes token review.
+                      properties:
+                        audiences:
+                          description: The list of audiences (scopes) that must be
+                            claimed in a Kubernetes authentication token supplied
+                            in the request, and reviewed by Authorino. If omitted,
+                            Authorino will review tokens expecting the host name of
+                            the requested protected service amongst the audiences.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
+                    oauth2Introspection:
+                      description: Authentication by OAuth2 token introspection.
+                      properties:
+                        credentialsRef:
+                          description: Reference to a Kubernetes secret in the same
+                            namespace, that stores client credentials to the OAuth2
+                            server.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        endpoint:
+                          description: The full URL of the token introspection endpoint.
+                          type: string
+                        tokenTypeHint:
+                          description: The token type hint for the token introspection.
+                            If omitted, it defaults to "access_token".
+                          type: string
+                      required:
+                      - credentialsRef
+                      - endpoint
+                      type: object
+                    overrides:
+                      additionalProperties:
+                        properties:
+                          selector:
+                            description: 'Simple path selector to fetch content from
+                              the authorization JSON (e.g. ''request.method'') or
+                              a string template with variables that resolve to patterns
+                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. The following Authorino custom modifiers are supported:
+                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                              @base64:encode|decode and @strip.'
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      description: Overrides the resolved identity object by setting
+                        the additional properties (claims) specified in this config,
+                        before appending the object to the authorization JSON. It
+                        requires the resolved identity object to always be a JSON
+                        object. Do not use this option with identity objects of other
+                        JSON types (array, string, etc).
+                      type: object
+                    plain:
+                      description: Identity object extracted from the context. Use
+                        this method when authentication is performed beforehand by
+                        a proxy and the resulting object passed to Authorino as JSON
+                        in the auth request.
+                      properties:
+                        selector:
+                          description: 'Simple path selector to fetch content from
+                            the authorization JSON (e.g. ''request.method'') or a
+                            string template with variables that resolve to patterns
+                            (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
+                            by https://pkg.go.dev/github.com/tidwall/gjson can be
+                            used. The following Authorino custom modifiers are supported:
+                            @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                            @base64:encode|decode and @strip.'
+                          type: string
+                      required:
+                      - selector
+                      type: object
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
+                    when:
+                      description: Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be
+                        enforced; otherwise, the config will be skipped.
+                      items:
+                        oneOf:
+                        - properties:
+                            patternRef: {}
+                          required:
+                          - patternRef
+                        - properties:
+                            operator: {}
+                            selector: {}
+                            value: {}
+                          required:
+                          - operator
+                          - selector
+                        properties:
+                          operator:
+                            description: 'The binary operator to be applied to the
+                              content fetched from the authorization JSON, for comparison
+                              with "value". Possible values are: "eq" (equal to),
+                              "neq" (not equal to), "incl" (includes; for arrays),
+                              "excl" (excludes; for arrays), "matches" (regex)'
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: Path selector to fetch content from the authorization
+                              JSON (e.g. 'request.method'). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. Authorino custom JSON path modifiers are also
+                              supported.
+                            type: string
+                          value:
+                            description: The value of reference for the comparison
+                              with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must
+                              compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                    x509:
+                      description: Authentication based on client X.509 certificates.
+                        The certificates presented by the clients must be signed by
+                        a trusted CA whose certificates are stored in Kubernetes secrets.
+                      properties:
+                        allNamespaces:
+                          default: false
+                          description: Whether Authorino should look for TLS secrets
+                            in all namespaces or only in the same namespace as the
+                            AuthConfig. Enabling this option in namespaced Authorino
+                            instances has no effect.
+                          type: boolean
+                        selector:
+                          description: Label selector used by Authorino to match secrets
+                            from the cluster storing trusted CA certificates to validate
+                            clients trying to authenticate to this service
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - selector
+                      type: object
+                  type: object
+                description: Authentication configs. At least one config MUST evaluate
+                  to a valid identity object for the auth request to be successful.
+                type: object
+              authorization:
+                additionalProperties:
+                  oneOf:
+                  - properties:
+                      opa: {}
+                    required:
+                    - opa
+                  - properties:
+                      patternMatching: {}
+                    required:
+                    - patternMatching
+                  - properties:
+                      kubernetesSubjectAccessReview: {}
+                    required:
+                    - kubernetesSubjectAccessReview
+                  - properties:
+                      spicedb: {}
+                    required:
+                    - spicedb
+                  properties:
+                    cache:
+                      description: Caching options for the resolved object returned
+                        when applying this config. Omit it to avoid caching objects
+                        for this config.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. The
+                            resolved key must be unique within the scope of this particular
+                            config.
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    kubernetesSubjectAccessReview:
+                      description: Authorization by Kubernetes SubjectAccessReview
+                      properties:
+                        groups:
+                          description: Groups the user must be a member of or, if
+                            `user` is omitted, the groups to check for authorization
+                            in the Kubernetes RBAC.
+                          items:
+                            type: string
+                          type: array
+                        resourceAttributes:
+                          description: Use resourceAttributes to check permissions
+                            on Kubernetes resources. If omitted, it performs a non-resource
+                            SubjectAccessReview, with verb and path inferred from
+                            the request.
+                          properties:
+                            group:
+                              description: API group of the resource. Use '*' for
+                                all API groups.
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            name:
+                              description: Resource name Omit it to check for authorization
+                                on all resources of the specified kind.
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            namespace:
+                              description: Namespace where the user must have permissions
+                                on the resource.
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            resource:
+                              description: Resource kind Use '*' for all resource
+                                kinds.
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            subresource:
+                              description: Subresource kind
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            verb:
+                              description: Verb to check for authorization on the
+                                resource. Use '*' for all verbs.
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                        user:
+                          description: User to check for authorization in the Kubernetes
+                            RBAC. Omit it to check for group authorization only.
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
+                    opa:
+                      description: Open Policy Agent (OPA) Rego policy.
+                      properties:
+                        allValues:
+                          default: false
+                          description: Returns the value of all Rego rules in the
+                            virtual document. Values can be read in subsequent evaluators/phases
+                            of the Auth Pipeline. Otherwise, only the default `allow`
+                            rule will be exposed. Returning all Rego rules can affect
+                            performance of OPA policies during reconciliation (policy
+                            precompile) and at runtime.
+                          type: boolean
+                        externalPolicy:
+                          description: External registry of OPA policies.
+                          properties:
+                            body:
+                              description: Raw body of the HTTP request. Supersedes
+                                'bodyParameters'; use either one or the other. Use
+                                it with method=POST; for GET requests, set parameters
+                                as query string in the 'endpoint' (placeholders can
+                                be used).
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            bodyParameters:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: 'Simple path selector to fetch content
+                                      from the authorization JSON (e.g. ''request.method'')
+                                      or a string template with variables that resolve
+                                      to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following Authorino custom
+                                      modifiers are supported: @extract:{sep:" ",pos:0},
+                                      @replace{old:"",new:""}, @case:upper|lower,
+                                      @base64:encode|decode and @strip.'
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: Custom parameters to encode in the body
+                                of the HTTP request. Superseded by 'body'; use either
+                                one or the other. Use it with method=POST; for GET
+                                requests, set parameters as query string in the 'endpoint'
+                                (placeholders can be used).
+                              type: object
+                            contentType:
+                              default: application/x-www-form-urlencoded
+                              description: Content-Type of the request body. Shapes
+                                how 'bodyParameters' are encoded. Use it with method=POST;
+                                for GET requests, Content-Type is automatically set
+                                to 'text/plain'.
+                              enum:
+                              - application/x-www-form-urlencoded
+                              - application/json
+                              type: string
+                            credentials:
+                              description: Defines where client credentials will be
+                                passed in the request to the service. If omitted,
+                                it defaults to client credentials passed in the HTTP
+                                Authorization header and the "Bearer" prefix expected
+                                prepended to the secret value.
+                              properties:
+                                authorizationHeader:
+                                  properties:
+                                    prefix:
+                                      type: string
+                                  type: object
+                                cookie:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                customHeader:
+                                  properties:
+                                    name:
+                                      type: string
+                                    prefix:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                queryString:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                              type: object
+                            headers:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: 'Simple path selector to fetch content
+                                      from the authorization JSON (e.g. ''request.method'')
+                                      or a string template with variables that resolve
+                                      to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following Authorino custom
+                                      modifiers are supported: @extract:{sep:" ",pos:0},
+                                      @replace{old:"",new:""}, @case:upper|lower,
+                                      @base64:encode|decode and @strip.'
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: Custom headers in the HTTP request.
+                              type: object
+                            insecure:
+                              description: Insecure HTTP connection (i.e. disables
+                                TLS verification)
+                              type: boolean
+                            method:
+                              default: GET
+                              description: 'HTTP verb used in the request to the service.
+                                Accepted values: GET (default), POST. When the request
+                                method is POST, the authorization JSON is passed in
+                                the body of the request.'
+                              enum:
+                              - GET
+                              - POST
+                              - PUT
+                              - PATCH
+                              - DELETE
+                              - HEAD
+                              - OPTIONS
+                              - CONNECT
+                              - TRACE
+                              type: string
+                            oauth2:
+                              description: Authentication with the HTTP service by
+                                OAuth2 Client Credentials grant.
+                              properties:
+                                cache:
+                                  default: true
+                                  description: Caches and reuses the token until expired.
+                                    Set it to false to force fetch the token at every
+                                    authorization request regardless of expiration.
+                                  type: boolean
+                                clientId:
+                                  description: OAuth2 Client ID.
+                                  type: string
+                                clientSecretRef:
+                                  description: Reference to a Kuberentes Secret key
+                                    that stores that OAuth2 Client Secret.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: The name of the secret in the Authorino's
+                                        namespace to select from.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                extraParams:
+                                  additionalProperties:
+                                    type: string
+                                  description: Optional extra parameters for the requests
+                                    to the token URL.
+                                  type: object
+                                scopes:
+                                  description: Optional scopes for the client credentials
+                                    grant, if supported by he OAuth2 server.
+                                  items:
+                                    type: string
+                                  type: array
+                                tokenUrl:
+                                  description: Token endpoint URL of the OAuth2 resource
+                                    server.
+                                  type: string
+                              required:
+                              - clientId
+                              - clientSecretRef
+                              - tokenUrl
+                              type: object
+                            sharedSecretRef:
+                              description: Reference to a Secret key whose value will
+                                be passed by Authorino in the request. The HTTP service
+                                can use the shared secret to authenticate the origin
+                                of the request. Ignored if used together with oauth2.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            ttl:
+                              description: Duration (in seconds) of the external data
+                                in the cache before pulled again from the source.
+                              type: integer
+                            url:
+                              description: Endpoint URL of the HTTP service. The value
+                                can include variable placeholders in the format "{selector}",
+                                where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                and selects value from the authorization JSON. E.g.
+                                https://ext-auth-server.io/metadata?p={request.path}
+                              type: string
+                          required:
+                          - url
+                          type: object
+                        rego:
+                          description: Authorization policy as a Rego language document.
+                            The Rego document must include the "allow" condition,
+                            set by Authorino to "false" by default (i.e. requests
+                            are unauthorized unless changed). The Rego document must
+                            NOT include the "package" declaration in line 1.
+                          type: string
+                      type: object
+                    patternMatching:
+                      description: Pattern-matching authorization rules.
+                      properties:
+                        patterns:
+                          items:
+                            oneOf:
+                            - properties:
+                                patternRef: {}
+                              required:
+                              - patternRef
+                            - properties:
+                                operator: {}
+                                selector: {}
+                                value: {}
+                              required:
+                              - operator
+                              - selector
+                            properties:
+                              operator:
+                                description: 'The binary operator to be applied to
+                                  the content fetched from the authorization JSON,
+                                  for comparison with "value". Possible values are:
+                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
+                                  for arrays), "excl" (excludes; for arrays), "matches"
+                                  (regex)'
+                                enum:
+                                - eq
+                                - neq
+                                - incl
+                                - excl
+                                - matches
+                                type: string
+                              patternRef:
+                                description: Reference to a named set of pattern expressions
+                                type: string
+                              selector:
+                                description: Path selector to fetch content from the
+                                  authorization JSON (e.g. 'request.method'). Any
+                                  pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. Authorino custom JSON path modifiers
+                                  are also supported.
+                                type: string
+                              value:
+                                description: The value of reference for the comparison
+                                  with the content fetched from the authorization
+                                  JSON. If used with the "matches" operator, the value
+                                  must compile to a valid Golang regex.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - patterns
+                      type: object
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
+                    spicedb:
+                      description: Authorization decision delegated to external Authzed/SpiceDB
+                        server.
+                      properties:
+                        endpoint:
+                          description: Hostname and port number to the GRPC interface
+                            of the SpiceDB server (e.g. spicedb:50051).
+                          type: string
+                        insecure:
+                          description: Insecure HTTP connection (i.e. disables TLS
+                            verification)
+                          type: boolean
+                        permission:
+                          description: The name of the permission (or relation) on
+                            which to execute the check.
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        resource:
+                          description: The resource on which to check the permission
+                            or relation.
+                          properties:
+                            kind:
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            name:
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                        sharedSecretRef:
+                          description: Reference to a Secret key whose value will
+                            be used by Authorino to authenticate with the Authzed
+                            service.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        subject:
+                          description: The subject that will be checked for the permission
+                            or relation.
+                          properties:
+                            kind:
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            name:
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                      required:
+                      - endpoint
+                      type: object
+                    when:
+                      description: Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be
+                        enforced; otherwise, the config will be skipped.
+                      items:
+                        oneOf:
+                        - properties:
+                            patternRef: {}
+                          required:
+                          - patternRef
+                        - properties:
+                            operator: {}
+                            selector: {}
+                            value: {}
+                          required:
+                          - operator
+                          - selector
+                        properties:
+                          operator:
+                            description: 'The binary operator to be applied to the
+                              content fetched from the authorization JSON, for comparison
+                              with "value". Possible values are: "eq" (equal to),
+                              "neq" (not equal to), "incl" (includes; for arrays),
+                              "excl" (excludes; for arrays), "matches" (regex)'
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: Path selector to fetch content from the authorization
+                              JSON (e.g. 'request.method'). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. Authorino custom JSON path modifiers are also
+                              supported.
+                            type: string
+                          value:
+                            description: The value of reference for the comparison
+                              with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must
+                              compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                description: Authorization policies. All policies MUST evaluate to
+                  "allowed = true" for the auth request be successful.
+                type: object
+              callbacks:
+                additionalProperties:
+                  properties:
+                    cache:
+                      description: Caching options for the resolved object returned
+                        when applying this config. Omit it to avoid caching objects
+                        for this config.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. The
+                            resolved key must be unique within the scope of this particular
+                            config.
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    http:
+                      description: Settings of the external HTTP request
+                      properties:
+                        body:
+                          description: Raw body of the HTTP request. Supersedes 'bodyParameters';
+                            use either one or the other. Use it with method=POST;
+                            for GET requests, set parameters as query string in the
+                            'endpoint' (placeholders can be used).
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        bodyParameters:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: 'Simple path selector to fetch content
+                                  from the authorization JSON (e.g. ''request.method'')
+                                  or a string template with variables that resolve
+                                  to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following Authorino custom modifiers
+                                  are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: Custom parameters to encode in the body of
+                            the HTTP request. Superseded by 'body'; use either one
+                            or the other. Use it with method=POST; for GET requests,
+                            set parameters as query string in the 'endpoint' (placeholders
+                            can be used).
+                          type: object
+                        contentType:
+                          default: application/x-www-form-urlencoded
+                          description: Content-Type of the request body. Shapes how
+                            'bodyParameters' are encoded. Use it with method=POST;
+                            for GET requests, Content-Type is automatically set to
+                            'text/plain'.
+                          enum:
+                          - application/x-www-form-urlencoded
+                          - application/json
+                          type: string
+                        credentials:
+                          description: Defines where client credentials will be passed
+                            in the request to the service. If omitted, it defaults
+                            to client credentials passed in the HTTP Authorization
+                            header and the "Bearer" prefix expected prepended to the
+                            secret value.
+                          properties:
+                            authorizationHeader:
+                              properties:
+                                prefix:
+                                  type: string
+                              type: object
+                            cookie:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            customHeader:
+                              properties:
+                                name:
+                                  type: string
+                                prefix:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            queryString:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          type: object
+                        headers:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: 'Simple path selector to fetch content
+                                  from the authorization JSON (e.g. ''request.method'')
+                                  or a string template with variables that resolve
+                                  to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following Authorino custom modifiers
+                                  are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: Custom headers in the HTTP request.
+                          type: object
+                        insecure:
+                          description: Insecure HTTP connection (i.e. disables TLS
+                            verification)
+                          type: boolean
+                        method:
+                          default: GET
+                          description: 'HTTP verb used in the request to the service.
+                            Accepted values: GET (default), POST. When the request
+                            method is POST, the authorization JSON is passed in the
+                            body of the request.'
+                          enum:
+                          - GET
+                          - POST
+                          - PUT
+                          - PATCH
+                          - DELETE
+                          - HEAD
+                          - OPTIONS
+                          - CONNECT
+                          - TRACE
+                          type: string
+                        oauth2:
+                          description: Authentication with the HTTP service by OAuth2
+                            Client Credentials grant.
+                          properties:
+                            cache:
+                              default: true
+                              description: Caches and reuses the token until expired.
+                                Set it to false to force fetch the token at every
+                                authorization request regardless of expiration.
+                              type: boolean
+                            clientId:
+                              description: OAuth2 Client ID.
+                              type: string
+                            clientSecretRef:
+                              description: Reference to a Kuberentes Secret key that
+                                stores that OAuth2 Client Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            extraParams:
+                              additionalProperties:
+                                type: string
+                              description: Optional extra parameters for the requests
+                                to the token URL.
+                              type: object
+                            scopes:
+                              description: Optional scopes for the client credentials
+                                grant, if supported by he OAuth2 server.
+                              items:
+                                type: string
+                              type: array
+                            tokenUrl:
+                              description: Token endpoint URL of the OAuth2 resource
+                                server.
+                              type: string
+                          required:
+                          - clientId
+                          - clientSecretRef
+                          - tokenUrl
+                          type: object
+                        sharedSecretRef:
+                          description: Reference to a Secret key whose value will
+                            be passed by Authorino in the request. The HTTP service
+                            can use the shared secret to authenticate the origin of
+                            the request. Ignored if used together with oauth2.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        url:
+                          description: Endpoint URL of the HTTP service. The value
+                            can include variable placeholders in the format "{selector}",
+                            where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                            and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={request.path}
+                          type: string
+                      required:
+                      - url
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
+                    when:
+                      description: Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be
+                        enforced; otherwise, the config will be skipped.
+                      items:
+                        properties:
+                          operator:
+                            description: 'The binary operator to be applied to the
+                              content fetched from the authorization JSON, for comparison
+                              with "value". Possible values are: "eq" (equal to),
+                              "neq" (not equal to), "incl" (includes; for arrays),
+                              "excl" (excludes; for arrays), "matches" (regex)'
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: Path selector to fetch content from the authorization
+                              JSON (e.g. 'request.method'). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. Authorino custom JSON path modifiers are also
+                              supported.
+                            type: string
+                          value:
+                            description: The value of reference for the comparison
+                              with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must
+                              compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - http
+                  type: object
+                description: Callback functions. Authorino sends callbacks at the
+                  end of the auth pipeline to the endpoints specified in this config.
+                type: object
+              hosts:
+                description: The list of public host names of the services protected
+                  by this authentication/authorization scheme. Authorino uses the
+                  requested host to lookup for the corresponding authentication/authorization
+                  configs to enforce.
+                items:
+                  type: string
+                type: array
+              metadata:
+                additionalProperties:
+                  oneOf:
+                  - properties:
+                      userInfo: {}
+                    required:
+                    - userInfo
+                  - properties:
+                      uma: {}
+                    required:
+                    - uma
+                  - properties:
+                      http: {}
+                    required:
+                    - http
+                  properties:
+                    cache:
+                      description: Caching options for the resolved object returned
+                        when applying this config. Omit it to avoid caching objects
+                        for this config.
+                      properties:
+                        key:
+                          description: Key used to store the entry in the cache. The
+                            resolved key must be unique within the scope of this particular
+                            config.
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    http:
+                      description: External source of auth metadata via HTTP request
+                      properties:
+                        body:
+                          description: Raw body of the HTTP request. Supersedes 'bodyParameters';
+                            use either one or the other. Use it with method=POST;
+                            for GET requests, set parameters as query string in the
+                            'endpoint' (placeholders can be used).
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        bodyParameters:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: 'Simple path selector to fetch content
+                                  from the authorization JSON (e.g. ''request.method'')
+                                  or a string template with variables that resolve
+                                  to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following Authorino custom modifiers
+                                  are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: Custom parameters to encode in the body of
+                            the HTTP request. Superseded by 'body'; use either one
+                            or the other. Use it with method=POST; for GET requests,
+                            set parameters as query string in the 'endpoint' (placeholders
+                            can be used).
+                          type: object
+                        contentType:
+                          default: application/x-www-form-urlencoded
+                          description: Content-Type of the request body. Shapes how
+                            'bodyParameters' are encoded. Use it with method=POST;
+                            for GET requests, Content-Type is automatically set to
+                            'text/plain'.
+                          enum:
+                          - application/x-www-form-urlencoded
+                          - application/json
+                          type: string
+                        credentials:
+                          description: Defines where client credentials will be passed
+                            in the request to the service. If omitted, it defaults
+                            to client credentials passed in the HTTP Authorization
+                            header and the "Bearer" prefix expected prepended to the
+                            secret value.
+                          properties:
+                            authorizationHeader:
+                              properties:
+                                prefix:
+                                  type: string
+                              type: object
+                            cookie:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            customHeader:
+                              properties:
+                                name:
+                                  type: string
+                                prefix:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            queryString:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          type: object
+                        headers:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: 'Simple path selector to fetch content
+                                  from the authorization JSON (e.g. ''request.method'')
+                                  or a string template with variables that resolve
+                                  to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                  can be used. The following Authorino custom modifiers
+                                  are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                  @case:upper|lower, @base64:encode|decode and @strip.'
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: Custom headers in the HTTP request.
+                          type: object
+                        insecure:
+                          description: Insecure HTTP connection (i.e. disables TLS
+                            verification)
+                          type: boolean
+                        method:
+                          default: GET
+                          description: 'HTTP verb used in the request to the service.
+                            Accepted values: GET (default), POST. When the request
+                            method is POST, the authorization JSON is passed in the
+                            body of the request.'
+                          enum:
+                          - GET
+                          - POST
+                          - PUT
+                          - PATCH
+                          - DELETE
+                          - HEAD
+                          - OPTIONS
+                          - CONNECT
+                          - TRACE
+                          type: string
+                        oauth2:
+                          description: Authentication with the HTTP service by OAuth2
+                            Client Credentials grant.
+                          properties:
+                            cache:
+                              default: true
+                              description: Caches and reuses the token until expired.
+                                Set it to false to force fetch the token at every
+                                authorization request regardless of expiration.
+                              type: boolean
+                            clientId:
+                              description: OAuth2 Client ID.
+                              type: string
+                            clientSecretRef:
+                              description: Reference to a Kuberentes Secret key that
+                                stores that OAuth2 Client Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            extraParams:
+                              additionalProperties:
+                                type: string
+                              description: Optional extra parameters for the requests
+                                to the token URL.
+                              type: object
+                            scopes:
+                              description: Optional scopes for the client credentials
+                                grant, if supported by he OAuth2 server.
+                              items:
+                                type: string
+                              type: array
+                            tokenUrl:
+                              description: Token endpoint URL of the OAuth2 resource
+                                server.
+                              type: string
+                          required:
+                          - clientId
+                          - clientSecretRef
+                          - tokenUrl
+                          type: object
+                        sharedSecretRef:
+                          description: Reference to a Secret key whose value will
+                            be passed by Authorino in the request. The HTTP service
+                            can use the shared secret to authenticate the origin of
+                            the request. Ignored if used together with oauth2.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        url:
+                          description: Endpoint URL of the HTTP service. The value
+                            can include variable placeholders in the format "{selector}",
+                            where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                            and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={request.path}
+                          type: string
+                      required:
+                      - url
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
+                    priority:
+                      default: 0
+                      description: Priority group of the config. All configs in the
+                        same priority group are evaluated concurrently; consecutive
+                        priority groups are evaluated sequentially.
+                      type: integer
+                    uma:
+                      description: User-Managed Access (UMA) source of resource data.
+                      properties:
+                        credentialsRef:
+                          description: Reference to a Kubernetes secret in the same
+                            namespace, that stores client credentials to the resource
+                            registration API of the UMA server.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        endpoint:
+                          description: The endpoint of the UMA server. The value must
+                            coincide with the "issuer" claim of the UMA config discovered
+                            from the well-known uma configuration endpoint.
+                          type: string
+                      required:
+                      - credentialsRef
+                      - endpoint
+                      type: object
+                    userInfo:
+                      description: OpendID Connect UserInfo linked to an OIDC authentication
+                        config specified in this same AuthConfig.
+                      properties:
+                        identitySource:
+                          description: The name of an OIDC-enabled JWT authentication
+                            config whose OpenID Connect configuration discovered includes
+                            the OIDC "userinfo_endpoint" claim.
+                          type: string
+                      required:
+                      - identitySource
+                      type: object
+                    when:
+                      description: Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be
+                        enforced; otherwise, the config will be skipped.
+                      items:
+                        oneOf:
+                        - properties:
+                            patternRef: {}
+                          required:
+                          - patternRef
+                        - properties:
+                            operator: {}
+                            selector: {}
+                            value: {}
+                          required:
+                          - operator
+                          - selector
+                        properties:
+                          operator:
+                            description: 'The binary operator to be applied to the
+                              content fetched from the authorization JSON, for comparison
+                              with "value". Possible values are: "eq" (equal to),
+                              "neq" (not equal to), "incl" (includes; for arrays),
+                              "excl" (excludes; for arrays), "matches" (regex)'
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: Path selector to fetch content from the authorization
+                              JSON (e.g. 'request.method'). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. Authorino custom JSON path modifiers are also
+                              supported.
+                            type: string
+                          value:
+                            description: The value of reference for the comparison
+                              with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must
+                              compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                description: Metadata sources. Authorino fetches auth metadata as
+                  JSON from sources specified in this config.
+                type: object
+              patterns:
+                additionalProperties:
+                  items:
+                    properties:
+                      operator:
+                        description: 'The binary operator to be applied to the content
+                          fetched from the authorization JSON, for comparison with
+                          "value". Possible values are: "eq" (equal to), "neq" (not
+                          equal to), "incl" (includes; for arrays), "excl" (excludes;
+                          for arrays), "matches" (regex)'
+                        enum:
+                        - eq
+                        - neq
+                        - incl
+                        - excl
+                        - matches
+                        type: string
+                      selector:
+                        description: Path selector to fetch content from the authorization
+                          JSON (e.g. 'request.method'). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                          can be used. Authorino custom JSON path modifiers are also
+                          supported.
+                        type: string
+                      value:
+                        description: The value of reference for the comparison with
+                          the content fetched from the authorization JSON. If used
+                          with the "matches" operator, the value must compile to a
+                          valid Golang regex.
+                        type: string
+                    type: object
+                  type: array
+                description: Named sets of patterns that can be referred in `when`
+                  conditions and in pattern-matching authorization policy rules.
+                type: object
+              response:
+                description: Response items. Authorino builds custom responses to
+                  the client of the auth request.
+                properties:
+                  success:
+                    description: Response items to be included in the auth response
+                      when the request is authenticated and authorized. For integration
+                      of Authorino via proxy, the proxy must use these settings to
+                      propagate dynamic metadata and/or inject data in the request.
+                    properties:
+                      dynamicMetadata:
+                        additionalProperties:
+                          description: Settings of the success custom response item.
+                          oneOf:
+                          - properties:
+                              wristband: {}
+                            required:
+                            - wristband
+                          - properties:
+                              json: {}
+                            required:
+                            - json
+                          - properties:
+                              plain: {}
+                            required:
+                            - plain
+                          properties:
+                            cache:
+                              description: Caching options for the resolved object
+                                returned when applying this config. Omit it to avoid
+                                caching objects for this config.
+                              properties:
+                                key:
+                                  description: Key used to store the entry in the
+                                    cache. The resolved key must be unique within
+                                    the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: 'Simple path selector to fetch
+                                        content from the authorization JSON (e.g.
+                                        ''request.method'') or a string template with
+                                        variables that resolve to patterns (e.g. "Hello,
+                                        {auth.identity.name}!"). Any pattern supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following Authorino custom
+                                        modifiers are supported: @extract:{sep:" ",pos:0},
+                                        @replace{old:"",new:""}, @case:upper|lower,
+                                        @base64:encode|decode and @strip.'
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            json:
+                              description: JSON object Specify it as the list of properties
+                                of the object, whose values can combine static values
+                                and values selected from the authorization JSON.
+                              properties:
+                                properties:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: 'Simple path selector to fetch
+                                          content from the authorization JSON (e.g.
+                                          ''request.method'') or a string template
+                                          with variables that resolve to patterns
+                                          (e.g. "Hello, {auth.identity.name}!"). Any
+                                          pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                          can be used. The following Authorino custom
+                                          modifiers are supported: @extract:{sep:"
+                                          ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                                          @base64:encode|decode and @strip.'
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: object
+                              required:
+                              - properties
+                              type: object
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            plain:
+                              description: Plain text content
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            priority:
+                              default: 0
+                              description: Priority group of the config. All configs
+                                in the same priority group are evaluated concurrently;
+                                consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            when:
+                              description: Conditions for Authorino to enforce this
+                                config. If omitted, the config will be enforced for
+                                all requests. If present, all conditions must match
+                                for the config to be enforced; otherwise, the config
+                                will be skipped.
+                              items:
+                                oneOf:
+                                - properties:
+                                    patternRef: {}
+                                  required:
+                                  - patternRef
+                                - properties:
+                                    operator: {}
+                                    selector: {}
+                                    value: {}
+                                  required:
+                                  - operator
+                                  - selector
+                                properties:
+                                  operator:
+                                    description: 'The binary operator to be applied
+                                      to the content fetched from the authorization
+                                      JSON, for comparison with "value". Possible
+                                      values are: "eq" (equal to), "neq" (not equal
+                                      to), "incl" (includes; for arrays), "excl" (excludes;
+                                      for arrays), "matches" (regex)'
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: Path selector to fetch content from
+                                      the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. Authorino custom JSON path modifiers
+                                      are also supported.
+                                    type: string
+                                  value:
+                                    description: The value of reference for the comparison
+                                      with the content fetched from the authorization
+                                      JSON. If used with the "matches" operator, the
+                                      value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                            wristband:
+                              description: Authorino Festival Wristband token
+                              properties:
+                                customClaims:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: 'Simple path selector to fetch
+                                          content from the authorization JSON (e.g.
+                                          ''request.method'') or a string template
+                                          with variables that resolve to patterns
+                                          (e.g. "Hello, {auth.identity.name}!"). Any
+                                          pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                          can be used. The following Authorino custom
+                                          modifiers are supported: @extract:{sep:"
+                                          ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                                          @base64:encode|decode and @strip.'
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Any claims to be added to the wristband
+                                    token apart from the standard JWT claims (iss,
+                                    iat, exp) added by default.
+                                  type: object
+                                issuer:
+                                  description: 'The endpoint to the Authorino service
+                                    that issues the wristband (format: <scheme>://<host>:<port>/<realm>,
+                                    where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                  type: string
+                                signingKeyRefs:
+                                  description: Reference by name to Kubernetes secrets
+                                    and corresponding signing algorithms. The secrets
+                                    must contain a `key.pem` entry whose value is
+                                    the signing key formatted as PEM.
+                                  items:
+                                    properties:
+                                      algorithm:
+                                        description: Algorithm to sign the wristband
+                                          token using the signing key provided
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - ES512
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      name:
+                                        description: Name of the signing key. The
+                                          value is used to reference the Kubernetes
+                                          secret that stores the key and in the `kid`
+                                          claim of the wristband token header.
+                                        type: string
+                                    required:
+                                    - algorithm
+                                    - name
+                                    type: object
+                                  type: array
+                                tokenDuration:
+                                  description: Time span of the wristband token, in
+                                    seconds.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - issuer
+                              - signingKeyRefs
+                              type: object
+                          type: object
+                        description: Custom success response items wrapped as HTTP
+                          headers. For integration of Authorino via proxy, the proxy
+                          must use these settings to propagate dynamic metadata. See
+                          https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata
+                        type: object
+                      headers:
+                        additionalProperties:
+                          oneOf:
+                          - properties:
+                              wristband: {}
+                            required:
+                            - wristband
+                          - properties:
+                              json: {}
+                            required:
+                            - json
+                          - properties:
+                              plain: {}
+                            required:
+                            - plain
+                          properties:
+                            cache:
+                              description: Caching options for the resolved object
+                                returned when applying this config. Omit it to avoid
+                                caching objects for this config.
+                              properties:
+                                key:
+                                  description: Key used to store the entry in the
+                                    cache. The resolved key must be unique within
+                                    the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: 'Simple path selector to fetch
+                                        content from the authorization JSON (e.g.
+                                        ''request.method'') or a string template with
+                                        variables that resolve to patterns (e.g. "Hello,
+                                        {auth.identity.name}!"). Any pattern supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following Authorino custom
+                                        modifiers are supported: @extract:{sep:" ",pos:0},
+                                        @replace{old:"",new:""}, @case:upper|lower,
+                                        @base64:encode|decode and @strip.'
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            json:
+                              description: JSON object Specify it as the list of properties
+                                of the object, whose values can combine static values
+                                and values selected from the authorization JSON.
+                              properties:
+                                properties:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: 'Simple path selector to fetch
+                                          content from the authorization JSON (e.g.
+                                          ''request.method'') or a string template
+                                          with variables that resolve to patterns
+                                          (e.g. "Hello, {auth.identity.name}!"). Any
+                                          pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                          can be used. The following Authorino custom
+                                          modifiers are supported: @extract:{sep:"
+                                          ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                                          @base64:encode|decode and @strip.'
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: object
+                              required:
+                              - properties
+                              type: object
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            plain:
+                              description: Plain text content
+                              properties:
+                                selector:
+                                  description: 'Simple path selector to fetch content
+                                    from the authorization JSON (e.g. ''request.method'')
+                                    or a string template with variables that resolve
+                                    to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                    can be used. The following Authorino custom modifiers
+                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            prefix:
+                              description: Prefix of the value to be added to the
+                                HTTP header
+                              type: string
+                            priority:
+                              default: 0
+                              description: Priority group of the config. All configs
+                                in the same priority group are evaluated concurrently;
+                                consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            when:
+                              description: Conditions for Authorino to enforce this
+                                config. If omitted, the config will be enforced for
+                                all requests. If present, all conditions must match
+                                for the config to be enforced; otherwise, the config
+                                will be skipped.
+                              items:
+                                oneOf:
+                                - properties:
+                                    patternRef: {}
+                                  required:
+                                  - patternRef
+                                - properties:
+                                    operator: {}
+                                    selector: {}
+                                    value: {}
+                                  required:
+                                  - operator
+                                  - selector
+                                properties:
+                                  operator:
+                                    description: 'The binary operator to be applied
+                                      to the content fetched from the authorization
+                                      JSON, for comparison with "value". Possible
+                                      values are: "eq" (equal to), "neq" (not equal
+                                      to), "incl" (includes; for arrays), "excl" (excludes;
+                                      for arrays), "matches" (regex)'
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: Path selector to fetch content from
+                                      the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. Authorino custom JSON path modifiers
+                                      are also supported.
+                                    type: string
+                                  value:
+                                    description: The value of reference for the comparison
+                                      with the content fetched from the authorization
+                                      JSON. If used with the "matches" operator, the
+                                      value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                            wristband:
+                              description: Authorino Festival Wristband token
+                              properties:
+                                customClaims:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: 'Simple path selector to fetch
+                                          content from the authorization JSON (e.g.
+                                          ''request.method'') or a string template
+                                          with variables that resolve to patterns
+                                          (e.g. "Hello, {auth.identity.name}!"). Any
+                                          pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                          can be used. The following Authorino custom
+                                          modifiers are supported: @extract:{sep:"
+                                          ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                                          @base64:encode|decode and @strip.'
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Any claims to be added to the wristband
+                                    token apart from the standard JWT claims (iss,
+                                    iat, exp) added by default.
+                                  type: object
+                                issuer:
+                                  description: 'The endpoint to the Authorino service
+                                    that issues the wristband (format: <scheme>://<host>:<port>/<realm>,
+                                    where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                  type: string
+                                signingKeyRefs:
+                                  description: Reference by name to Kubernetes secrets
+                                    and corresponding signing algorithms. The secrets
+                                    must contain a `key.pem` entry whose value is
+                                    the signing key formatted as PEM.
+                                  items:
+                                    properties:
+                                      algorithm:
+                                        description: Algorithm to sign the wristband
+                                          token using the signing key provided
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - ES512
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      name:
+                                        description: Name of the signing key. The
+                                          value is used to reference the Kubernetes
+                                          secret that stores the key and in the `kid`
+                                          claim of the wristband token header.
+                                        type: string
+                                    required:
+                                    - algorithm
+                                    - name
+                                    type: object
+                                  type: array
+                                tokenDuration:
+                                  description: Time span of the wristband token, in
+                                    seconds.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - issuer
+                              - signingKeyRefs
+                              type: object
+                          type: object
+                        description: Custom success response items wrapped as HTTP
+                          headers. For integration of Authorino via proxy, the proxy
+                          must use these settings to inject data in the request.
+                        type: object
+                    type: object
+                  unauthenticated:
+                    description: 'Customizations on the denial status attributes when
+                      the request is unauthenticated. For integration of Authorino
+                      via proxy, the proxy must honour the response status attributes
+                      specified in this config. Default: 401 Unauthorized'
+                    properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          selector:
+                            description: 'Simple path selector to fetch content from
+                              the authorization JSON (e.g. ''request.method'') or
+                              a string template with variables that resolve to patterns
+                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. The following Authorino custom modifiers are supported:
+                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                              @base64:encode|decode and @strip.'
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      code:
+                        description: HTTP status code to override the default denial
+                          status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        additionalProperties:
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        description: HTTP response headers to override the default
+                          denial headers.
+                        type: object
+                      message:
+                        description: HTTP message to override the default denial message.
+                        properties:
+                          selector:
+                            description: 'Simple path selector to fetch content from
+                              the authorization JSON (e.g. ''request.method'') or
+                              a string template with variables that resolve to patterns
+                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. The following Authorino custom modifiers are supported:
+                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                              @base64:encode|decode and @strip.'
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                  unauthorized:
+                    description: 'Customizations on the denial status attributes when
+                      the request is unauthorized. For integration of Authorino via
+                      proxy, the proxy must honour the response status attributes
+                      specified in this config. Default: 403 Forbidden'
+                    properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          selector:
+                            description: 'Simple path selector to fetch content from
+                              the authorization JSON (e.g. ''request.method'') or
+                              a string template with variables that resolve to patterns
+                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. The following Authorino custom modifiers are supported:
+                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                              @base64:encode|decode and @strip.'
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      code:
+                        description: HTTP status code to override the default denial
+                          status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        additionalProperties:
+                          properties:
+                            selector:
+                              description: 'Simple path selector to fetch content
+                                from the authorization JSON (e.g. ''request.method'')
+                                or a string template with variables that resolve to
+                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
+                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                can be used. The following Authorino custom modifiers
+                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        description: HTTP response headers to override the default
+                          denial headers.
+                        type: object
+                      message:
+                        description: HTTP message to override the default denial message.
+                        properties:
+                          selector:
+                            description: 'Simple path selector to fetch content from
+                              the authorization JSON (e.g. ''request.method'') or
+                              a string template with variables that resolve to patterns
+                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
+                              by https://pkg.go.dev/github.com/tidwall/gjson can be
+                              used. The following Authorino custom modifiers are supported:
+                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
+                              @base64:encode|decode and @strip.'
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                type: object
+              when:
+                description: Overall conditions for the AuthConfig to be enforced.
+                  If omitted, the AuthConfig will be enforced at all requests. If
+                  present, all conditions must match for the AuthConfig to be enforced;
+                  otherwise, Authorino skips the AuthConfig and returns to the auth
+                  request with status OK.
+                items:
+                  oneOf:
+                  - properties:
+                      patternRef: {}
+                    required:
+                    - patternRef
+                  - properties:
+                      operator: {}
+                      selector: {}
+                      value: {}
+                    required:
+                    - operator
+                    - selector
+                  properties:
+                    operator:
+                      description: 'The binary operator to be applied to the content
+                        fetched from the authorization JSON, for comparison with "value".
+                        Possible values are: "eq" (equal to), "neq" (not equal to),
+                        "incl" (includes; for arrays), "excl" (excludes; for arrays),
+                        "matches" (regex)'
+                      enum:
+                      - eq
+                      - neq
+                      - incl
+                      - excl
+                      - matches
+                      type: string
+                    patternRef:
+                      description: Reference to a named set of pattern expressions
+                      type: string
+                    selector:
+                      description: Path selector to fetch content from the authorization
+                        JSON (e.g. 'request.method'). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                        can be used. Authorino custom JSON path modifiers are also
+                        supported.
+                      type: string
+                    value:
+                      description: The value of reference for the comparison with
+                        the content fetched from the authorization JSON. If used with
+                        the "matches" operator, the value must compile to a valid
+                        Golang regex.
+                      type: string
+                  type: object
+                type: array
+            required:
+            - hosts
+            type: object
+          status:
+            description: AuthConfigStatus defines the observed state of AuthConfig
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transit from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdatedTime:
+                      description: Last time the condition was updated
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: (brief) reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              summary:
+                properties:
+                  festivalWristbandEnabled:
+                    description: Indicator of whether the AuthConfig issues Festival
+                      Wristband tokens on successful evaluation of the AuthConfig
+                      (access granted)
+                    type: boolean
+                  hostsReady:
+                    description: Lists the hosts from spec.hosts linked to the resource
+                      in the index
+                    items:
+                      type: string
+                    type: array
+                  numAuthorizationPolicies:
+                    description: Number of authorization policies in the AuthConfig
+                    format: int64
+                    type: integer
+                  numHostsReady:
+                    description: Number of hosts from spec.hosts linked to the resource
+                      in the index, compared to the total number of hosts in spec.hosts
+                    type: string
+                  numIdentitySources:
+                    description: Number of trusted sources of identity for authentication
+                      in the AuthConfig
+                    format: int64
+                    type: integer
+                  numMetadataSources:
+                    description: Number of sources of external metadata in the AuthConfig
+                    format: int64
+                    type: integer
+                  numResponseItems:
+                    description: Number of custom authorization response items in
+                      the AuthConfig
+                    format: int64
+                    type: integer
+                  ready:
+                    description: Whether all hosts from spec.hosts have been linked
+                      to the resource in the index
+                    type: boolean
+                required:
+                - festivalWristbandEnabled
+                - hostsReady
+                - numAuthorizationPolicies
+                - numHostsReady
+                - numIdentitySources
+                - numMetadataSources
+                - numResponseItems
+                - ready
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
     subresources:
       status: {}
 ---

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -2257,6 +2257,8 @@ spec:
                       description: The name of key used in the wrapped response (name
                         of the HTTP header or property of the Envoy Dynamic Metadata
                         JSON). If omitted, it will be set to the name of the configuration.
+                        [DEPRECATED] Starting in v1beta2, use the name of the response
+                        config instead.
                       type: string
                     wristband:
                       properties:
@@ -2692,8 +2694,6 @@ spec:
                           properties:
                             name:
                               type: string
-                            prefix:
-                              type: string
                           required:
                           - name
                           type: object
@@ -2741,11 +2741,6 @@ spec:
                             to obtain the "jkws_uri" claim from. The value must coincide
                             with the value of  the "iss" (issuer) claim of the discovered
                             OpenID Connect configuration.
-                          type: string
-                        jwksUrl:
-                          description: URL of the JSON Web Ket Set (JWKS) endpoint.
-                            Use this if the issuer of the JWT tokens is not an OIDC
-                            provider or does not implement OIDC Discovery.
                           type: string
                         ttl:
                           description: Decides how long to wait before refreshing
@@ -3173,7 +3168,12 @@ spec:
                             precompile) and at runtime.
                           type: boolean
                         externalPolicy:
-                          description: External registry of OPA policies.
+                          description: 'Settings for fetching the OPA policy from
+                            an external registry. Use it alternatively to ''inlineRego''.
+                            For the configurations of the HTTP request, the following
+                            options are not implemented: ''method'', ''body'', ''bodyParameters'',
+                            ''contentType'', ''headers'', ''oauth2''. Use it only
+                            with: ''url'', ''sharedSecret'', ''credentials''.'
                           properties:
                             body:
                               description: Raw body of the HTTP request. Supersedes
@@ -3253,8 +3253,6 @@ spec:
                                   properties:
                                     name:
                                       type: string
-                                    prefix:
-                                      type: string
                                   required:
                                   - name
                                   type: object
@@ -3286,10 +3284,6 @@ spec:
                                 type: object
                               description: Custom headers in the HTTP request.
                               type: object
-                            insecure:
-                              description: Insecure HTTP connection (i.e. disables
-                                TLS verification)
-                              type: boolean
                             method:
                               default: GET
                               description: 'HTTP verb used in the request to the service.
@@ -3748,8 +3742,6 @@ spec:
                               properties:
                                 name:
                                   type: string
-                                prefix:
-                                  type: string
                               required:
                               - name
                               type: object
@@ -3780,10 +3772,6 @@ spec:
                             type: object
                           description: Custom headers in the HTTP request.
                           type: object
-                        insecure:
-                          description: Insecure HTTP connection (i.e. disables TLS
-                            verification)
-                          type: boolean
                         method:
                           default: GET
                           description: 'HTTP verb used in the request to the service.
@@ -4068,8 +4056,6 @@ spec:
                               properties:
                                 name:
                                   type: string
-                                prefix:
-                                  type: string
                               required:
                               - name
                               type: object
@@ -4100,10 +4086,6 @@ spec:
                             type: object
                           description: Custom headers in the HTTP request.
                           type: object
-                        insecure:
-                          description: Insecure HTTP connection (i.e. disables TLS
-                            verification)
-                          type: boolean
                         method:
                           default: GET
                           description: 'HTTP verb used in the request to the service.

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -3167,7 +3167,7 @@ spec:
                           type: boolean
                         externalPolicy:
                           description: 'Settings for fetching the OPA policy from
-                            an external registry. Use it alternatively to ''inlineRego''.
+                            an external registry. Use it alternatively to ''rego''.
                             For the configurations of the HTTP request, the following
                             options are not implemented: ''method'', ''body'', ''bodyParameters'',
                             ''contentType'', ''headers'', ''oauth2''. Use it only

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ========================================================================
+#
+# Use this script to install the Authorino Operator and dependencies
+# to the current kubectl context, without having to clone the repo
+# or depending on Operator Lifecycle Manager (OLM).
+#
+# E.g.:
+#   curl -sL https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/utils/install.sh | bash -s -- [options]
+#
+
+VERSION='latest'
+CERT_MANAGER_VERSION="1.12.1"
+NO_DEPS=''
+DRY_RUN=''
+
+print_usage() {
+  cat <<EOF
+Installs the Authorino Operator and dependencies to the current kubectl context.
+
+Usage:
+
+  install.sh [options]
+
+Options:
+
+  -v | --version    The version of the Authorino Operator to install. Defaults to 'latest'.
+       --git-ref    The Git reference of the Authorino Operator to install.
+                    Provide it in the form of a branch, tag or commit hash, alternatively to providing a version.
+                    If omitted, the Git reference will be inferred from the version.
+       --no-deps    Do not install dependencies.
+       --dry-run    Print the commands that would be executed, but do not execute them.
+  -h | --help       Print this help message.
+EOF
+}
+
+while test $# -gt 0; do
+  case "$1" in
+    -v|--version)
+      shift
+      if test $# -gt 0; then
+        VERSION=$1
+      else
+        echo "missing version argument"
+        exit 1
+      fi
+      shift
+      ;;
+    --git-ref)
+      shift
+      if test $# -gt 0; then
+        GIT_REF=$1
+      else
+        echo "missing git-ref argument"
+        exit 1
+      fi
+      shift
+      ;;
+    --no-deps)
+      shift
+      NO_DEPS='true'
+      ;;
+    --dry-run)
+      shift
+      DRY_RUN='true'
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1"
+      print_usage
+      exit 1
+      ;;
+  esac
+done
+
+set -o pipefail -e
+
+steps=()
+cmds=()
+
+step() {
+  local descr=$1
+  shift
+  append_step "$descr"
+  append_cmd "$@"
+}
+
+append_step() {
+  steps+=("$*")
+}
+
+append_cmd() {
+  cmds+=("$*")
+}
+
+run() {
+  local steps_curr=0
+  local steps_total="${#steps[@]}"
+  for i in "${!steps[@]}"; do
+    steps_curr=$((steps_curr + 1))
+    echo -e "[\033[0;34m${steps_curr}/${steps_total}\033[0m] ${steps[$i]}"
+    eval "${cmds[$i]}"
+  done
+}
+
+cmd() {
+  if [[ -z $DRY_RUN ]]; then
+    eval "$@"
+  else
+    echo "$@"
+  fi
+}
+
+# Define your steps below this point.
+# Wrap individual commands in a `cmd` function call to skip and print them to STDOUT in dry-run mode.
+#
+# E.g.:
+#   step "Installing foo..." cmd arg1 arg2
+
+install_cert_manager() {
+  cmd kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml
+  cmd kubectl -n cert-manager wait --timeout=300s --for=condition=Available deployments --all
+}
+
+install_operator() {
+  cmd kubectl apply -f https://raw.githubusercontent.com/Kuadrant/authorino-operator/${GIT_REF}/config/deploy/manifests.yaml
+}
+
+if [[ -z $NO_DEPS ]]; then
+  step "Installing \033[0;32mcert-manager\033[0m \033[0;37m(version: ${CERT_MANAGER_VERSION})\033[0m to the current kubectl context..." \
+       install_cert_manager
+fi
+
+version_info="git-ref: $GIT_REF"
+if [[ -z $GIT_REF ]]; then
+  version_info="version: $VERSION"
+  if [[ $VERSION == "latest" ]]; then
+    GIT_REF="main"
+  else
+    if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
+      GIT_REF="v${VERSION}"
+    else
+      GIT_REF="${VERSION}"
+    fi
+  fi
+fi
+
+step "Installing \033[0;32mAuthorino Operator\033[0m \033[0;37m(${version_info})\033[0m to the current kubectl context..." \
+     install_operator
+
+# Runs all the steps in order
+run


### PR DESCRIPTION
Deploys the AuthConfig CRD conversion webhook (based on the Authorino container image), as part of deploying the Operator.

This is because the conversion webhook is a single deployment per cluster (similarly to the Operator itself), nevertheless it's based on the Authorino code base (which owns the AuthConfig type and therefore the functions to convert between versions of the CRD).

**_Important!_**

This change introduces a new dependency of the Operator on [cert-manager](https://cert-manager.io). Actually the dependency is introduced by the conversion webhook (not by the Operator itself), but since installing/deploying the Operator will also deploy the webhook, cert-manager needs to be installed before installing the Operator.

Because of that, installing the Operator by simply applying the `config/deploy` manifests may no longer work, with the webhook possibly failing due to cert-manager not running in the cluster. Hence, the PR also introduces a script to continue supporting installing the Operator – and now also cert-manager –  without having to clone the repo nor depending on Operator Lifecycle Manager (OLM).

The script can be used as follows:

```sh
curl -sL https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/utils/install.sh | bash -s -- [options]
```

The options include : `--version`, `--git-ref`, `--no-deps`, and `--dry-run`.

For installations via OLM, installing cert-manager first is [not required](https://olm.operatorframework.io/docs/advanced-tasks/adding-admission-and-conversion-webhooks/).

---

Related to https://github.com/Kuadrant/authorino/pull/417