### PR TITLE
[workflow] Adding channels input for bundle images in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,10 @@ on:
         description: Is the release a prerelease
         required: false
         type: boolean
+      channels:
+        description: Bundle and catalog channels, comma separated
+        default: preview
+        type: string
 
 jobs:
   build:
@@ -41,7 +45,11 @@ jobs:
       run: |
         git checkout -b release-v${{ github.event.inputs.operatorVersion }}
     - name: Prepare release
-      run: VERSION=${{ github.event.inputs.operatorVersion }} AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }} make prepare-release
+      run: |
+        VERSION=${{ github.event.inputs.operatorVersion }} \
+        AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }} \
+        CHANNELS=${{ github.event.inputs.channels }} \
+        make prepare-release
     - name: Commit and push
       run: |
         git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
This PR is part of Kuadrant Operator issue https://github.com/Kuadrant/kuadrant-operator/issues/244

The workflow dispatch input channels accepts comma separated values, i.e.: "stable,release". The Makefile target could be executed as:

```sh
make prepare-release \
  VERSION=0.7.0 \
  AUTHORINO_VERSION=0.14.0 \
  CHANNELS=stable,release
```

And it will generate, among other changes, the following:

```sh
diff --git a/bundle.Dockerfile b/bundle.Dockerfile
index 8fe9a64..5b9211f 100644
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -5,7 +5,7 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
-LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channels.v1=stable,release

diff --git a/bundle/metadata/annotations.yaml b/bundle/metadata/annotations.yaml
index 118a56d..39e6d57 100644
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,7 +4,7 @@ annotations:
-  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channels.v1: stable,release
```