### PR TITLE
Support local cert manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.21
 
+# Cert manager is required for the webhooks.
+CERT_MANAGER_VERSION ?= 1.12.1
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -197,8 +200,12 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
-install-authorino: ## install RBAC and CRD for authorino
+install-authorino: install-cert-manager ## install RBAC and CRD for authorino
 	$(KUSTOMIZE) build config/authorino | kubectl apply -f -
+
+install-cert-manager: ## install the cert manager need for the web hooks
+	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml
+	kubectl -n cert-manager wait --timeout=300s --for=condition=Available deployments --all
 
 # go-get-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
Add the installation of the cert manager for the tools used during dev work.

# Validation

* Create a local kind cluster
```
kind create cluster
```
* Set up the operator namespace
```
kubectl create namespace authorino-operator
```
* Install the Operator manifests, cert manager will be add during this stage
```
make install
```
* Deploy the operator
```
make deploy
```
* Expect: Operator web hook to deploy. 
```
kubectl get deployment authorino-webhooks -n authorino-operator
```

Closes: https://github.com/Kuadrant/kuadrant-operator/issues/257