### PR TITLE
Disable bundle verify for release v0.9.0

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -120,17 +120,17 @@ jobs:
       - name: Run make bundle (main)
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
         run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.sha }}
-      - name: Run make bundle (release)
-        if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
-        run: make bundle fix-csv-replaces REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} VERSION=${TAG_NAME/v/} AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }} CHANNELS=${{ github.event.inputs.channels }}
+      # - name: Run make bundle (release)
+      #   if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
+      #   run: make bundle fix-csv-replaces REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} VERSION=${TAG_NAME/v/} AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }} CHANNELS=${{ github.event.inputs.channels }}
       - name: Git diff
         run: git diff
       - name: Verify manifests and bundle (main)
         if: github.ref_name == env.MAIN_BRANCH_NAME
         run: make verify-manifests verify-bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.sha }}
-      - name: Verify manifests and bundle (release)
-        if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
-        run: make verify-manifests verify-bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} VERSION=${TAG_NAME/v/} AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }} CHANNELS=${{ github.event.inputs.channels }}
+      # - name: Verify manifests and bundle (release)
+      #   if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
+      #   run: make verify-manifests verify-bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} VERSION=${TAG_NAME/v/} AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }} CHANNELS=${{ github.event.inputs.channels }}
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2


### PR DESCRIPTION
A bug in the bundle manifests verification is causing the builds to fail as the `replaces` directive is generated from the latest github release. During the release workflow the bundle manifests were created correctly (prior to publishing the github release) and have been verified manually. This PR is to disable these checks (on the release branch only) to build the bundle and catalog from the previously generated bundle files.