### PR TITLE
refactor: use k8score.PullPolicy type for image pull policy type in spec

### DIFF
--- a/api/v1beta1/authorino_types.go
+++ b/api/v1beta1/authorino_types.go
@@ -60,22 +60,22 @@ type AuthorinoSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	Image                    string      `json:"image,omitempty"`
-	ImagePullPolicy          string      `json:"imagePullPolicy,omitempty"`
-	Replicas                 *int32      `json:"replicas,omitempty"`
-	Volumes                  VolumesSpec `json:"volumes,omitempty"`
-	LogLevel                 string      `json:"logLevel,omitempty"`
-	LogMode                  string      `json:"logMode,omitempty"`
-	ClusterWide              bool        `json:"clusterWide,omitempty"`
-	Listener                 Listener    `json:"listener"`
-	OIDCServer               OIDCServer  `json:"oidcServer"`
-	AuthConfigLabelSelectors string      `json:"authConfigLabelSelectors,omitempty"`
-	SecretLabelSelectors     string      `json:"secretLabelSelectors,omitempty"`
-	SupersedingHostSubsets   bool        `json:"supersedingHostSubsets,omitempty"`
-	EvaluatorCacheSize       *int        `json:"evaluatorCacheSize,omitempty"`
-	Tracing                  Tracing     `json:"tracing,omitempty"`
-	Metrics                  Metrics     `json:"metrics,omitempty"`
-	Healthz                  Healthz     `json:"healthz,omitempty"`
+	Image                    string             `json:"image,omitempty"`
+	ImagePullPolicy          k8score.PullPolicy `json:"imagePullPolicy,omitempty"`
+	Replicas                 *int32             `json:"replicas,omitempty"`
+	Volumes                  VolumesSpec        `json:"volumes,omitempty"`
+	LogLevel                 string             `json:"logLevel,omitempty"`
+	LogMode                  string             `json:"logMode,omitempty"`
+	ClusterWide              bool               `json:"clusterWide,omitempty"`
+	Listener                 Listener           `json:"listener"`
+	OIDCServer               OIDCServer         `json:"oidcServer"`
+	AuthConfigLabelSelectors string             `json:"authConfigLabelSelectors,omitempty"`
+	SecretLabelSelectors     string             `json:"secretLabelSelectors,omitempty"`
+	SupersedingHostSubsets   bool               `json:"supersedingHostSubsets,omitempty"`
+	EvaluatorCacheSize       *int               `json:"evaluatorCacheSize,omitempty"`
+	Tracing                  Tracing            `json:"tracing,omitempty"`
+	Metrics                  Metrics            `json:"metrics,omitempty"`
+	Healthz                  Healthz            `json:"healthz,omitempty"`
 }
 
 type Listener struct {

--- a/bundle/manifests/operator.authorino.kuadrant.io_authorinos.yaml
+++ b/bundle/manifests/operator.authorino.kuadrant.io_authorinos.yaml
@@ -50,6 +50,8 @@ spec:
               image:
                 type: string
               imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container
+                  image
                 type: string
               listener:
                 properties:

--- a/config/crd/bases/operator.authorino.kuadrant.io_authorinos.yaml
+++ b/config/crd/bases/operator.authorino.kuadrant.io_authorinos.yaml
@@ -52,6 +52,8 @@ spec:
               image:
                 type: string
               imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container
+                  image
                 type: string
               listener:
                 properties:

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -5451,6 +5451,8 @@ spec:
               image:
                 type: string
               imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container
+                  image
                 type: string
               listener:
                 properties:

--- a/config/install/manifests.yaml
+++ b/config/install/manifests.yaml
@@ -50,6 +50,8 @@ spec:
               image:
                 type: string
               imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container
+                  image
                 type: string
               listener:
                 properties:

--- a/controllers/authorino_controller_test.go
+++ b/controllers/authorino_controller_test.go
@@ -256,7 +256,7 @@ func newFullAuthorinoInstance() *api.Authorino {
 		Spec: api.AuthorinoSpec{
 			Image:           image,
 			Replicas:        &replicas,
-			ImagePullPolicy: string(k8score.PullAlways),
+			ImagePullPolicy: k8score.PullAlways,
 			Volumes: api.VolumesSpec{
 				Items: []api.VolumeSpec{
 					{

--- a/pkg/resources/k8s_deployment.go
+++ b/pkg/resources/k8s_deployment.go
@@ -31,13 +31,13 @@ func GetDeployment(name, namespace, saName string, replicas *int32, containers [
 	}
 }
 
-func GetContainer(image, imagePullPolicy, containerName string, args []string, envVars []k8score.EnvVar, volMounts []k8score.VolumeMount) k8score.Container {
+func GetContainer(image string, imagePullPolicy k8score.PullPolicy, containerName string, args []string, envVars []k8score.EnvVar, volMounts []k8score.VolumeMount) k8score.Container {
 	if imagePullPolicy == "" {
-		imagePullPolicy = "Always"
+		imagePullPolicy = k8score.PullAlways
 	}
 	c := k8score.Container{
 		Image:           image,
-		ImagePullPolicy: k8score.PullPolicy(imagePullPolicy),
+		ImagePullPolicy: imagePullPolicy,
 		Name:            containerName,
 		Env:             envVars,
 		VolumeMounts:    volMounts,


### PR DESCRIPTION
* Minor refactor to use `k8score.PullPolicy` as the type instead of string for `ImagePullPolicy`