### PR TITLE
Fix bundle manifests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,7 @@ jobs:
         VERSION=${{ github.event.inputs.operatorVersion }} \
         AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }} \
         CHANNELS=${{ github.event.inputs.channels }} \
+        DEFAULT_CHANNEL=${{ github.event.inputs.channels }} \
         make prepare-release
     - name: Commit and push
       run: |

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,10 @@ SHELL = /usr/bin/env bash -o pipefail
 AUTHORINO_VERSION ?= latest
 ifeq (latest,$(AUTHORINO_VERSION))
 AUTHORINO_BRANCH = main
+AUTHORINO_IMAGE_TAG = latest
 else
 AUTHORINO_BRANCH = v$(AUTHORINO_VERSION)
+AUTHORINO_IMAGE_TAG = v$(AUTHORINO_VERSION)
 endif
 
 AUTHORINO_IMAGE_FILE ?= authorino_image
@@ -140,7 +142,7 @@ manifests: controller-gen kustomize authorino-manifests ## Generate WebhookConfi
 
 .PHONY: authorino-manifests
 authorino-manifests: export AUTHORINO_GITREF := $(AUTHORINO_BRANCH)
-authorino-manifests: export AUTHORINO_VERSION := $(AUTHORINO_VERSION)
+authorino-manifests: export AUTHORINO_IMAGE_TAG := $(AUTHORINO_IMAGE_TAG)
 authorino-manifests: ## Update authorino manifests.
 	envsubst \
         < config/authorino/kustomization.template.yaml \
@@ -266,7 +268,7 @@ prepare-release:
 	@if [ "$(AUTHORINO_VERSION)" = "latest" ]; then\
 		[ ! -e "$(AUTHORINO_IMAGE_FILE)" ] || rm $(AUTHORINO_IMAGE_FILE); \
 	else \
-	    echo quay.io/kuadrant/authorino:v$(AUTHORINO_VERSION) > $(AUTHORINO_IMAGE_FILE); \
+	    echo quay.io/kuadrant/authorino:$(AUTHORINO_IMAGE_TAG) > $(AUTHORINO_IMAGE_FILE); \
 	fi
 	$(MAKE) fix-csv-replaces
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,6 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=authorino-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.22.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3

--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -303,7 +303,7 @@ spec:
                   - command:
                       - authorino
                       - webhooks
-                    image: quay.io/kuadrant/authorino:0.15.0
+                    image: quay.io/kuadrant/authorino:v0.15.0
                     name: webhooks
                     ports:
                       - containerPort: 9443

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,6 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: authorino-operator
   operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.22.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3

--- a/config/authorino/kustomization.template.yaml
+++ b/config/authorino/kustomization.template.yaml
@@ -9,7 +9,7 @@ resources:
 images:
 - name: AUTHORINO_IMAGE
   newName: quay.io/kuadrant/authorino
-  newTag: ${AUTHORINO_VERSION}
+  newTag: ${AUTHORINO_IMAGE_TAG}
 
 patchesStrategicMerge:
 - webhook/patches/webhook_in_authconfigs.yaml

--- a/config/authorino/kustomization.yaml
+++ b/config/authorino/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 images:
 - name: AUTHORINO_IMAGE
   newName: quay.io/kuadrant/authorino
-  newTag: 0.15.0
+  newTag: v0.15.0
 
 patchesStrategicMerge:
 - webhook/patches/webhook_in_authconfigs.yaml

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -6199,7 +6199,7 @@ spec:
       - command:
         - authorino
         - webhooks
-        image: quay.io/kuadrant/authorino:0.15.0
+        image: quay.io/kuadrant/authorino:v0.15.0
         name: webhooks
         ports:
         - containerPort: 9443


### PR DESCRIPTION
I spotted the version of authorino defined for the webhook container in the CSV is missing the 'v' which does not match the container tag pushed to [quay.io/kuadrant/authorino:v0.15.0](quay.io/kuadrant/authorino:v0.15.0). Will investigate the root cause of this to fix in the main branch for the next release.

On top of this, now that we have moved to the stable channel, any catalog build containing bundles of both the stable and preview type requires specifying a default channel to determine the head of the catalog.

wip until we have verified no other issues in the manifests and I have tested re-running the image builds locally passes.