### PR TITLE
Add missing information to CSV

### DIFF
--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -5,6 +5,34 @@ metadata:
     alm-examples: |-
       [
         {
+          "apiVersion": "authorino.kuadrant.io/v1beta2",
+          "kind": "AuthConfig",
+          "metadata": {
+            "name": "talker-api-protection"
+          },
+          "spec": {
+            "authentication": {
+              "api-key-users": {
+                "apiKey": {
+                  "selector": {
+                    "matchLabels": {
+                      "group": "friends"
+                    }
+                  }
+                },
+                "credentials": {
+                  "authorizationHeader": {
+                    "prefix": "APIKEY"
+                  }
+                }
+              }
+            },
+            "hosts": [
+              "talker-api.io"
+            ]
+          }
+        },
+        {
           "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
           "kind": "Authorino",
           "metadata": {
@@ -43,7 +71,9 @@ spec:
         kind: AuthConfig
         name: authconfigs.authorino.kuadrant.io
         version: v1beta1
-      - kind: AuthConfig
+      - description: API to describe the desired protection for a service
+        displayName: AuthConfig
+        kind: AuthConfig
         name: authconfigs.authorino.kuadrant.io
         version: v1beta2
       - description: API to create instances of authorino

--- a/config/manifests/bases/authorino-operator.clusterserviceversion.template.yaml
+++ b/config/manifests/bases/authorino-operator.clusterserviceversion.template.yaml
@@ -21,6 +21,11 @@ spec:
       displayName: AuthConfig
       kind: AuthConfig
       name: authconfigs.authorino.kuadrant.io
+      version: v1beta2
+    - description: API to describe the desired protection for a service
+      displayName: AuthConfig
+      kind: AuthConfig
+      name: authconfigs.authorino.kuadrant.io
       version: v1beta1
     - description: API to create instances of authorino
       displayName: Authorino

--- a/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
@@ -21,6 +21,11 @@ spec:
       displayName: AuthConfig
       kind: AuthConfig
       name: authconfigs.authorino.kuadrant.io
+      version: v1beta2
+    - description: API to describe the desired protection for a service
+      displayName: AuthConfig
+      kind: AuthConfig
+      name: authconfigs.authorino.kuadrant.io
       version: v1beta1
     - description: API to create instances of authorino
       displayName: Authorino

--- a/config/samples/authorino-operator_v1beta2_authconfig.yaml
+++ b/config/samples/authorino-operator_v1beta2_authconfig.yaml
@@ -1,0 +1,16 @@
+apiVersion: authorino.kuadrant.io/v1beta2
+kind: AuthConfig
+metadata:
+  name: talker-api-protection
+spec:
+  hosts:
+  - talker-api.io
+  authentication:
+    "api-key-users":
+      apiKey:
+        selector:
+          matchLabels:
+            group: friends
+      credentials:
+        authorizationHeader:
+          prefix: APIKEY

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,5 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
 - authorino-operator_v1beta1_authorino.yaml
+- authorino-operator_v1beta2_authconfig.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
This PR attempts to fix #162.

It looks like adding the information to the CSV template sorts out the issue of missing names/descriptions.

There is one peculiar thing caused by two versions of AuthConfig CRD which results in two seemingly duplicated cards rendered in OperatorHub.

While the displayed name could be altered so the first card would display for example `AuthConfig/v1beta1` and the second card `AuthConfig/v1beta2` the YAML example displayed on both cards would still show an example from `AuthConfig/v1beta2` (even for v1beta1 card), despite examples existing for both versions in the CSV file. It's a bit confusing, I hope this describes the issue in an understandable way.

For this reason I have included the example YAML for `AuthConfig/v1beta2` only and kept the `displayName` for both versions as `AuthConfig`. This way the OperatorHub will only show the most recent version to the visitors with a correct YAML example.


As an example, this approach can be also seen in [ArgoCD operator](https://operatorhub.io/operator/argocd-operator) with the `Argo CD` schema.

To verify the changes, copy the full contents of the generated CSV manifest to [OperatorHub Preview](https://operatorhub.io/preview) tool.

Also a pic of how it looks like after the changes:
![image](https://github.com/Kuadrant/authorino-operator/assets/97438342/2d692b4e-0119-4350-b821-dd88a86b995f)

 