### PR TITLE
Add example for AuthConfig v1beta1 in the CSV

### DIFF
--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -5,10 +5,38 @@ metadata:
     alm-examples: |-
       [
         {
+          "apiVersion": "authorino.kuadrant.io/v1beta1",
+          "kind": "AuthConfig",
+          "metadata": {
+            "name": "my-api-protection"
+          },
+          "spec": {
+            "hosts": [
+              "my-api.io"
+            ],
+            "identity": [
+              {
+                "apiKey": {
+                  "selector": {
+                    "matchLabels": {
+                      "group": "friends"
+                    }
+                  }
+                },
+                "credentials": {
+                  "in": "authorization_header",
+                  "keySelector": "APIKEY"
+                },
+                "name": "api-key-users"
+              }
+            ]
+          }
+        },
+        {
           "apiVersion": "authorino.kuadrant.io/v1beta2",
           "kind": "AuthConfig",
           "metadata": {
-            "name": "talker-api-protection"
+            "name": "my-api-protection"
           },
           "spec": {
             "authentication": {
@@ -28,7 +56,7 @@ metadata:
               }
             },
             "hosts": [
-              "talker-api.io"
+              "my-api.io"
             ]
           }
         },

--- a/config/samples/authorino-operator_v1beta1_authconfig.yaml
+++ b/config/samples/authorino-operator_v1beta1_authconfig.yaml
@@ -1,0 +1,16 @@
+apiVersion: authorino.kuadrant.io/v1beta1
+kind: AuthConfig
+metadata:
+  name: my-api-protection
+spec:
+  hosts:
+  - my-api.io
+  identity:
+  - name: api-key-users
+    apiKey:
+      selector:
+        matchLabels:
+          group: friends
+    credentials:
+      in: authorization_header
+      keySelector: APIKEY

--- a/config/samples/authorino-operator_v1beta2_authconfig.yaml
+++ b/config/samples/authorino-operator_v1beta2_authconfig.yaml
@@ -1,10 +1,10 @@
 apiVersion: authorino.kuadrant.io/v1beta2
 kind: AuthConfig
 metadata:
-  name: talker-api-protection
+  name: my-api-protection
 spec:
   hosts:
-  - talker-api.io
+  - my-api.io
   authentication:
     "api-key-users":
       apiKey:

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,5 +1,6 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
 - authorino-operator_v1beta1_authorino.yaml
+- authorino-operator_v1beta1_authconfig.yaml
 - authorino-operator_v1beta2_authconfig.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
What: Adds an example of the AuthConfig CR in v1beta1 to the CSV
Why: Having an example for each version of the API that is served is required by some operator hub test pipelines.