### PR TITLE
Remove extra quotes in tracing tags

### DIFF
--- a/controllers/authorino_controller.go
+++ b/controllers/authorino_controller.go
@@ -384,7 +384,7 @@ func (r *AuthorinoReconciler) buildAuthorinoArgs(authorino *api.Authorino) []str
 	if tracingServiceEndpoint := authorino.Spec.Tracing.Endpoint; tracingServiceEndpoint != "" {
 		args = append(args, fmt.Sprintf("--%s=%s", flagTracingServiceEndpoint, tracingServiceEndpoint))
 		for key, value := range authorino.Spec.Tracing.Tags {
-			args = append(args, fmt.Sprintf(`--%s="%s=%s"`, flagTracingServiceTag, key, value))
+			args = append(args, fmt.Sprintf(`--%s=%s=%s`, flagTracingServiceTag, key, value))
 		}
 		if authorino.Spec.Tracing.Insecure {
 			args = append(args, fmt.Sprintf(`--%s`, flagTracingServiceInsecure))

--- a/controllers/authorino_controller_test.go
+++ b/controllers/authorino_controller_test.go
@@ -352,7 +352,7 @@ func checkAuthorinoArgs(authorinoInstance *api.Authorino, args []string) {
 		case flagTracingServiceEndpoint:
 			Expect(value).Should(Equal(authorinoInstance.Spec.Tracing.Endpoint))
 		case flagTracingServiceTag:
-			kv := strings.Split(strings.TrimPrefix(strings.TrimSuffix(value, `"`), `"`), "=")
+			kv := strings.Split(value, "=")
 			Expect(len(kv)).Should(Equal(2))
 			Expect(kv[1]).Should(Equal(authorinoInstance.Spec.Tracing.Tags[kv[0]]))
 		case flagTracingServiceInsecure:


### PR DESCRIPTION
Tested with new image built from this ([quay.io/acatterm/authorino-operator:fix-tracing-tags](quay.io/acatterm/authorino-operator:fix-tracing-tags)):

Authorino CR spec:
```yaml
spec:
  clusterWide: true
  healthz: {}
  listener:
    ports: {}
    tls:
      enabled: false
  metrics: {}
  oidcServer:
    tls:
      enabled: false
  supersedingHostSubsets: true
  tracing:
    endpoint: rpc://jaeger-collector.istio-system.svc.cluster.local:4317
    insecure: true
    tags:
      random-key: random-value
      test-key: test-value
  volumes: {}
```

![image](https://github.com/Kuadrant/authorino-operator/assets/6575004/6dafaea9-5bd2-4f2c-aeb7-c8129e047fce)

Resolves #171

