### PR TITLE
Fix setup-envtest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ vet: ## Run go vet against code.
 
 setup-envtest:
 ifeq (, $(shell which setup-envtest))
-	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.16
 SETUP_ENVTEST=$(GOBIN)/setup-envtest
 else
 SETUP_ENVTEST=$(shell which setup-envtest)


### PR DESCRIPTION
Fix setup-envtest version to controller-runtime v0.16, to avoid requiring bumping to go 1.22

Fixes issues such as https://github.com/Kuadrant/authorino-operator/actions/runs/8463027295