### PR TITLE
Fix: Adding missing operator metrics service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ endif
 ##@ Development
 
 manifests: controller-gen kustomize authorino-manifests ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=authorino-operator-manager webhook paths="./..." output:crd:artifacts:config=config/crd/bases && $(KUSTOMIZE) build config/install > $(OPERATOR_MANIFESTS)
+	$(CONTROLLER_GEN) -h $(CRD_OPTIONS) rbac:roleName=authorino-operator-manager webhook paths="./..." output:crd:artifacts:config=config/crd/bases && $(KUSTOMIZE) build config/install > $(OPERATOR_MANIFESTS)
 	$(MAKE) deploy-manifest OPERATOR_IMAGE=$(OPERATOR_IMAGE)
 
 .PHONY: authorino-manifests

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ authorino-manifests: ## Update authorino manifests.
         > config/authorino/kustomization.yaml
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(CONTROLLER_GEN) -h object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 fmt: ## Run go fmt against code.
 	go fmt ./...

--- a/controllers/authorino_controller.go
+++ b/controllers/authorino_controller.go
@@ -665,7 +665,7 @@ func (r *AuthorinoReconciler) createAuthorinoServices(authorino *api.Authorino) 
 	} else {
 		httpPort = defaultMetricsServicePort
 	}
-	
+
 	// operator metrics service
 	desiredServices = append(desiredServices, authorinoResources.NewOperatorMetricsService(
 		authorinoInstanceName,

--- a/controllers/authorino_controller.go
+++ b/controllers/authorino_controller.go
@@ -619,6 +619,9 @@ func (r *AuthorinoReconciler) createAuthorinoServices(authorino *api.Authorino) 
 
 	authorinoInstanceName := authorino.Name
 	authorinoInstanceNamespace := authorino.Namespace
+	authorinoOperatorLabels := map[string]string{
+		"app": "authorino-operator",
+	}
 
 	var desiredServices []*k8score.Service
 	var grpcPort, httpPort int32
@@ -657,13 +660,22 @@ func (r *AuthorinoReconciler) createAuthorinoServices(authorino *api.Authorino) 
 		authorino.Labels,
 	))
 
-	// metrics service
 	if p := authorino.Spec.Metrics.Port; p != nil {
 		httpPort = *p
 	} else {
 		httpPort = defaultMetricsServicePort
 	}
-	desiredServices = append(desiredServices, authorinoResources.NewMetricsService(
+	
+	// operator metrics service
+	desiredServices = append(desiredServices, authorinoResources.NewOperatorMetricsService(
+		authorinoInstanceName,
+		authorinoInstanceNamespace,
+		httpPort,
+		authorinoOperatorLabels,
+	))
+
+	// operand metrics service
+	desiredServices = append(desiredServices, authorinoResources.NewOperandMetricsService(
 		authorinoInstanceName,
 		authorinoInstanceNamespace,
 		httpPort,

--- a/controllers/authorino_controller_test.go
+++ b/controllers/authorino_controller_test.go
@@ -53,7 +53,8 @@ var _ = Describe("Authorino controller", func() {
 		It("Should create authorino required services", func() {
 			desiredServices := []*k8score.Service{
 				authorinoResources.NewOIDCService(authorinoInstance.Name, authorinoInstance.Namespace, defaultOIDCServicePort, authorinoInstance.Labels),
-				authorinoResources.NewMetricsService(authorinoInstance.Name, authorinoInstance.Namespace, defaultMetricsServicePort, authorinoInstance.Labels),
+				authorinoResources.NewOperandMetricsService(authorinoInstance.Name, authorinoInstance.Namespace, defaultMetricsServicePort, authorinoInstance.Labels),
+				authorinoResources.NewOperatorMetricsService(authorinoInstance.Name, authorinoInstance.Namespace, defaultMetricsServicePort, authorinoInstance.Labels),
 				authorinoResources.NewAuthService(authorinoInstance.Name, authorinoInstance.Namespace, defaultAuthGRPCServicePort, defaultAuthHTTPServicePort, authorinoInstance.Labels),
 			}
 

--- a/pkg/resources/k8s_services.go
+++ b/pkg/resources/k8s_services.go
@@ -32,8 +32,8 @@ func NewOperandMetricsService(authorinoName, serviceNamespace string, port int32
 	if port != 0 {
 		ports = append(ports, newServicePort("http", port))
 	}
-	
-	return newService("-metrics", serviceNamespace, authorinoName, labels, ports...)
+
+	return newService("metrics", serviceNamespace, authorinoName, labels, ports...)
 }
 
 func NewOperatorMetricsService(authorinoName, serviceNamespace string, port int32, labels map[string]string) *k8score.Service {

--- a/pkg/resources/k8s_services.go
+++ b/pkg/resources/k8s_services.go
@@ -27,12 +27,21 @@ func NewOIDCService(authorinoName, authorinoNamespace string, port int32, labels
 	return newService("authorino-oidc", authorinoNamespace, authorinoName, labels, ports...)
 }
 
-func NewMetricsService(authorinoName, serviceNamespace string, port int32, labels map[string]string) *k8score.Service {
+func NewOperandMetricsService(authorinoName, serviceNamespace string, port int32, labels map[string]string) *k8score.Service {
 	var ports []k8score.ServicePort
 	if port != 0 {
 		ports = append(ports, newServicePort("http", port))
 	}
-	return newService("controller-metrics", serviceNamespace, authorinoName, labels, ports...)
+	
+	return newService("-metrics", serviceNamespace, authorinoName, labels, ports...)
+}
+
+func NewOperatorMetricsService(authorinoName, serviceNamespace string, port int32, labels map[string]string) *k8score.Service {
+	var ports []k8score.ServicePort
+	if port != 0 {
+		ports = append(ports, newServicePort("http", port))
+	}
+	return newService("operator-controller-manager-metrics-service", serviceNamespace, authorinoName, labels, ports...)
 }
 
 func EqualServices(s1, s2 *k8score.Service) bool {


### PR DESCRIPTION
Adding missing service to expose authorino operator metrics & adding flag to fix panic that happens with manifests make target

## Verification
```
kind create cluster --name authorino-operator
kubectl create namespace authorino-operator
make install
make run
```

Create a authorino cr
```
kubectl apply -f -<<EOF             
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino
  namespace: authorino-operator
spec:
  clusterWide: true
  healthz: {}
  listener:
    ports: {}
    tls:
      enabled: false
  metrics: {}
  oidcServer:
    tls:
      enabled: false
  supersedingHostSubsets: true
  tracing:
    endpoint: ''
  volumes: {}
EOF
```

You should see multiple services come up
`k get services -n authorino-operator
`
ensure you get the following
```
authorino-metrics                                      ClusterIP   10.96.96.154   <none>        8080/TCP             8s
authorino-authorino-authorization                       ClusterIP   10.96.218.59   <none>        50051/TCP,5001/TCP   8s
authorino-authorino-oidc                                ClusterIP   10.96.25.6     <none>        8083/TCP             8s
authorino-operator-controller-manager-metrics-service   ClusterIP   10.96.197.85   <none>        8080/TCP             8s
authorino-webhooks                                      ClusterIP   10.96.168.70   <none>        443/TCP              113s
```