### PR TITLE
updated changes for supporting s390x & ppc64le

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -49,10 +49,8 @@ jobs:
           else
           echo "VERSION=${{ github.sha }}" >> $GITHUB_ENV
           fi
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Install yq dependency
         run: make yq
       - name: Set default authorino image
@@ -64,7 +62,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}
           tags: ${{ env.IMG_TAGS }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           build-args: |
             VERSION=${{ env.VERSION }}
             DEFAULT_AUTHORINO_IMAGE=${{ env.DEFAULT_AUTHORINO_IMAGE }}
@@ -116,10 +114,8 @@ jobs:
           else
           echo "VERSION=${{ github.sha }}" >> $GITHUB_ENV
           fi
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Run make bundle (main)
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
         run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.sha }}
@@ -140,7 +136,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}-bundle
           tags: ${{ env.IMG_TAGS }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           build-args: |
             version=${{ env.VERSION }}
           containerfiles: |

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.20.0/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ spec:
 EOF
 ```
 
+## Deploy authorino operator using operator-sdk
+1. Install operator-sdk bin
+   ```sh
+   make operator-sdk
+   ```
+2. Run operator-sdk bundle command 
+   ```
+   ./bin/operator-sdk run bundle quay.io/kuadrant/authorino-operator-bundle:latest
+   ```
+## Note: For s390x & ppc64le , use operator-sdk to install authorino-operator 
+
 ## Requesting an Authorino instance
 
 Once the Operator is up and running, you can request instances of Authorino by creating `Authorino` CRs. E.g.:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ EOF
    ```
    ./bin/operator-sdk run bundle quay.io/kuadrant/authorino-operator-bundle:latest
    ```
-## Note: For s390x & ppc64le , use operator-sdk to install authorino-operator 
+Note: For s390x & ppc64le , use operator-sdk to install authorino-operator 
 
 ## Requesting an Authorino instance
 

--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -90,6 +90,11 @@ metadata:
     support: kuadrant
   name: authorino-operator.v0.0.0
   namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/os.linux: supported
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:

--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -83,18 +83,18 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/authorino-operator:latest
-    createdAt: "2024-07-01T08:30:34Z"
+    createdAt: "2024-07-11T09:10:47Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/authorino-operator
     support: kuadrant
-  name: authorino-operator.v0.0.0
-  namespace: placeholder
   labels:
     operatorframework.io/arch.amd64: supported
-    operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
+  name: authorino-operator.v0.0.0
+  namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:

--- a/config/manifests/bases/authorino-operator.clusterserviceversion.template.yaml
+++ b/config/manifests/bases/authorino-operator.clusterserviceversion.template.yaml
@@ -13,6 +13,11 @@ metadata:
     support: kuadrant
   name: authorino-operator.v${BUNDLE_VERSION}
   namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/os.linux: supported
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:

--- a/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
@@ -13,6 +13,11 @@ metadata:
     support: kuadrant
   name: authorino-operator.v0.0.0
   namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/os.linux: supported
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:


### PR DESCRIPTION
Updated build image workflow to prepare Multi-arch for:
1. authorino-operator
2. authorino-operator-bundle

Updated CSV with labels to support multi-arch

Validated the Operator using operator SDK 
[root@m1305001 authorino-operator]# ./bin/operator-sdk run bundle quay.io/morana/authorino-operator-bundle:latest
INFO[0011] Creating a File-Based Catalog of the bundle "quay.io/morana/authorino-operator-bundle:latest" 
INFO[0014] Generated a valid File-Based Catalog         
INFO[0018] Created registry pod: quay-io-morana-authorino-operator-bundle-latest 
INFO[0018] Created CatalogSource: authorino-operator-catalog 
INFO[0018] OperatorGroup "operator-sdk-og" created      
INFO[0018] Created Subscription: authorino-operator-v0-0-0-sub 
INFO[0047] Approved InstallPlan install-hzkwt for the Subscription: authorino-operator-v0-0-0-sub 
INFO[0047] Waiting for ClusterServiceVersion "default/authorino-operator.v0.0.0" to reach 'Succeeded' phase 
INFO[0047]   Waiting for ClusterServiceVersion "default/authorino-operator.v0.0.0" to appear 
INFO[0050]   Found ClusterServiceVersion "default/authorino-operator.v0.0.0" phase: Pending 
INFO[0056]   Found ClusterServiceVersion "default/authorino-operator.v0.0.0" phase: InstallReady 
INFO[0059]   Found ClusterServiceVersion "default/authorino-operator.v0.0.0" phase: Installing 
INFO[0081]   Found ClusterServiceVersion "default/authorino-operator.v0.0.0" phase: Succeeded 
INFO[0081] OLM has successfully installed "authorino-operator.v0.0.0" 

**Note: Catalog image has not been made multi-arch. Reason - Currently its taking opm of x86 arch. Working on another PR to make muti-arch image for Catalog. Then user can deploy operator using CatalogSource & Subscription**
 