### PR TITLE
Update make uninstall 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,12 +206,9 @@ docker-push: ## Push docker image with the manager.
 
 ##@ Deployment
 
-install: manifests kustomize install-authorino ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	kubectl apply -f $(OPERATOR_MANIFESTS)
+install: install-authorino install-operator ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 
-uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
-	kubectl delete -f $(OPERATOR_MANIFESTS)
-	$(MAKE) uninstall-authorino
+uninstall: uninstall-operator uninstall-authorino ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${OPERATOR_IMAGE}
@@ -220,23 +217,32 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${DEFAULT_OPERATOR_IMAGE}
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/default | kubectl delete -f -
+	$(KUSTOMIZE) build config/default | kubectl delete -f - --ignore-not-found
 
-install-authorino: install-cert-manager ## install RBAC and CRD for authorino
-	kubectl create namespace authorino-operator
+install-operator: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
+	kubectl apply -f $(OPERATOR_MANIFESTS)
+
+uninstall-operator: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
+	kubectl delete -f $(OPERATOR_MANIFESTS) --ignore-not-found
+
+install-authorino: create-namespace install-cert-manager ## install RBAC and CRD for authorino
 	$(KUSTOMIZE) build config/authorino | kubectl apply -f -
 
 uninstall-authorino:  ## uninstall RBAC and CRD for authorino
-	$(KUSTOMIZE) build config/authorino | kubectl delete -f -
-	kubectl delete namespace authorino-operator
-	$(MAKE) uninstall-cert-manager
+	$(KUSTOMIZE) build config/authorino | kubectl delete -f - --ignore-not-found
 
 install-cert-manager: ## install the cert manager need for the web hooks
 	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml
 	kubectl -n cert-manager wait --timeout=300s --for=condition=Available deployments --all
 
 uninstall-cert-manager: ## uninstall the cert manager need for the web hooks
-	kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml
+	kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml --ignore-not-found
+
+create-namespace:
+	kubectl create namespace authorino-operator --dry-run=client -o yaml | kubectl apply -f - ## handle namespace already existing.
+
+delete-namespace:
+	kubectl delete namespace authorino-operator --ignore-not-found
 
 # go-get-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/README.md
+++ b/README.md
@@ -11,19 +11,13 @@ The Operator can be installed by applying the manifests to the Kubernetes cluste
 
 ### Applying the manifests to the cluster
 
-1. Create the namespace for the Operator
-
-```sh
-kubectl create namespace authorino-operator
-```
-
-2. Install the Operator manifests
+1. Install the Operator manifests
 
 ```sh
 make install
 ```
 
-3. Deploy the Operator
+2. Deploy the Operator
 
 ```sh
 make deploy
@@ -277,4 +271,31 @@ spec:
           - key: keycloak.crt
             path: keycloak.crt
     defaultMode: 420
+```
+## Removal
+
+### Removing the operator installed via manifests
+
+1. Undeploy the Operator
+
+```sh
+make undeploy
+```
+
+2. Remove the Operator manifests
+
+```sh
+make uninstall
+```
+
+#### Remove dependencies (Optional)
+
+1. Remove operator namespace
+```sh
+make delete-namespace
+```
+
+2. Uninstall cert manager
+```sh
+make uninstall-cert-manager
 ```


### PR DESCRIPTION
closes: https://github.com/Kuadrant/authorino-operator/issues/3

- create and delete authorino-operator namespace (requied by make install-authorino)
- add make uninstall-authorino
- add make uninstall-cert-manager
- update make uninstall

# Verification 
- create a kind cluster
- list CRDS on cluster `kubectl get crds`
- install the authorino-operator resources `make install`
- check the CRDS again `kubectl get crds`
- run uninstall command `make uninstall`
- check the CRDS again `kubectl get crds`, this will equal the initial list of CRDS from the cluster.