### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ OPERATOR_MANIFESTS ?= $(PROJECT_DIR)/config/install/manifests.yaml
 BUNDLE_CSV = bundle/manifests/authorino-operator.clusterserviceversion.yaml
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.21
+ENVTEST_K8S_VERSION = 1.29.0
 
 # Cert manager is required for the webhooks.
 CERT_MANAGER_VERSION ?= 1.12.1
@@ -188,7 +188,7 @@ endif
 # Run the tests
 test: manifests generate fmt vet setup-envtest
 	echo $(SETUP_ENVTEST)
-	KUBEBUILDER_ASSETS='$(strip $(shell $(SETUP_ENVTEST) --arch=amd64 use -p path 1.22.x))'  go test -ldflags="-X github.com/kuadrant/authorino-operator/controllers.DefaultAuthorinoImage=$(DEFAULT_AUTHORINO_IMAGE)" ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS='$(strip $(shell $(SETUP_ENVTEST)  use -p path $(ENVTEST_K8S_VERSION)))'  go test -ldflags="-X github.com/kuadrant/authorino-operator/controllers.DefaultAuthorinoImage=$(DEFAULT_AUTHORINO_IMAGE)" ./... -coverprofile cover.out
 
 ##@ Build
 


### PR DESCRIPTION
Updated envtest k8s version for s390x

Validated by running make test on s390x
```
[root@modassar-authorino-envtest authorino-operator]# make test
/usr/bin/which: no setup-envtest in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/usr/local/go/bin)
envsubst \
        < config/authorino/kustomization.template.yaml \
        > config/authorino/kustomization.yaml
/root/authorino-operator/bin/controller-gen crd rbac:roleName=authorino-operator-manager webhook paths="./..." output:crd:artifacts:config=config/crd/bases && /root/authorino-operator/bin/kustomize build config/install > /root/authorino-operator/config/install/manifests.yaml
make deploy-manifest OPERATOR_IMAGE=quay.io/kuadrant/authorino-operator:latest
make[1]: Entering directory '/root/authorino-operator'
/usr/bin/which: no setup-envtest in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/usr/local/go/bin)
mkdir -p /root/authorino-operator/config/deploy
cd /root/authorino-operator/config/manager && /root/authorino-operator/bin/kustomize edit set image controller=quay.io/kuadrant/authorino-operator:latest ;\
cd /root/authorino-operator && /root/authorino-operator/bin/kustomize build config/deploy > /root/authorino-operator/config/deploy/manifests.yaml
# clean up
cd /root/authorino-operator/config/manager && /root/authorino-operator/bin/kustomize edit set image controller=quay.io/kuadrant/authorino-operator:latest
make[1]: Leaving directory '/root/authorino-operator'
/root/authorino-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
go: downloading gotest.tools v2.2.0+incompatible
go: downloading github.com/onsi/ginkgo/v2 v2.11.0
go: downloading github.com/onsi/gomega v1.27.10
go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.16
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20240531164907-7006f379adf2
go: downloading sigs.k8s.io/controller-runtime v0.16.7-0.20240531164907-7006f379adf2
go: downloading github.com/go-logr/zapr v1.3.0
go: downloading github.com/spf13/afero v1.6.0
go: downloading go.uber.org/zap v1.26.0
go: downloading go.uber.org/multierr v1.10.0
Error: open build.yaml: no such file or directory
echo /root/go/bin/setup-envtest
/root/go/bin/setup-envtest
KUBEBUILDER_ASSETS='/root/.local/share/kubebuilder-envtest/k8s/1.29.0-linux-s390x'  go test -ldflags="-X github.com/kuadrant/authorino-operator/controllers.DefaultAuthorinoImage=quay.io/kuadrant/authorino:latest" ./... -coverprofile cover.out
?   	github.com/kuadrant/authorino-operator	[no test files]
?   	github.com/kuadrant/authorino-operator/api/v1beta1	[no test files]
?   	github.com/kuadrant/authorino-operator/pkg/condition	[no test files]
?   	github.com/kuadrant/authorino-operator/pkg/resources	[no test files]
ok  	github.com/kuadrant/authorino-operator/controllers	31.495s	coverage: 74.4% of statements
ok  	github.com/kuadrant/authorino-operator/pkg/log	0.013s	coverage: 44.0% of statements
```

Arch - s390x
```
[root@modassar-authorino-envtest authorino-operator]# uname -m
s390x
```
