### PR TITLE
File based catalog

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -193,12 +193,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
-      - name: Run make catalog-generate (main)
-        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
-        run: make catalog-generate REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.sha }}
-      - name: Run make catalog-generate (release)
-        if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
-        run: make catalog-generate REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ env.TAG_NAME }}
+      - name: Run make catalog
+        run: |
+          make catalog \
+            REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \
+            VERSION=${{ env.VERSION }} \
+            AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }} \
+            CHANNELS=${{ inputs.channels }}
       - name: Git diff
         run: git diff
       - name: Build Image
@@ -208,10 +209,9 @@ jobs:
           image: ${{ env.OPERATOR_NAME }}-catalog
           tags: ${{ env.IMG_TAGS }}
           platforms: linux/amd64,linux/arm64
-          build-args: |
-            version=${{ env.VERSION }}
-          containerfiles: |
-            ./index.Dockerfile
+          context: ./catalog
+          dockerfiles: |
+            ./catalog/${{ env.OPERATOR_NAME }}-catalog.Dockerfile
       - name: Push Image
         if: ${{ !env.ACT }}
         id: push-to-quay

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ vendor
 
 # Bundles
 tmp
+
+# Catalogs
+/catalog/authorino-operator-catalog
+/catalog/authorino-operator-catalog.Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -109,9 +109,13 @@ CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0)
 
-KUSTOMIZE = $(shell pwd)/bin/kustomize
-kustomize: ## Download kustomize locally if necessary.
+KUSTOMIZE = $(PROJECT_DIR)/bin/kustomize
+$(KUSTOMIZE):
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.5)
+
+.PHONY: kustomize
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
+
 
 YQ = $(shell pwd)/bin/yq
 YQ_VERSION := v4.34.2

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 SHELL = /bin/bash
 
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 
 # VERSION defines the project version for the bundle.
 VERSION ?= $(shell git rev-parse HEAD)
@@ -122,7 +121,7 @@ $(YQ):
 .PHONY: yq
 yq: $(YQ) ## Download yq locally if necessary.
 
-OPM = $(PROJECT_PATH)/bin/opm
+OPM = $(PROJECT_DIR)/bin/opm
 OPM_VERSION = v1.26.2
 $(OPM):
 	@{ \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # Use bash as shell
 SHELL = /bin/bash
 
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
+
 # VERSION defines the project version for the bundle.
 VERSION ?= $(shell git rev-parse HEAD)
 
@@ -119,22 +122,20 @@ $(YQ):
 .PHONY: yq
 yq: $(YQ) ## Download yq locally if necessary.
 
-.PHONY: opm
-OPM = ./bin/opm
-opm: ## Download opm locally if necessary.
-ifeq (,$(wildcard $(OPM)))
-ifeq (,$(shell which opm 2>/dev/null))
+OPM = $(PROJECT_PATH)/bin/opm
+OPM_VERSION = v1.26.2
+$(OPM):
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.20.0/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
-else
-OPM = $(shell which opm)
-endif
-endif
+
+.PHONY: opm
+opm: $(OPM) ## Download opm locally if necessary.
+
 
 HELM = ./bin/helm
 HELM_VERSION = v3.15.0
@@ -321,30 +322,6 @@ prepare-release:
 # A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
 # These images MUST exist in a registry and be pull-able.
 BUNDLE_IMGS ?= $(BUNDLE_IMG)
-
-# The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
-CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(IMAGE_TAG)
-
-# Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
-ifneq ($(origin CATALOG_BASE_IMG), undefined)
-FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
-endif
-
-# Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
-# This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
-# https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
-.PHONY: catalog-build
-catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
-
-.PHONY: catalog-generate
-catalog-generate: opm ## Generate a catalog/index Dockerfile.
-	$(OPM) index add --generate --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
-
-# Push the catalog image.
-.PHONY: catalog-push
-catalog-push: ## Push a catalog image.
-	$(MAKE) docker-push OPERATOR_IMAGE=$(CATALOG_IMG)
 
 ##@ Verify
 

--- a/catalog/authorino-operator-channel-entry.yaml
+++ b/catalog/authorino-operator-channel-entry.yaml
@@ -1,6 +1,6 @@
 ---
 schema: olm.channel
 package: authorino-operator
-name: preview
+name: stable
 entries:
   - name: authorino-operator.v0.0.0

--- a/catalog/authorino-operator-channel-entry.yaml
+++ b/catalog/authorino-operator-channel-entry.yaml
@@ -1,0 +1,6 @@
+---
+schema: olm.channel
+package: authorino-operator
+name: preview
+entries:
+  - name: authorino-operator.v0.0.0

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: authorino-operator-catalog
+spec:
+  sourceType: grpc
+  image: quay.io/kuadrant/authorino-operator-catalog:local-testing-dd
+  displayName: Authorino Operator
+  publisher: grpc

--- a/config/deploy/olm/kustomization.yaml
+++ b/config/deploy/olm/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: authorino-system
+namespace: authorino-operator
 
 resources:
 - namespace.yaml

--- a/config/deploy/olm/kustomization.yaml
+++ b/config/deploy/olm/kustomization.yaml
@@ -1,0 +1,8 @@
+# Adds namespace to all resources.
+namespace: authorino-system
+
+resources:
+- namespace.yaml
+- operatorgroup.yaml
+- catalogsource.yaml
+- subscription.yaml

--- a/config/deploy/olm/namespace.yaml
+++ b/config/deploy/olm/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system

--- a/config/deploy/olm/namespace.yaml
+++ b/config/deploy/olm/namespace.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-  name: system
+  name: operator

--- a/config/deploy/olm/operatorgroup.yaml
+++ b/config/deploy/olm/operatorgroup.yaml
@@ -1,0 +1,4 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kuadrant

--- a/config/deploy/olm/subscription.yaml
+++ b/config/deploy/olm/subscription.yaml
@@ -5,6 +5,6 @@ metadata:
   name: kuadrant
 spec:
   source: authorino-operator-catalog
-  sourceNamespace: authorino-system
+  sourceNamespace: authorino-operator
   name: authorino-operator
-  channel: "preview"
+  channel: "stable"

--- a/config/deploy/olm/subscription.yaml
+++ b/config/deploy/olm/subscription.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kuadrant
+spec:
+  source: authorino-operator-catalog
+  sourceNamespace: authorino-system
+  name: authorino-operator
+  channel: "preview"

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -3,12 +3,12 @@
 # The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
 CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(IMAGE_TAG)
 
-CATALOG_FILE = $(PROJECT_PATH)/catalog/authorino-operator-catalog/operator.yaml
-CATALOG_DOCKERFILE = $(PROJECT_PATH)/catalog/authorino-operator-catalog.Dockerfile
+CATALOG_FILE = $(PROJECT_DIR)/catalog/authorino-operator-catalog/operator.yaml
+CATALOG_DOCKERFILE = $(PROJECT_DIR)/catalog/authorino-operator-catalog.Dockerfile
 
 $(CATALOG_DOCKERFILE): $(OPM)
-	-mkdir -p $(PROJECT_PATH)/catalog/authorino-operator-catalog
-	cd $(PROJECT_PATH)/catalog && $(OPM) generate dockerfile authorino-operator-catalog
+	-mkdir -p $(PROJECT_DIR)/catalog/authorino-operator-catalog
+	cd $(PROJECT_DIR)/catalog && $(OPM) generate dockerfile authorino-operator-catalog
 catalog-dockerfile: $(CATALOG_DOCKERFILE) ## Generate catalog dockerfile.
 
 $(CATALOG_FILE): $(OPM) $(YQ)
@@ -21,23 +21,23 @@ $(CATALOG_FILE): $(OPM) $(YQ)
 	@echo
 	@echo Please check this matches your expectations and override variables if needed.
 	@echo
-	$(PROJECT_PATH)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $@ $(CHANNELS)
+	$(PROJECT_DIR)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $@ $(CHANNELS)
 
 .PHONY: catalog
 catalog: $(OPM) ## Generate catalog content and validate.
 	# Initializing the Catalog
-	-rm -rf $(PROJECT_PATH)/catalog/authorino-operator-catalog
-	-rm -rf $(PROJECT_PATH)/catalog/authorino-operator-catalog.Dockerfile
+	-rm -rf $(PROJECT_DIR)/catalog/authorino-operator-catalog
+	-rm -rf $(PROJECT_DIR)/catalog/authorino-operator-catalog.Dockerfile
 	$(MAKE) $(CATALOG_DOCKERFILE)
 	$(MAKE) $(CATALOG_FILE) BUNDLE_IMG=$(BUNDLE_IMG)
-	cd $(PROJECT_PATH)/catalog && $(OPM) validate authorino-operator-catalog
+	cd $(PROJECT_DIR)/catalog && $(OPM) validate authorino-operator-catalog
 
 # Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
 # Ref https://olm.operatorframework.io/docs/tasks/creating-a-catalog/#catalog-creation-with-raw-file-based-catalogs
 .PHONY: catalog-build
 catalog-build: ## Build a catalog image.
 	# Build the Catalog
-	docker build $(PROJECT_PATH)/catalog -f $(PROJECT_PATH)/catalog/authorino-operator-catalog.Dockerfile -t $(CATALOG_IMG)
+	docker build $(PROJECT_DIR)/catalog -f $(PROJECT_DIR)/catalog/authorino-operator-catalog.Dockerfile -t $(CATALOG_IMG)
 
 # Push the catalog image.
 .PHONY: catalog-push

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -1,0 +1,52 @@
+##@ Operator Catalog
+
+# The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
+CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(IMAGE_TAG)
+
+CATALOG_FILE = $(PROJECT_PATH)/catalog/authorino-operator-catalog/operator.yaml
+CATALOG_DOCKERFILE = $(PROJECT_PATH)/catalog/authorino-operator-catalog.Dockerfile
+
+$(CATALOG_DOCKERFILE): $(OPM)
+	-mkdir -p $(PROJECT_PATH)/catalog/authorino-operator-catalog
+	cd $(PROJECT_PATH)/catalog && $(OPM) generate dockerfile authorino-operator-catalog
+catalog-dockerfile: $(CATALOG_DOCKERFILE) ## Generate catalog dockerfile.
+
+$(CATALOG_FILE): $(OPM) $(YQ)
+	@echo "************************************************************"
+	@echo Build authorino operator catalog
+	@echo
+	@echo BUNDLE_IMG					= $(BUNDLE_IMG)
+	@echo CHANNELS						= $(CHANNELS)
+	@echo "************************************************************"
+	@echo
+	@echo Please check this matches your expectations and override variables if needed.
+	@echo
+	$(PROJECT_PATH)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $@ $(CHANNELS)
+
+.PHONY: catalog
+catalog: $(OPM) ## Generate catalog content and validate.
+	# Initializing the Catalog
+	-rm -rf $(PROJECT_PATH)/catalog/authorino-operator-catalog
+	-rm -rf $(PROJECT_PATH)/catalog/authorino-operator-catalog.Dockerfile
+	$(MAKE) $(CATALOG_DOCKERFILE)
+	$(MAKE) $(CATALOG_FILE) BUNDLE_IMG=$(BUNDLE_IMG)
+	cd $(PROJECT_PATH)/catalog && $(OPM) validate authorino-operator-catalog
+
+# Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
+# Ref https://olm.operatorframework.io/docs/tasks/creating-a-catalog/#catalog-creation-with-raw-file-based-catalogs
+.PHONY: catalog-build
+catalog-build: ## Build a catalog image.
+	# Build the Catalog
+	docker build $(PROJECT_PATH)/catalog -f $(PROJECT_PATH)/catalog/authorino-operator-catalog.Dockerfile -t $(CATALOG_IMG)
+
+# Push the catalog image.
+.PHONY: catalog-push
+catalog-push: ## Push a catalog image.
+	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+deploy-catalog: $(KUSTOMIZE) $(YQ) ## Deploy operator to the K8s cluster specified in ~/.kube/config using OLM catalog image.
+	V="$(CATALOG_IMG)" $(YQ) eval '.spec.image = strenv(V)' -i config/deploy/olm/catalogsource.yaml
+	$(KUSTOMIZE) build config/deploy/olm | kubectl apply -f -
+
+undeploy-catalog: $(KUSTOMIZE) ## Undeploy controller from the K8s cluster specified in ~/.kube/config using OLM catalog image.
+	$(KUSTOMIZE) build config/deploy/olm | kubectl delete -f -

--- a/utils/generate-catalog.sh
+++ b/utils/generate-catalog.sh
@@ -15,8 +15,8 @@ BUNDLE_IMG="${3?:Error \$BUNDLE_IMG not set. Bye}"
 CATALOG_FILE="${4?:Error \$CATALOG_FILE not set. Bye}"
 CHANNELS="${5:-$DEFAULT_CHANNEL}"
 
-CATALOG_FILE_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE})" )" && pwd )"
-CATALOG_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE_BASEDIR})" )" && pwd )"
+CATALOG_FILE_BASEDIR="$( cd "$( dirname ${CATALOG_FILE} )" && pwd )"
+CATALOG_BASEDIR="$( cd "$( dirname ${CATALOG_FILE_BASEDIR} )" && pwd )"
 
 TMP_DIR=$(mktemp -d)
 

--- a/utils/generate-catalog.sh
+++ b/utils/generate-catalog.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 ### CONSTANTS
 # Used as well in the subscription object
-DEFAULT_CHANNEL=preview
+DEFAULT_CHANNEL=stable
 ###
 
 OPM="${1?:Error \$OPM not set. Bye}"

--- a/utils/generate-catalog.sh
+++ b/utils/generate-catalog.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Generate OLM catalog file
+
+set -euo pipefail
+
+### CONSTANTS
+# Used as well in the subscription object
+DEFAULT_CHANNEL=preview
+###
+
+OPM="${1?:Error \$OPM not set. Bye}"
+YQ="${2?:Error \$YQ not set. Bye}"
+BUNDLE_IMG="${3?:Error \$BUNDLE_IMG not set. Bye}"
+CATALOG_FILE="${4?:Error \$CATALOG_FILE not set. Bye}"
+CHANNELS="${5:-$DEFAULT_CHANNEL}"
+
+CATALOG_FILE_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE})" )" && pwd )"
+CATALOG_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE_BASEDIR})" )" && pwd )"
+
+TMP_DIR=$(mktemp -d)
+
+${OPM} render ${BUNDLE_IMG} --output=yaml >> ${TMP_DIR}/authorino-operator-bundle.yaml
+
+mkdir -p ${CATALOG_FILE_BASEDIR}
+touch ${CATALOG_FILE}
+
+###
+# Authorino Operator
+###
+# Add the package
+${OPM} init authorino-operator --default-channel=${CHANNELS} --output yaml >> ${CATALOG_FILE}
+# Add a bundles to the Catalog
+cat ${TMP_DIR}/authorino-operator-bundle.yaml >> ${CATALOG_FILE}
+# Add a channel entry for the bundle
+V=`${YQ} eval '.name' ${TMP_DIR}/authorino-operator-bundle.yaml` \
+CHANNELS=${CHANNELS} \
+    ${YQ} eval '(.entries[0].name = strenv(V)) | (.name = strenv(CHANNELS))' ${CATALOG_BASEDIR}/authorino-operator-channel-entry.yaml >> ${CATALOG_FILE}
+
+rm -rf $TMP_DIR


### PR DESCRIPTION
This PR replaces the old catalog generation sql based for the file based. This is due some limitations (semver check that doesn't allow beta tags) and deprecation notice: `time="2024-08-26T13:47:11Z" level=warning msg="\x1b[1;33mDEPRECATION NOTICE:\nSqlite-based catalogs and their related subcommands are deprecated. Support for\nthem will be removed in a future release. Please migrate your catalog workflows\nto the new file-based catalog format.\x1b[0m"
`

### Verification steps

Build local catalog.

```
make catalog
make catalog-build CATALOG_IMG=quay.io/kuadrant/authorino-operator-catalog:local-testing-dd
```

Push the image to Quay.io.

```
make catalog-push CATALOG_IMG=quay.io/kuadrant/authorino-operator-catalog:local-testing-dd
```

Create kind cluster

```
kind create cluster --name kuadrant-local 
```

Deploy OLM

```
bin/operator-sdk olm install
```

Deploy authorino operator using OLM

```
make deploy-catalog CATALOG_IMG=quay.io/kuadrant/authorino-operator-catalog:local-testing-dd
```

Check the authorino operator is up and running (it takes up to few minutes)

```
k get pods -n authorino-operator
NAME                                                              READY   STATUS      RESTARTS   AGE
authorino-operator-catalog-67mrl   0/1     Terminating   0          5s
authorino-operator-catalog-gjc5c   1/1     Running       0          2s
```

