### PR TITLE
Pin operand's latest SHA

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -55,7 +55,7 @@ jobs:
         run: make yq
       - name: Set default authorino image
         run: |
-          echo "DEFAULT_AUTHORINO_IMAGE=$(./bin/yq e -e '.config.authorinoImage' ${{ env.BUILD_CONFIG_FILE }} || echo ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino:latest)" >> $GITHUB_ENV
+          echo "DEFAULT_AUTHORINO_IMAGE=$(./bin/yq e -e '.config.authorinoImage' ${{ env.BUILD_CONFIG_FILE }} || echo ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino:${{ vars.AUTHORINO_SHA }})" >> $GITHUB_ENV
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
@@ -119,7 +119,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Run make bundle (main)
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
-        run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.sha }}
+        run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.sha }} AUTHORINO_VERSION=${{ vars.AUTHORINO_SHA }}
       - name: Run make bundle (release)
         if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
         run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} VERSION=${{env.VERSION}} AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }} CHANNELS=${{ github.event.inputs.channels }} DEFAULT_CHANNEL=stable
@@ -127,7 +127,7 @@ jobs:
         run: git diff
       - name: Verify manifests and bundle (main)
         if: github.ref_name == env.MAIN_BRANCH_NAME
-        run: make verify-manifests verify-bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.sha }}
+        run: make verify-manifests verify-bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.sha }} AUTHORINO_VERSION=${{ vars.AUTHORINO_SHA }}
       - name: Verify manifests and bundle (release)
         if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
         run: make verify-manifests verify-bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} VERSION=${{env.VERSION}} AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }} CHANNELS=${{ github.event.inputs.channels }} DEFAULT_CHANNEL=stable
@@ -193,7 +193,17 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
-      - name: Run make catalog
+      - name: Run make catalog (main)
+        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+        run: |
+          make catalog \
+            REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \
+            VERSION=${{ env.VERSION }} \
+            IMAGE_TAG=${{ github.sha }} \
+            AUTHORINO_VERSION=${{ vars.AUTHORINO_SHA }} \
+            CHANNELS=${{ inputs.channels }}
+      - name: Run make catalog (release)
+        if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
         run: |
           make catalog \
             REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -23,6 +23,7 @@ env:
   MAIN_BRANCH_NAME: main
   OPERATOR_NAME: authorino-operator
   BUILD_CONFIG_FILE: build.yaml
+  LATEST_AUTHORINO_GITREF: ${{ vars.AUTHORINO_SHA != '' && vars.AUTHORINO_SHA || 'latest' }}
 
 jobs:
   build:
@@ -55,7 +56,7 @@ jobs:
         run: make yq
       - name: Set default authorino image
         run: |
-          echo "DEFAULT_AUTHORINO_IMAGE=$(./bin/yq e -e '.config.authorinoImage' ${{ env.BUILD_CONFIG_FILE }} || echo ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino:${{ vars.AUTHORINO_SHA }})" >> $GITHUB_ENV
+          echo "DEFAULT_AUTHORINO_IMAGE=$(./bin/yq e -e '.config.authorinoImage' ${{ env.BUILD_CONFIG_FILE }} || echo ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/authorino:${{ env.LATEST_AUTHORINO_GITREF }})" >> $GITHUB_ENV
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
@@ -119,7 +120,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Run make bundle (main)
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
-        run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.sha }} AUTHORINO_VERSION=${{ vars.AUTHORINO_SHA }}
+        run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.sha }} AUTHORINO_VERSION=${{ env.LATEST_AUTHORINO_GITREF }}
       - name: Run make bundle (release)
         if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
         run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} VERSION=${{env.VERSION}} AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }} CHANNELS=${{ github.event.inputs.channels }} DEFAULT_CHANNEL=stable
@@ -127,7 +128,7 @@ jobs:
         run: git diff
       - name: Verify manifests and bundle (main)
         if: github.ref_name == env.MAIN_BRANCH_NAME
-        run: make verify-manifests verify-bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.sha }} AUTHORINO_VERSION=${{ vars.AUTHORINO_SHA }}
+        run: make verify-manifests verify-bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.sha }} AUTHORINO_VERSION=${{ env.LATEST_AUTHORINO_GITREF }}
       - name: Verify manifests and bundle (release)
         if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
         run: make verify-manifests verify-bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} VERSION=${{env.VERSION}} AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }} CHANNELS=${{ github.event.inputs.channels }} DEFAULT_CHANNEL=stable
@@ -200,7 +201,7 @@ jobs:
             REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \
             VERSION=${{ env.VERSION }} \
             IMAGE_TAG=${{ github.sha }} \
-            AUTHORINO_VERSION=${{ vars.AUTHORINO_SHA }} \
+            AUTHORINO_VERSION=${{ env.LATEST_AUTHORINO_GITREF }} \
             CHANNELS=${{ inputs.channels }}
       - name: Run make catalog (release)
         if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}


### PR DESCRIPTION
Option to pin the operand image tag to a git ref (commit sha) instead of only 'latest' (default) or a release version tag ('vX.Y.Z').

Changes the CI workflow to pin the operand's image tag in the manifests to the latest git ref (commit sha) known at the GitHub org.

This still requires additional automation to rebuild the Operator images whenever the operand's most recent git sha changes (Authorino repo).

Closes #168