### PR TITLE
feat: use RuntimeDefault seccomp profile in security context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,20 @@ bundle: manifests kustomize operator-sdk $(YQ) ## Generate bundle manifests and 
 	$(OPERATOR_SDK) bundle validate ./bundle
 	# Roll back edit
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${DEFAULT_OPERATOR_IMAGE}
+	$(MAKE) bundle-custom-modifications
+
+.PHONY: bundle-custom-modifications
+OPENSHIFT_VERSIONS_ANNOTATION_KEY="com.redhat.openshift.versions"
+# Supports Openshift v4.12+ (https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions)
+OPENSHIFT_SUPPORTED_VERSIONS="v4.12"
+bundle-custom-modifications:
+	# Set Openshift version in bundle annotations
+	$(YQ) -i '.annotations[$(OPENSHIFT_VERSIONS_ANNOTATION_KEY)] = $(OPENSHIFT_SUPPORTED_VERSIONS)' bundle/metadata/annotations.yaml
+	$(YQ) -i '(.annotations[$(OPENSHIFT_VERSIONS_ANNOTATION_KEY)] | key) headComment = "Custom annotations"' bundle/metadata/annotations.yaml
+	# Set Openshift version in bundle Dockerfile
+	@echo "" >> bundle.Dockerfile
+	@echo "# Custom labels" >> bundle.Dockerfile
+	@echo "LABEL $(OPENSHIFT_VERSIONS_ANNOTATION_KEY)=$(OPENSHIFT_SUPPORTED_VERSIONS)" >> bundle.Dockerfile
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -18,3 +18,6 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/
+
+# Custom labels
+LABEL com.redhat.openshift.versions=v4.12

--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -83,7 +83,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/authorino-operator:latest
-    createdAt: "2024-09-12T09:32:42Z"
+    createdAt: "2024-09-12T11:22:55Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/authorino-operator
@@ -498,7 +498,7 @@ spec:
     - email: mcassola@redhat.com
       name: Guilherme Cassolato
   maturity: alpha
-  minKubeVersion: 1.8.0
+  minKubeVersion: 1.25.0
   provider:
     name: Red Hat
   version: 0.0.0

--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -83,7 +83,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/authorino-operator:latest
-    createdAt: "2024-09-03T17:46:45Z"
+    createdAt: "2024-09-12T09:32:42Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/authorino-operator
@@ -345,6 +345,12 @@ spec:
                         memory: 200Mi
                     securityContext:
                       allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      readOnlyRootFilesystem: true
+                      seccompProfile:
+                        type: RuntimeDefault
                 securityContext:
                   runAsNonRoot: true
                 serviceAccountName: authorino-operator

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -8,7 +8,8 @@ annotations:
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
-
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  # Custom annotations
+  com.redhat.openshift.versions: v4.12

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -5767,6 +5767,12 @@ spec:
             memory: 200Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
       securityContext:
         runAsNonRoot: true
       serviceAccountName: authorino-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,6 +33,12 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         ports:
         - name: metrics
           containerPort: 8080

--- a/config/manifests/bases/authorino-operator.clusterserviceversion.template.yaml
+++ b/config/manifests/bases/authorino-operator.clusterserviceversion.template.yaml
@@ -74,7 +74,7 @@ spec:
   - email: mcassola@redhat.com
     name: Guilherme Cassolato
   maturity: alpha
-  minKubeVersion: 1.8.0
+  minKubeVersion: 1.25.0
   provider:
     name: Red Hat
   version: ${BUNDLE_VERSION}

--- a/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ spec:
   - email: mcassola@redhat.com
     name: Guilherme Cassolato
   maturity: alpha
-  minKubeVersion: 1.8.0
+  minKubeVersion: 1.25.0
   provider:
     name: Red Hat
   version: 0.0.0


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/authorino-operator/issues/98

* Re-introduces change to use `RuntimeDefault` as the seccomp profile
* Annotate the bundle for compatibility with OpenShift 4.12+ (https://github.com/redhat-openshift-ecosystem/community-operators-prod/commit/6849cac05456d1074c37bc62e431ea5157a44138)
  * Bundle is always regenerated so these labels were added through the makefile 