### PR TITLE
feat: set quay image expiry to prevent overflow of images

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -1,10 +1,20 @@
 name: Build and push images
 
 on:
-  push:
-    branches:
-      - 'main'
-      - 'master'
+  workflow_call:
+    inputs:
+      authorinoVersion:
+        description: Authorino version
+        required: true
+        default: latest
+      channels:
+        description: Bundle and catalog channels, comma separated
+        required: true
+        default: stable
+      quayImageExpiry:
+        description: When to expire the built quay images. The time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively, from the time the image is built.
+        default: never
+        type: string
   workflow_dispatch:
     inputs:
       authorinoVersion:
@@ -15,15 +25,19 @@ on:
         description: Bundle and catalog channels, comma separated
         required: true
         default: stable
+      quayImageExpiry:
+        description: When to expire the built quay images. The time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively, from the time the image is built.
+        default: never
+        type: string
 
 env:
-  IMG_TAGS: ${{ github.sha }}
+  IMG_TAGS: ${{ inputs.authorinoVersion }}
   IMG_REGISTRY_HOST: quay.io
   IMG_REGISTRY_ORG: kuadrant
-  MAIN_BRANCH_NAME: main
   OPERATOR_NAME: authorino-operator
   BUILD_CONFIG_FILE: build.yaml
   LATEST_AUTHORINO_GITREF: ${{ vars.AUTHORINO_SHA != '' && vars.AUTHORINO_SHA || 'latest' }}
+  QUAY_IMAGE_EXPIRY: ${{ inputs.quayImageExpiry }}
 
 jobs:
   build:
@@ -32,16 +46,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Add latest tag
-        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
-        id: add-latest-tag
-        run: |
-          echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
-      - name: Add branch tag
-        if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
-        id: add-branch-tag
-        run: |
-          echo "IMG_TAGS=${GITHUB_REF_NAME/\//-} ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
       - name: Set Operator version
         id: operator-version
         run: |
@@ -69,6 +73,7 @@ jobs:
             GIT_SHA=${{ github.sha }}
             DIRTY=false
             DEFAULT_AUTHORINO_IMAGE=${{ env.DEFAULT_AUTHORINO_IMAGE }}
+            QUAY_IMAGE_EXPIRY=${{ inputs.quayImageExpiry }}
           containerfiles: |
             ./Dockerfile
       - name: Push Image
@@ -143,6 +148,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           build-args: |
             version=${{ env.VERSION }}
+            QUAY_IMAGE_EXPIRY=${{ inputs.quayImageExpiry }}
           containerfiles: |
             ./bundle.Dockerfile
       - name: Push Image
@@ -225,6 +231,7 @@ jobs:
           context: ./catalog
           dockerfiles: |
             ./catalog/${{ env.OPERATOR_NAME }}-catalog.Dockerfile
+          # The Quay image expiry label for the generated catalog Dockerfile is set via opm, using the value set in the QUAY_IMAGE_EXPIRY environment variable
       - name: Push Image
         if: ${{ !env.ACT }}
         id: push-to-quay

--- a/.github/workflows/build-images-main-sha.yaml
+++ b/.github/workflows/build-images-main-sha.yaml
@@ -1,0 +1,14 @@
+name: Build SHA image for main branch
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  workflow-build:
+    name: Calls build-images-base workflow
+    uses: ./.github/workflows/build-images-base.yaml
+    secrets: inherit
+    with:
+      authorinoVersion: ${{ github.sha }}
+      quayImageExpiry: 2w

--- a/.github/workflows/build-images-main.yaml
+++ b/.github/workflows/build-images-main.yaml
@@ -1,0 +1,11 @@
+name: Build latest image for main branch
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  workflow-build:
+    name: Calls build-images-base workflow
+    uses: ./.github/workflows/build-images-base.yaml
+    secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,9 @@ WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 1001
 
+# Quay image expiry
+ARG QUAY_IMAGE_EXPIRY
+ENV QUAY_IMAGE_EXPIRY=${QUAY_IMAGE_EXPIRY:-never}
+LABEL quay.expires-after=$QUAY_IMAGE_EXPIRY
+
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 docker-build: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 docker-build: DIRTY=$(shell $(PROJECT_DIR)/utils/check-git-dirty.sh || echo "unknown")
 docker-build:  ## Build docker image with the manager.
-	docker build --build-arg VERSION=$(VERSION) --build-arg GIT_SHA=$(GIT_SHA) --build-arg DIRTY=$(DIRTY) --build-arg ACTUAL_DEFAULT_AUTHORINO_IMAGE=$(ACTUAL_DEFAULT_AUTHORINO_IMAGE) -t $(OPERATOR_IMAGE) .
+	docker build --build-arg VERSION=$(VERSION) --build-arg GIT_SHA=$(GIT_SHA) --build-arg DIRTY=$(DIRTY) --build-arg ACTUAL_DEFAULT_AUTHORINO_IMAGE=$(ACTUAL_DEFAULT_AUTHORINO_IMAGE) --build-arg QUAY_IMAGE_EXPIRY=$(QUAY_IMAGE_EXPIRY) -t $(OPERATOR_IMAGE) .
 
 docker-push: ## Push docker image with the manager.
 	docker push ${OPERATOR_IMAGE}
@@ -311,11 +311,13 @@ bundle-custom-modifications:
 	# Set Openshift version in bundle Dockerfile
 	@echo "" >> bundle.Dockerfile
 	@echo "# Custom labels" >> bundle.Dockerfile
+	# Quay image expiry label
+	@echo "$$QUAY_EXPIRY_TIME_LABEL" >> bundle.Dockerfile
 	@echo "LABEL $(OPENSHIFT_VERSIONS_ANNOTATION_KEY)=$(OPENSHIFT_SUPPORTED_VERSIONS)" >> bundle.Dockerfile
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	docker build --build-arg QUAY_IMAGE_EXPIRY=$(QUAY_IMAGE_EXPIRY) -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -20,4 +20,8 @@ COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/
 
 # Custom labels
+## Quay image expiry
+ARG QUAY_IMAGE_EXPIRY
+ENV QUAY_IMAGE_EXPIRY=${QUAY_IMAGE_EXPIRY:-never}
+LABEL quay.expires-after=${QUAY_IMAGE_EXPIRY}
 LABEL com.redhat.openshift.versions=v4.12

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -6,9 +6,21 @@ CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(IMAGE_TAG)
 CATALOG_FILE = $(PROJECT_DIR)/catalog/authorino-operator-catalog/operator.yaml
 CATALOG_DOCKERFILE = $(PROJECT_DIR)/catalog/authorino-operator-catalog.Dockerfile
 
+# Quay image default expiry
+QUAY_IMAGE_EXPIRY ?= never
+
+# A LABEL that can be appended to a generated Dockerfile to set the Quay image expiration through Docker arguments.
+define QUAY_EXPIRY_TIME_LABEL
+## Quay image expiry
+ARG QUAY_IMAGE_EXPIRY
+ENV QUAY_IMAGE_EXPIRY=$${QUAY_IMAGE_EXPIRY:-never}
+LABEL quay.expires-after=$${QUAY_IMAGE_EXPIRY}
+endef
+export QUAY_EXPIRY_TIME_LABEL
+
 $(CATALOG_DOCKERFILE): $(OPM)
 	-mkdir -p $(PROJECT_DIR)/catalog/authorino-operator-catalog
-	cd $(PROJECT_DIR)/catalog && $(OPM) generate dockerfile authorino-operator-catalog
+	cd $(PROJECT_DIR)/catalog && $(OPM) generate dockerfile authorino-operator-catalog -l quay.expires-after=$(QUAY_IMAGE_EXPIRY)
 catalog-dockerfile: $(CATALOG_DOCKERFILE) ## Generate catalog dockerfile.
 
 $(CATALOG_FILE): $(OPM) $(YQ)


### PR DESCRIPTION
# Description
Part of: https://github.com/Kuadrant/kuadrant-operator/issues/769
Associated with: https://github.com/Kuadrant/kuadrant-operator/pull/843

Currently, all built Quay images never expire and are consuming unnecessary quota on Quay.io. Quay provides a way to [set tag expiration from a Dockerfile](https://docs.redhat.com/en/documentation/red_hat_quay/3.4/html/use_red_hat_quay/working_with_tags#setting_tag_expiration_from_a_dockerfile) to prevent this issue for images that don't need to be kept indefinitely, such as development branches and nightly builds. This can help prevent the problem from escalating over time.

# Verification
Since there is no auto trigger of building the images on dev branches, you at manually verify at least the makefile changes by:

  *  Remove local image
     ```
     docker rmi quay.io/kuadrant/authorino-operator:latest
     docker rmi quay.io/kuadrant/authorino-operator-bundle:latest
     docker rmi quay.io/kuadrant/authorino-operator-catalog:latest
     ```
  * Build image
    ```
     # Delete the generated catalog Dockerfile as it won't regenerate again with the correct label if it's already present
     rm catalog/authorino-operator-catalog.Dockerfile 
     make docker-build bundle-build catalog-dockerfile catalog-build
    ```
  * Inspect image labels 
    ```
    docker inspect quay.io/kuadrant/authorino-operator:latest --format='{{json .Config.Labels}}'
    docker inspect quay.io/kuadrant/authorino-operator-bundle:latest --format='{{json .Config.Labels}}'
    docker inspect quay.io/kuadrant/authorino-operator-catalog:latest --format='{{json .Config.Labels}}'
    ```
  * The `quay.expires-after` label should be set to `never`
     
    ![image](https://github.com/user-attachments/assets/980f8b57-1ec7-434e-9b99-05a878182d53)

  * Remove local image again
     ```
     docker rmi quay.io/kuadrant/authorino-operator:latest
     docker rmi quay.io/kuadrant/authorino-operator-bundle:latest
     docker rmi quay.io/kuadrant/authorino-operator-catalog:latest
     ```
  * Build image with a set expiry
    ```
     # Delete the generated catalog Dockerfile as it won't regenerate again with the correct label if it's already present
     rm catalog/authorino-operator-catalog.Dockerfile 
     QUAY_IMAGE_EXPIRY=3d make docker-build bundle-build catalog-dockerfile catalog-build
    ```
  * Inspect image labels 
    ```
    docker inspect quay.io/kuadrant/authorino-operator:latest --format='{{json .Config.Labels}}'
    docker inspect quay.io/kuadrant/authorino-operator-bundle:latest --format='{{json .Config.Labels}}'
    docker inspect quay.io/kuadrant/authorino-operator-catalog:latest --format='{{json .Config.Labels}}'
    ```
  * The `quay.expires-after` label should be set to `3d`
    
     ![image](https://github.com/user-attachments/assets/59be3a58-39ea-4724-83af-157f2cb550c2)