### PR TITLE
feat: support arm64 install on csv

### DIFF
--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -83,13 +83,14 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/authorino-operator:latest
-    createdAt: "2024-09-12T11:22:55Z"
+    createdAt: "2024-09-19T13:31:42Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/authorino-operator
     support: kuadrant
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported

--- a/config/manifests/bases/authorino-operator.clusterserviceversion.template.yaml
+++ b/config/manifests/bases/authorino-operator.clusterserviceversion.template.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: placeholder
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/os.linux: supported

--- a/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: placeholder
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/os.linux: supported


### PR DESCRIPTION
# Description 

We already build the arm64 image for the binary, bundle and catalog

* https://github.com/Kuadrant/authorino-operator/blob/82e7719ad48aa1cbfa95faff3e9d2c026b9c22d7/.github/workflows/build-images.yaml#L66
* https://github.com/Kuadrant/authorino-operator/blob/82e7719ad48aa1cbfa95faff3e9d2c026b9c22d7/.github/workflows/build-images.yaml#L143
* https://github.com/Kuadrant/authorino-operator/blob/82e7719ad48aa1cbfa95faff3e9d2c026b9c22d7/.github/workflows/build-images.yaml#L224

However, we do not set allowing this install on the CSV. This prevents the catalog from showing on OperatorHub if we want to verify the catalog install via local Openshift platforms such as [CRC](https://docs.redhat.com/en/documentation/red_hat_codeready_containers/2.0/html/getting_started_guide/introducing-codeready-containers_gsg#about-codeready-containers_gsg) if the local environment is using the `arm64` architecture.

This changes adds `arm64` as a supported architecture on the CSV to allow for installing the image/bundle/catalog to this architecture