### PR TITLE
Avoid conflict with the VERSION build arg

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -65,7 +65,7 @@ jobs:
           tags: ${{ env.IMG_TAGS }}
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           build-args: |
-            VERSION=${{ env.VERSION }}
+            OPERATOR_VERSION=${{ env.VERSION }}
             GIT_SHA=${{ github.sha }}
             DIRTY=false
             DEFAULT_AUTHORINO_IMAGE=${{ env.DEFAULT_AUTHORINO_IMAGE }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
-ARG VERSION=latest
+ARG OPERATOR_VERSION=latest
 ARG DEFAULT_AUTHORINO_IMAGE=quay.io/kuadrant/authorino:latest
 ARG GIT_SHA=unknown
 ARG DIRTY=unknown
 
-RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "-X main.version=${VERSION} -X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY} -X github.com/kuadrant/authorino-operator/controllers.DefaultAuthorinoImage=${DEFAULT_AUTHORINO_IMAGE}" -o manager main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "-X main.version=${OPERATOR_VERSION} -X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY} -X github.com/kuadrant/authorino-operator/controllers.DefaultAuthorinoImage=${DEFAULT_AUTHORINO_IMAGE}" -o manager main.go
 
 # Use Red Hat minimal base image to package the binary
 # https://catalog.redhat.com/software/containers/ubi9-minimal

--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 docker-build: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 docker-build: DIRTY=$(shell $(PROJECT_DIR)/utils/check-git-dirty.sh || echo "unknown")
 docker-build:  ## Build docker image with the manager.
-	docker build --build-arg VERSION=$(VERSION) --build-arg GIT_SHA=$(GIT_SHA) --build-arg DIRTY=$(DIRTY) --build-arg ACTUAL_DEFAULT_AUTHORINO_IMAGE=$(ACTUAL_DEFAULT_AUTHORINO_IMAGE) -t $(OPERATOR_IMAGE) .
+	docker build --build-arg OPERATOR_VERSION=$(VERSION) --build-arg GIT_SHA=$(GIT_SHA) --build-arg DIRTY=$(DIRTY) --build-arg ACTUAL_DEFAULT_AUTHORINO_IMAGE=$(ACTUAL_DEFAULT_AUTHORINO_IMAGE) -t $(OPERATOR_IMAGE) .
 
 docker-push: ## Push docker image with the manager.
 	docker push ${OPERATOR_IMAGE}


### PR DESCRIPTION
Use a different name for the `VERSION` build arg in the Dockerfile, to avoid conflict with env vars set at the base image.

```
❯ docker run --rm -ti registry.access.redhat.com/ubi9/go-toolset:1.21 /bin/bash
bash-5.1$ echo ${VERSION}
1.21.13
```