### PR TITLE
refactor: update manifests for authconfig v1beta3

### DIFF
--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -5,34 +5,6 @@ metadata:
     alm-examples: |-
       [
         {
-          "apiVersion": "authorino.kuadrant.io/v1beta1",
-          "kind": "AuthConfig",
-          "metadata": {
-            "name": "my-api-protection"
-          },
-          "spec": {
-            "hosts": [
-              "my-api.io"
-            ],
-            "identity": [
-              {
-                "apiKey": {
-                  "selector": {
-                    "matchLabels": {
-                      "group": "friends"
-                    }
-                  }
-                },
-                "credentials": {
-                  "in": "authorization_header",
-                  "keySelector": "APIKEY"
-                },
-                "name": "api-key-users"
-              }
-            ]
-          }
-        },
-        {
           "apiVersion": "authorino.kuadrant.io/v1beta2",
           "kind": "AuthConfig",
           "metadata": {
@@ -83,7 +55,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/authorino-operator:latest
-    createdAt: "2024-09-30T15:29:42Z"
+    createdAt: "2024-10-16T16:01:21Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/authorino-operator
@@ -104,12 +76,10 @@ spec:
         displayName: AuthConfig
         kind: AuthConfig
         name: authconfigs.authorino.kuadrant.io
-        version: v1beta1
-      - description: API to describe the desired protection for a service
-        displayName: AuthConfig
-        kind: AuthConfig
-        name: authconfigs.authorino.kuadrant.io
         version: v1beta2
+      - kind: AuthConfig
+        name: authconfigs.authorino.kuadrant.io
+        version: v1beta3
       - description: API to create instances of authorino
         displayName: Authorino
         kind: Authorino

--- a/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
+++ b/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
@@ -60,7 +60,7 @@ spec:
       name: Wristband
       priority: 2
       type: boolean
-    name: v1beta1
+    name: v1beta2
     schema:
       openAPIV3Schema:
         description: AuthConfig is the schema for Authorino's AuthConfig API
@@ -87,1130 +87,51 @@ spec:
               the authencation/authorization scheme to be applied to protect the matching
               service hosts.
             properties:
-              authorization:
-                description: |-
-                  Authorization is the list of authorization policies.
-                  All policies in this list MUST evaluate to "true" for a request be successful in the authorization phase.
-                items:
-                  description: |-
-                    Authorization policy to be enforced.
-                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "opa", "json" or "kubernetes".
-                  oneOf:
-                  - properties:
-                      name: {}
-                      opa: {}
-                    required:
-                    - name
-                    - opa
-                  - properties:
-                      json: {}
-                      name: {}
-                    required:
-                    - name
-                    - json
-                  - properties:
-                      kubernetes: {}
-                      name: {}
-                    required:
-                    - name
-                    - kubernetes
-                  - properties:
-                      authzed: {}
-                      name: {}
-                    required:
-                    - name
-                    - authzed
-                  properties:
-                    authzed:
-                      description: Authzed authorization
-                      properties:
-                        endpoint:
-                          description: Endpoint of the Authzed service.
-                          type: string
-                        insecure:
-                          description: Insecure HTTP connection (i.e. disables TLS
-                            verification)
-                          type: boolean
-                        permission:
-                          description: The name of the permission (or relation) on
-                            which to execute the check.
-                          properties:
-                            value:
-                              description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          type: object
-                        resource:
-                          description: The resource on which to check the permission
-                            or relation.
-                          properties:
-                            kind:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            name:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                        sharedSecretRef:
-                          description: Reference to a Secret key whose value will
-                            be used by Authorino to authenticate with the Authzed
-                            service.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: The name of the secret in the Authorino's
-                                namespace to select from.
-                              type: string
-                          required:
-                          - key
-                          - name
-                          type: object
-                        subject:
-                          description: The subject that will be checked for the permission
-                            or relation.
-                          properties:
-                            kind:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            name:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                      required:
-                      - endpoint
-                      type: object
-                    cache:
-                      description: |-
-                        Caching options for the policy evaluation results when enforcing this config.
-                        Omit it to avoid caching policy evaluation results for this config.
-                      properties:
-                        key:
-                          description: |-
-                            Key used to store the entry in the cache.
-                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
-                          properties:
-                            value:
-                              description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          type: object
-                        ttl:
-                          default: 60
-                          description: Duration (in seconds) of the external data
-                            in the cache before pulled again from the source.
-                          type: integer
-                      required:
-                      - key
-                      type: object
-                    json:
-                      description: JSON pattern matching authorization policy.
-                      properties:
-                        rules:
-                          description: The rules that must all evaluate to "true"
-                            for the request to be authorized.
-                          items:
-                            oneOf:
-                            - properties:
-                                patternRef: {}
-                              required:
-                              - patternRef
-                            - properties:
-                                operator: {}
-                                selector: {}
-                                value: {}
-                              required:
-                              - operator
-                              - selector
-                            - properties:
-                                all: {}
-                              required:
-                              - all
-                            - properties:
-                                any: {}
-                              required:
-                              - any
-                            properties:
-                              all:
-                                description: A list of pattern expressions to be evaluated
-                                  as a logical AND.
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                type: array
-                              any:
-                                description: A list of pattern expressions to be evaluated
-                                  as a logical OR.
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                type: array
-                              operator:
-                                description: |-
-                                  The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
-                                  Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
-                                enum:
-                                - eq
-                                - neq
-                                - incl
-                                - excl
-                                - matches
-                                type: string
-                              patternRef:
-                                description: Name of a named pattern
-                                type: string
-                              selector:
-                                description: |-
-                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                                  The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
-                                type: string
-                              value:
-                                description: |-
-                                  The value of reference for the comparison with the content fetched from the authorization JSON.
-                                  If used with the "matches" operator, the value must compile to a valid Golang regex.
-                                type: string
-                            type: object
-                          type: array
-                      required:
-                      - rules
-                      type: object
-                    kubernetes:
-                      description: |-
-                        Kubernetes authorization policy based on `SubjectAccessReview`
-                        Path and Verb are inferred from the request.
-                      properties:
-                        groups:
-                          description: Groups to test for.
-                          items:
-                            type: string
-                          type: array
-                        resourceAttributes:
-                          description: |-
-                            Use ResourceAttributes for checking permissions on Kubernetes resources
-                            If omitted, it performs a non-resource `SubjectAccessReview`, with verb and path inferred from the request.
-                          properties:
-                            group:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            name:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            namespace:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            resource:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            subresource:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            verb:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                        user:
-                          description: |-
-                            User to test for.
-                            If without "Groups", then is it interpreted as "What if User were not a member of any groups"
-                          properties:
-                            value:
-                              description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          type: object
-                      required:
-                      - user
-                      type: object
-                    metrics:
-                      default: false
-                      description: Whether this authorization config should generate
-                        individual observability metrics
-                      type: boolean
-                    name:
-                      description: |-
-                        Name of the authorization policy.
-                        It can be used to refer to the resolved authorization object in other configs.
-                      type: string
-                    opa:
-                      description: Open Policy Agent (OPA) authorization policy.
-                      properties:
-                        allValues:
-                          default: false
-                          description: |-
-                            Returns the value of all Rego rules in the virtual document. Values can be read in subsequent evaluators/phases of the Auth Pipeline.
-                            Otherwise, only the default `allow` rule will be exposed.
-                            Returning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.
-                          type: boolean
-                        externalRegistry:
-                          description: External registry of OPA policies.
-                          properties:
-                            credentials:
-                              description: |-
-                                Defines where client credentials will be passed in the request to the service.
-                                If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
-                              properties:
-                                in:
-                                  default: authorization_header
-                                  description: The location in the request where client
-                                    credentials shall be passed on requests authenticating
-                                    with this identity source/authentication mode.
-                                  enum:
-                                  - authorization_header
-                                  - custom_header
-                                  - query
-                                  - cookie
-                                  type: string
-                                keySelector:
-                                  description: |-
-                                    Used in conjunction with the `in` parameter.
-                                    When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
-                                    When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
-                                  type: string
-                              required:
-                              - keySelector
-                              type: object
-                            endpoint:
-                              description: |-
-                                Endpoint of the HTTP external registry.
-                                The endpoint must respond with either plain/text or application/json content-type.
-                                In the latter case, the JSON returned in the body must include a path `result.raw`, where the raw Rego policy will be extracted from. This complies with the specification of the OPA REST API (https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
-                              type: string
-                            sharedSecretRef:
-                              description: |-
-                                Reference to a Secret key whose value will be passed by Authorino in the request.
-                                The HTTP service can use the shared secret to authenticate the origin of the request.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: The name of the secret in the Authorino's
-                                    namespace to select from.
-                                  type: string
-                              required:
-                              - key
-                              - name
-                              type: object
-                            ttl:
-                              description: Duration (in seconds) of the external data
-                                in the cache before pulled again from the source.
-                              type: integer
-                          type: object
-                        inlineRego:
-                          description: |-
-                            Authorization policy as a Rego language document.
-                            The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed).
-                            The Rego document must NOT include the "package" declaration in line 1.
-                          type: string
-                      type: object
-                    priority:
-                      default: 0
-                      description: |-
-                        Priority group of the config.
-                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
-                      type: integer
-                    when:
-                      description: |-
-                        Conditions for Authorino to enforce this authorization policy.
-                        If omitted, the config will be enforced for all requests.
-                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
-                      items:
-                        oneOf:
-                        - properties:
-                            patternRef: {}
-                          required:
-                          - patternRef
-                        - properties:
-                            operator: {}
-                            selector: {}
-                            value: {}
-                          required:
-                          - operator
-                          - selector
-                        - properties:
-                            all: {}
-                          required:
-                          - all
-                        - properties:
-                            any: {}
-                          required:
-                          - any
-                        properties:
-                          all:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical AND.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          any:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical OR.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          operator:
-                            description: |-
-                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
-                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
-                            enum:
-                            - eq
-                            - neq
-                            - incl
-                            - excl
-                            - matches
-                            type: string
-                          patternRef:
-                            description: Name of a named pattern
-                            type: string
-                          selector:
-                            description: |-
-                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
-                            type: string
-                          value:
-                            description: |-
-                              The value of reference for the comparison with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must compile to a valid Golang regex.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - name
-                  type: object
-                type: array
-              callbacks:
-                description: |-
-                  List of callback configs.
-                  Authorino sends callbacks to specified endpoints at the end of the auth pipeline.
-                items:
-                  description: Endpoints to callback at the end of each auth pipeline.
-                  properties:
-                    http:
-                      description: Generic HTTP interface to obtain authorization
-                        metadata from a HTTP service.
-                      properties:
-                        body:
-                          description: |-
-                            Raw body of the HTTP request.
-                            Supersedes 'bodyParameters'; use either one or the other.
-                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
-                          properties:
-                            value:
-                              description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          type: object
-                        bodyParameters:
-                          description: |-
-                            Custom parameters to encode in the body of the HTTP request.
-                            Superseded by 'body'; use either one or the other.
-                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
-                          items:
-                            properties:
-                              name:
-                                description: The name of the JSON property
-                                type: string
-                              value:
-                                description: Static value of the JSON property
-                                x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
-                                properties:
-                                  authJSON:
-                                    description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        contentType:
-                          default: application/x-www-form-urlencoded
-                          description: |-
-                            Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
-                            Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
-                          enum:
-                          - application/x-www-form-urlencoded
-                          - application/json
-                          type: string
-                        credentials:
-                          description: |-
-                            Defines where client credentials will be passed in the request to the service.
-                            If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
-                          properties:
-                            in:
-                              default: authorization_header
-                              description: The location in the request where client
-                                credentials shall be passed on requests authenticating
-                                with this identity source/authentication mode.
-                              enum:
-                              - authorization_header
-                              - custom_header
-                              - query
-                              - cookie
-                              type: string
-                            keySelector:
-                              description: |-
-                                Used in conjunction with the `in` parameter.
-                                When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
-                                When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
-                              type: string
-                          required:
-                          - keySelector
-                          type: object
-                        endpoint:
-                          description: |-
-                            Endpoint of the HTTP service.
-                            The endpoint accepts variable placeholders in the format "{selector}", where "selector" is any pattern supported
-                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
-                            E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
-                          type: string
-                        headers:
-                          description: Custom headers in the HTTP request.
-                          items:
-                            properties:
-                              name:
-                                description: The name of the JSON property
-                                type: string
-                              value:
-                                description: Static value of the JSON property
-                                x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
-                                properties:
-                                  authJSON:
-                                    description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        method:
-                          default: GET
-                          description: |-
-                            HTTP verb used in the request to the service. Accepted values: GET (default), POST.
-                            When the request method is POST, the authorization JSON is passed in the body of the request.
-                          enum:
-                          - GET
-                          - POST
-                          type: string
-                        oauth2:
-                          description: Authentication with the HTTP service by OAuth2
-                            Client Credentials grant.
-                          properties:
-                            cache:
-                              default: true
-                              description: |-
-                                Caches and reuses the token until expired.
-                                Set it to false to force fetch the token at every authorization request regardless of expiration.
-                              type: boolean
-                            clientId:
-                              description: OAuth2 Client ID.
-                              type: string
-                            clientSecretRef:
-                              description: Reference to a Kubernetes Secret key that
-                                stores that OAuth2 Client Secret.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: The name of the secret in the Authorino's
-                                    namespace to select from.
-                                  type: string
-                              required:
-                              - key
-                              - name
-                              type: object
-                            extraParams:
-                              additionalProperties:
-                                type: string
-                              description: Optional extra parameters for the requests
-                                to the token URL.
-                              type: object
-                            scopes:
-                              description: Optional scopes for the client credentials
-                                grant, if supported by he OAuth2 server.
-                              items:
-                                type: string
-                              type: array
-                            tokenUrl:
-                              description: Token endpoint URL of the OAuth2 resource
-                                server.
-                              type: string
-                          required:
-                          - clientId
-                          - clientSecretRef
-                          - tokenUrl
-                          type: object
-                        sharedSecretRef:
-                          description: |-
-                            Reference to a Secret key whose value will be passed by Authorino in the request.
-                            The HTTP service can use the shared secret to authenticate the origin of the request.
-                            Ignored if used together with oauth2.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: The name of the secret in the Authorino's
-                                namespace to select from.
-                              type: string
-                          required:
-                          - key
-                          - name
-                          type: object
-                      required:
-                      - endpoint
-                      type: object
-                    metrics:
-                      default: false
-                      description: Whether this callback config should generate individual
-                        observability metrics
-                      type: boolean
-                    name:
-                      description: |-
-                        Name of the callback.
-                        It can be used to refer to the resolved callback response in other configs.
-                      type: string
-                    priority:
-                      default: 0
-                      description: |-
-                        Priority group of the config.
-                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
-                      type: integer
-                    when:
-                      description: |-
-                        Conditions for Authorino to perform this callback.
-                        If omitted, the callback will be attempted for all requests.
-                        If present, all conditions must match for the callback to be attempted; otherwise, the callback will be skipped.
-                      items:
-                        properties:
-                          all:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical AND.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          any:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical OR.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          operator:
-                            description: |-
-                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
-                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
-                            enum:
-                            - eq
-                            - neq
-                            - incl
-                            - excl
-                            - matches
-                            type: string
-                          patternRef:
-                            description: Name of a named pattern
-                            type: string
-                          selector:
-                            description: |-
-                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
-                            type: string
-                          value:
-                            description: |-
-                              The value of reference for the comparison with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must compile to a valid Golang regex.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - http
-                  - name
-                  type: object
-                type: array
-              denyWith:
-                description: Custom denial response codes, statuses and headers to
-                  override default 40x's.
-                properties:
-                  unauthenticated:
-                    description: Denial status customization when the request is unauthenticated.
-                    properties:
-                      body:
-                        description: HTTP response body to override the default denial
-                          body.
-                        properties:
-                          value:
-                            description: Static value
-                            type: string
-                          valueFrom:
-                            description: Dynamic value
-                            properties:
-                              authJSON:
-                                description: |-
-                                  Selector to fetch a value from the authorization JSON.
-                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                type: string
-                            type: object
-                        type: object
-                      code:
-                        description: HTTP status code to override the default denial
-                          status code.
-                        format: int64
-                        maximum: 599
-                        minimum: 300
-                        type: integer
-                      headers:
-                        description: HTTP response headers to override the default
-                          denial headers.
-                        items:
-                          properties:
-                            name:
-                              description: The name of the JSON property
-                              type: string
-                            value:
-                              description: Static value of the JSON property
-                              x-kubernetes-preserve-unknown-fields: true
-                            valueFrom:
-                              description: Dynamic value of the JSON property
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      message:
-                        description: HTTP message to override the default denial message.
-                        properties:
-                          value:
-                            description: Static value
-                            type: string
-                          valueFrom:
-                            description: Dynamic value
-                            properties:
-                              authJSON:
-                                description: |-
-                                  Selector to fetch a value from the authorization JSON.
-                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                type: string
-                            type: object
-                        type: object
-                    type: object
-                  unauthorized:
-                    description: Denial status customization when the request is unauthorized.
-                    properties:
-                      body:
-                        description: HTTP response body to override the default denial
-                          body.
-                        properties:
-                          value:
-                            description: Static value
-                            type: string
-                          valueFrom:
-                            description: Dynamic value
-                            properties:
-                              authJSON:
-                                description: |-
-                                  Selector to fetch a value from the authorization JSON.
-                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                type: string
-                            type: object
-                        type: object
-                      code:
-                        description: HTTP status code to override the default denial
-                          status code.
-                        format: int64
-                        maximum: 599
-                        minimum: 300
-                        type: integer
-                      headers:
-                        description: HTTP response headers to override the default
-                          denial headers.
-                        items:
-                          properties:
-                            name:
-                              description: The name of the JSON property
-                              type: string
-                            value:
-                              description: Static value of the JSON property
-                              x-kubernetes-preserve-unknown-fields: true
-                            valueFrom:
-                              description: Dynamic value of the JSON property
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      message:
-                        description: HTTP message to override the default denial message.
-                        properties:
-                          value:
-                            description: Static value
-                            type: string
-                          valueFrom:
-                            description: Dynamic value
-                            properties:
-                              authJSON:
-                                description: |-
-                                  Selector to fetch a value from the authorization JSON.
-                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                type: string
-                            type: object
-                        type: object
-                    type: object
-                type: object
-              hosts:
-                description: |-
-                  The list of public host names of the services protected by this authentication/authorization scheme.
-                  Authorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.
-                items:
-                  type: string
-                type: array
-              identity:
-                description: |-
-                  List of identity sources/authentication modes.
-                  At least one config of this list MUST evaluate to a valid identity for a request to be successful in the identity verification phase.
-                items:
-                  description: |-
-                    The identity source/authentication mode config.
-                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "oicd", "apiKey" or "kubernetes".
+              authentication:
+                additionalProperties:
                   oneOf:
                   - properties:
                       credentials: {}
-                      name: {}
-                      oauth2: {}
+                      oauth2Introspection: {}
                     required:
-                    - name
-                    - oauth2
+                    - oauth2Introspection
                   - properties:
                       credentials: {}
-                      name: {}
-                      oidc: {}
+                      jwt: {}
                     required:
-                    - name
-                    - oidc
+                    - jwt
                   - properties:
                       apiKey: {}
                       credentials: {}
-                      name: {}
                     required:
-                    - name
                     - apiKey
                   - properties:
                       credentials: {}
-                      mtls: {}
-                      name: {}
+                      x509: {}
                     required:
-                    - name
-                    - mtls
+                    - x509
                   - properties:
                       credentials: {}
-                      kubernetes: {}
-                      name: {}
+                      kubernetesTokenReview: {}
                     required:
-                    - name
-                    - kubernetes
+                    - kubernetesTokenReview
                   - properties:
                       anonymous: {}
                       credentials: {}
-                      name: {}
                     required:
-                    - name
                     - anonymous
                   - properties:
                       credentials: {}
-                      name: {}
                       plain: {}
                     required:
-                    - name
                     - plain
                   properties:
                     anonymous:
+                      description: Anonymous access.
                       type: object
                     apiKey:
+                      description: Authentication based on API keys stored in Kubernetes
+                        secrets.
                       properties:
                         allNamespaces:
                           default: false
@@ -1269,29 +190,23 @@ spec:
                       type: object
                     cache:
                       description: |-
-                        Caching options for the identity resolved when applying this config.
-                        Omit it to avoid caching identity objects for this config.
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
                       properties:
                         key:
                           description: |-
                             Key used to store the entry in the cache.
-                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                            The resolved key must be unique within the scope of this particular config.
                           properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
                             value:
                               description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                           type: object
                         ttl:
                           default: 60
@@ -1303,63 +218,74 @@ spec:
                       type: object
                     credentials:
                       description: |-
-                        Defines where client credentials are required to be passed in the request for this identity source/authentication mode.
-                        If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the credentials value (token, API key, etc).
+                        Defines where credentials are required to be passed in the request for authentication based on this config.
+                        If omitted, it defaults to credentials passed in the HTTP Authorization header and the "Bearer" prefix prepended to the secret credential value.
                       properties:
-                        in:
-                          default: authorization_header
-                          description: The location in the request where client credentials
-                            shall be passed on requests authenticating with this identity
-                            source/authentication mode.
-                          enum:
-                          - authorization_header
-                          - custom_header
-                          - query
-                          - cookie
-                          type: string
-                        keySelector:
-                          description: |-
-                            Used in conjunction with the `in` parameter.
-                            When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
-                            When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
-                          type: string
-                      required:
-                      - keySelector
+                        authorizationHeader:
+                          properties:
+                            prefix:
+                              type: string
+                          type: object
+                        cookie:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        customHeader:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        queryString:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
                       type: object
-                    extendedProperties:
-                      description: |-
-                        Extends the resolved identity object with additional custom properties before appending to the authorization JSON.
-                        It requires the resolved identity object to always be of the JSON type 'object'. Other JSON types (array, string, etc) will break.
-                      items:
+                    defaults:
+                      additionalProperties:
                         properties:
-                          name:
-                            description: The name of the JSON property
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                             type: string
-                          overwrite:
-                            default: false
-                            description: Whether the value should overwrite the value
-                              of an existing property with the same name.
-                            type: boolean
                           value:
-                            description: Static value of the JSON property
+                            description: Static value
                             x-kubernetes-preserve-unknown-fields: true
-                          valueFrom:
-                            description: Dynamic value of the JSON property
-                            properties:
-                              authJSON:
-                                description: |-
-                                  Selector to fetch a value from the authorization JSON.
-                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                type: string
-                            type: object
-                        required:
-                        - name
                         type: object
-                      type: array
-                    kubernetes:
+                      description: |-
+                        Set default property values (claims) for the resolved identity object, that are set before appending the object to
+                        the authorization JSON. If the property is already present in the resolved identity object, the default value is ignored.
+                        It requires the resolved identity object to always be a JSON object.
+                        Do not use this option with identity objects of other JSON types (array, string, etc).
+                      type: object
+                    jwt:
+                      description: Authentication based on JWT tokens.
+                      properties:
+                        issuerUrl:
+                          description: |-
+                            URL of the issuer of the JWT.
+                            If `jwksUrl` is omitted, Authorino will append the path to the OpenID Connect Well-Known Discovery endpoint
+                            (i.e. "/.well-known/openid-configuration") to this URL, to discover the OIDC configuration where to obtain
+                            the "jkws_uri" claim from.
+                            The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
+                          type: string
+                        ttl:
+                          description: |-
+                            Decides how long to wait before refreshing the JWKS (in seconds).
+                            If omitted, Authorino will never refresh the JWKS.
+                          type: integer
+                      type: object
+                    kubernetesTokenReview:
+                      description: Authentication by Kubernetes token review.
                       properties:
                         audiences:
                           description: |-
@@ -1371,73 +297,11 @@ spec:
                       type: object
                     metrics:
                       default: false
-                      description: Whether this identity config should generate individual
+                      description: Whether this config should generate individual
                         observability metrics
                       type: boolean
-                    mtls:
-                      properties:
-                        allNamespaces:
-                          default: false
-                          description: |-
-                            Whether Authorino should look for TLS secrets in all namespaces or only in the same namespace as the AuthConfig.
-                            Enabling this option in namespaced Authorino instances has no effect.
-                          type: boolean
-                        selector:
-                          description: Label selector used by Authorino to match secrets
-                            from the cluster storing trusted CA certificates to validate
-                            clients trying to authenticate to this service
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                          x-kubernetes-map-type: atomic
-                      required:
-                      - selector
-                      type: object
-                    name:
-                      description: |-
-                        The name of this identity source/authentication mode.
-                        It usually identifies a source of identities or group of users/clients of the protected service.
-                        It can be used to refer to the resolved identity object in other configs.
-                      type: string
-                    oauth2:
+                    oauth2Introspection:
+                      description: Authentication by OAuth2 token introspection.
                       properties:
                         credentialsRef:
                           description: Reference to a Kubernetes secret in the same
@@ -1452,7 +316,7 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
-                        tokenIntrospectionUrl:
+                        endpoint:
                           description: The full URL of the token introspection endpoint.
                           type: string
                         tokenTypeHint:
@@ -1462,33 +326,40 @@ spec:
                           type: string
                       required:
                       - credentialsRef
-                      - tokenIntrospectionUrl
-                      type: object
-                    oidc:
-                      properties:
-                        endpoint:
-                          description: |-
-                            Endpoint of the OIDC issuer.
-                            Authorino will append to this value the well-known path to the OpenID Connect discovery endpoint (i.e. "/.well-known/openid-configuration"), used to automatically discover the OpenID Connect configuration, whose set of claims is expected to include (among others) the "jkws_uri" claim.
-                            The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
-                          type: string
-                        ttl:
-                          description: Decides how long to wait before refreshing
-                            the OIDC configuration (in seconds).
-                          type: integer
-                      required:
                       - endpoint
                       type: object
+                    overrides:
+                      additionalProperties:
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      description: |-
+                        Overrides the resolved identity object by setting the additional properties (claims) specified in this config,
+                        before appending the object to the authorization JSON.
+                        It requires the resolved identity object to always be a JSON object.
+                        Do not use this option with identity objects of other JSON types (array, string, etc).
+                      type: object
                     plain:
+                      description: |-
+                        Identity object extracted from the context.
+                        Use this method when authentication is performed beforehand by a proxy and the resulting object passed to Authorino as JSON in the auth request.
                       properties:
-                        authJSON:
+                        selector:
                           description: |-
-                            Selector to fetch a value from the authorization JSON.
-                            It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                            or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                            Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                            The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                           type: string
+                      required:
+                      - selector
                       type: object
                     priority:
                       default: 0
@@ -1498,7 +369,7 @@ spec:
                       type: integer
                     when:
                       description: |-
-                        Conditions for Authorino to enforce this identity config.
+                        Conditions for Authorino to enforce this config.
                         If omitted, the config will be enforced for all requests.
                         If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
                       items:
@@ -1549,12 +420,13 @@ spec:
                             - matches
                             type: string
                           patternRef:
-                            description: Name of a named pattern
+                            description: Reference to a named set of pattern expressions
                             type: string
                           selector:
                             description: |-
-                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
                             type: string
                           value:
                             description: |-
@@ -1563,63 +435,730 @@ spec:
                             type: string
                         type: object
                       type: array
-                  required:
-                  - name
+                    x509:
+                      description: |-
+                        Authentication based on client X.509 certificates.
+                        The certificates presented by the clients must be signed by a trusted CA whose certificates are stored in Kubernetes secrets.
+                      properties:
+                        allNamespaces:
+                          default: false
+                          description: |-
+                            Whether Authorino should look for TLS secrets in all namespaces or only in the same namespace as the AuthConfig.
+                            Enabling this option in namespaced Authorino instances has no effect.
+                          type: boolean
+                        selector:
+                          description: |-
+                            Label selector used by Authorino to match secrets from the cluster storing trusted CA certificates to validate
+                            clients trying to authenticate to this service
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - selector
+                      type: object
                   type: object
-                type: array
-              metadata:
                 description: |-
-                  List of metadata source configs.
-                  Authorino fetches JSON content from sources on this list on every request.
-                items:
-                  description: |-
-                    The metadata config.
-                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "http", userInfo" or "uma".
+                  Authentication configs.
+                  At least one config MUST evaluate to a valid identity object for the auth request to be successful.
+                type: object
+              authorization:
+                additionalProperties:
                   oneOf:
                   - properties:
-                      name: {}
-                      userInfo: {}
+                      opa: {}
                     required:
-                    - name
-                    - userInfo
+                    - opa
                   - properties:
-                      name: {}
-                      uma: {}
+                      patternMatching: {}
                     required:
-                    - name
-                    - uma
+                    - patternMatching
                   - properties:
-                      http: {}
-                      name: {}
+                      kubernetesSubjectAccessReview: {}
                     required:
-                    - name
-                    - http
+                    - kubernetesSubjectAccessReview
+                  - properties:
+                      spicedb: {}
+                    required:
+                    - spicedb
                   properties:
                     cache:
                       description: |-
-                        Caching options for the external metadata fetched when applying this config.
-                        Omit it to avoid caching metadata from this source.
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
                       properties:
                         key:
                           description: |-
                             Key used to store the entry in the cache.
-                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                            The resolved key must be unique within the scope of this particular config.
                           properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
                             value:
                               description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    kubernetesSubjectAccessReview:
+                      description: Authorization by Kubernetes SubjectAccessReview
+                      properties:
+                        groups:
+                          description: Groups the user must be a member of or, if
+                            `user` is omitted, the groups to check for authorization
+                            in the Kubernetes RBAC.
+                          items:
+                            type: string
+                          type: array
+                        resourceAttributes:
+                          description: |-
+                            Use resourceAttributes to check permissions on Kubernetes resources.
+                            If omitted, it performs a non-resource SubjectAccessReview, with verb and path inferred from the request.
+                          properties:
+                            group:
+                              description: |-
+                                API group of the resource.
+                                Use '*' for all API groups.
                               properties:
-                                authJSON:
+                                selector:
                                   description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                   type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
                               type: object
+                            name:
+                              description: |-
+                                Resource name
+                                Omit it to check for authorization on all resources of the specified kind.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            namespace:
+                              description: Namespace where the user must have permissions
+                                on the resource.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            resource:
+                              description: |-
+                                Resource kind
+                                Use '*' for all resource kinds.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            subresource:
+                              description: Subresource kind
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            verb:
+                              description: |-
+                                Verb to check for authorization on the resource.
+                                Use '*' for all verbs.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                        user:
+                          description: |-
+                            User to check for authorization in the Kubernetes RBAC.
+                            Omit it to check for group authorization only.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
+                    opa:
+                      description: Open Policy Agent (OPA) Rego policy.
+                      properties:
+                        allValues:
+                          default: false
+                          description: |-
+                            Returns the value of all Rego rules in the virtual document. Values can be read in subsequent evaluators/phases of the Auth Pipeline.
+                            Otherwise, only the default `allow` rule will be exposed.
+                            Returning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.
+                          type: boolean
+                        externalPolicy:
+                          description: |-
+                            Settings for fetching the OPA policy from an external registry.
+                            Use it alternatively to 'rego'.
+                            For the configurations of the HTTP request, the following options are not implemented: 'method', 'body', 'bodyParameters',
+                            'contentType', 'headers', 'oauth2'. Use it only with: 'url', 'sharedSecret', 'credentials'.
+                          properties:
+                            body:
+                              description: |-
+                                Raw body of the HTTP request.
+                                Supersedes 'bodyParameters'; use either one or the other.
+                                Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            bodyParameters:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: |-
+                                Custom parameters to encode in the body of the HTTP request.
+                                Superseded by 'body'; use either one or the other.
+                                Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                              type: object
+                            contentType:
+                              default: application/x-www-form-urlencoded
+                              description: |-
+                                Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                                Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                              enum:
+                              - application/x-www-form-urlencoded
+                              - application/json
+                              type: string
+                            credentials:
+                              description: |-
+                                Defines where client credentials will be passed in the request to the service.
+                                If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                              properties:
+                                authorizationHeader:
+                                  properties:
+                                    prefix:
+                                      type: string
+                                  type: object
+                                cookie:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                customHeader:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                queryString:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                              type: object
+                            headers:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: Custom headers in the HTTP request.
+                              type: object
+                            method:
+                              default: GET
+                              description: |-
+                                HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                                When the request method is POST, the authorization JSON is passed in the body of the request.
+                              enum:
+                              - GET
+                              - POST
+                              - PUT
+                              - PATCH
+                              - DELETE
+                              - HEAD
+                              - OPTIONS
+                              - CONNECT
+                              - TRACE
+                              type: string
+                            oauth2:
+                              description: Authentication with the HTTP service by
+                                OAuth2 Client Credentials grant.
+                              properties:
+                                cache:
+                                  default: true
+                                  description: |-
+                                    Caches and reuses the token until expired.
+                                    Set it to false to force fetch the token at every authorization request regardless of expiration.
+                                  type: boolean
+                                clientId:
+                                  description: OAuth2 Client ID.
+                                  type: string
+                                clientSecretRef:
+                                  description: Reference to a Kuberentes Secret key
+                                    that stores that OAuth2 Client Secret.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: The name of the secret in the Authorino's
+                                        namespace to select from.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                extraParams:
+                                  additionalProperties:
+                                    type: string
+                                  description: Optional extra parameters for the requests
+                                    to the token URL.
+                                  type: object
+                                scopes:
+                                  description: Optional scopes for the client credentials
+                                    grant, if supported by he OAuth2 server.
+                                  items:
+                                    type: string
+                                  type: array
+                                tokenUrl:
+                                  description: Token endpoint URL of the OAuth2 resource
+                                    server.
+                                  type: string
+                              required:
+                              - clientId
+                              - clientSecretRef
+                              - tokenUrl
+                              type: object
+                            sharedSecretRef:
+                              description: |-
+                                Reference to a Secret key whose value will be passed by Authorino in the request.
+                                The HTTP service can use the shared secret to authenticate the origin of the request.
+                                Ignored if used together with oauth2.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            ttl:
+                              description: Duration (in seconds) of the external data
+                                in the cache before pulled again from the source.
+                              type: integer
+                            url:
+                              description: |-
+                                Endpoint URL of the HTTP service.
+                                The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                                by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                                E.g. https://ext-auth-server.io/metadata?p={request.path}
+                              type: string
+                          required:
+                          - url
+                          type: object
+                        rego:
+                          description: |-
+                            Authorization policy as a Rego language document.
+                            The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed).
+                            The Rego document must NOT include the "package" declaration in line 1.
+                          type: string
+                      type: object
+                    patternMatching:
+                      description: Pattern-matching authorization rules.
+                      properties:
+                        patterns:
+                          items:
+                            oneOf:
+                            - properties:
+                                patternRef: {}
+                              required:
+                              - patternRef
+                            - properties:
+                                operator: {}
+                                selector: {}
+                                value: {}
+                              required:
+                              - operator
+                              - selector
+                            - properties:
+                                all: {}
+                              required:
+                              - all
+                            - properties:
+                                any: {}
+                              required:
+                              - any
+                            properties:
+                              all:
+                                description: A list of pattern expressions to be evaluated
+                                  as a logical AND.
+                                items:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                type: array
+                              any:
+                                description: A list of pattern expressions to be evaluated
+                                  as a logical OR.
+                                items:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                type: array
+                              operator:
+                                description: |-
+                                  The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                  Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                enum:
+                                - eq
+                                - neq
+                                - incl
+                                - excl
+                                - matches
+                                type: string
+                              patternRef:
+                                description: Reference to a named set of pattern expressions
+                                type: string
+                              selector:
+                                description: |-
+                                  Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  Authorino custom JSON path modifiers are also supported.
+                                type: string
+                              value:
+                                description: |-
+                                  The value of reference for the comparison with the content fetched from the authorization JSON.
+                                  If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - patterns
+                      type: object
+                    priority:
+                      default: 0
+                      description: |-
+                        Priority group of the config.
+                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      type: integer
+                    spicedb:
+                      description: Authorization decision delegated to external Authzed/SpiceDB
+                        server.
+                      properties:
+                        endpoint:
+                          description: Hostname and port number to the GRPC interface
+                            of the SpiceDB server (e.g. spicedb:50051).
+                          type: string
+                        insecure:
+                          description: Insecure HTTP connection (i.e. disables TLS
+                            verification)
+                          type: boolean
+                        permission:
+                          description: The name of the permission (or relation) on
+                            which to execute the check.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        resource:
+                          description: The resource on which to check the permission
+                            or relation.
+                          properties:
+                            kind:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            name:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                        sharedSecretRef:
+                          description: Reference to a Secret key whose value will
+                            be used by Authorino to authenticate with the Authzed
+                            service.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        subject:
+                          description: The subject that will be checked for the permission
+                            or relation.
+                          properties:
+                            kind:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            name:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                      required:
+                      - endpoint
+                      type: object
+                    when:
+                      description: |-
+                        Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                      items:
+                        oneOf:
+                        - properties:
+                            patternRef: {}
+                          required:
+                          - patternRef
+                        - properties:
+                            operator: {}
+                            selector: {}
+                            value: {}
+                          required:
+                          - operator
+                          - selector
+                        - properties:
+                            all: {}
+                          required:
+                          - all
+                        - properties:
+                            any: {}
+                          required:
+                          - any
+                        properties:
+                          all:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical AND.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          any:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical OR.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          operator:
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: |-
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
+                            type: string
+                          value:
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                description: |-
+                  Authorization policies.
+                  All policies MUST evaluate to "allowed = true" for the auth request be successful.
+                type: object
+              callbacks:
+                additionalProperties:
+                  properties:
+                    cache:
+                      description: |-
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
+                      properties:
+                        key:
+                          description: |-
+                            Key used to store the entry in the cache.
+                            The resolved key must be unique within the scope of this particular config.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
                           type: object
                         ttl:
                           default: 60
@@ -1630,8 +1169,7 @@ spec:
                       - key
                       type: object
                     http:
-                      description: Generic HTTP interface to obtain authorization
-                        metadata from a HTTP service.
+                      description: Settings of the external HTTP request
                       properties:
                         body:
                           description: |-
@@ -1639,51 +1177,34 @@ spec:
                             Supersedes 'bodyParameters'; use either one or the other.
                             Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
                           properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
                             value:
                               description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                           type: object
                         bodyParameters:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
                           description: |-
                             Custom parameters to encode in the body of the HTTP request.
                             Superseded by 'body'; use either one or the other.
                             Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
-                          items:
-                            properties:
-                              name:
-                                description: The name of the JSON property
-                                type: string
-                              value:
-                                description: Static value of the JSON property
-                                x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
-                                properties:
-                                  authJSON:
-                                    description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
+                          type: object
                         contentType:
                           default: application/x-www-form-urlencoded
                           description: |-
@@ -1698,59 +1219,48 @@ spec:
                             Defines where client credentials will be passed in the request to the service.
                             If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
                           properties:
-                            in:
-                              default: authorization_header
-                              description: The location in the request where client
-                                credentials shall be passed on requests authenticating
-                                with this identity source/authentication mode.
-                              enum:
-                              - authorization_header
-                              - custom_header
-                              - query
-                              - cookie
-                              type: string
-                            keySelector:
-                              description: |-
-                                Used in conjunction with the `in` parameter.
-                                When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
-                                When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
-                              type: string
-                          required:
-                          - keySelector
+                            authorizationHeader:
+                              properties:
+                                prefix:
+                                  type: string
+                              type: object
+                            cookie:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            customHeader:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            queryString:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
                           type: object
-                        endpoint:
-                          description: |-
-                            Endpoint of the HTTP service.
-                            The endpoint accepts variable placeholders in the format "{selector}", where "selector" is any pattern supported
-                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
-                            E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
-                          type: string
                         headers:
-                          description: Custom headers in the HTTP request.
-                          items:
+                          additionalProperties:
                             properties:
-                              name:
-                                description: The name of the JSON property
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                 type: string
                               value:
-                                description: Static value of the JSON property
+                                description: Static value
                                 x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
-                                properties:
-                                  authJSON:
-                                    description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                    type: string
-                                type: object
-                            required:
-                            - name
                             type: object
-                          type: array
+                          description: Custom headers in the HTTP request.
+                          type: object
                         method:
                           default: GET
                           description: |-
@@ -1759,6 +1269,13 @@ spec:
                           enum:
                           - GET
                           - POST
+                          - PUT
+                          - PATCH
+                          - DELETE
+                          - HEAD
+                          - OPTIONS
+                          - CONNECT
+                          - TRACE
                           type: string
                         oauth2:
                           description: Authentication with the HTTP service by OAuth2
@@ -1774,7 +1291,7 @@ spec:
                               description: OAuth2 Client ID.
                               type: string
                             clientSecretRef:
-                              description: Reference to a Kubernetes Secret key that
+                              description: Reference to a Kuberentes Secret key that
                                 stores that OAuth2 Client Secret.
                               properties:
                                 key:
@@ -1828,19 +1345,325 @@ spec:
                           - key
                           - name
                           type: object
+                        url:
+                          description: |-
+                            Endpoint URL of the HTTP service.
+                            The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                            E.g. https://ext-auth-server.io/metadata?p={request.path}
+                          type: string
                       required:
-                      - endpoint
+                      - url
                       type: object
                     metrics:
                       default: false
-                      description: Whether this metadata config should generate individual
+                      description: Whether this config should generate individual
                         observability metrics
                       type: boolean
-                    name:
+                    priority:
+                      default: 0
                       description: |-
-                        The name of the metadata source.
-                        It can be used to refer to the resolved metadata object in other configs.
-                      type: string
+                        Priority group of the config.
+                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      type: integer
+                    when:
+                      description: |-
+                        Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                      items:
+                        properties:
+                          all:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical AND.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          any:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical OR.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          operator:
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: |-
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
+                            type: string
+                          value:
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - http
+                  type: object
+                description: |-
+                  Callback functions.
+                  Authorino sends callbacks at the end of the auth pipeline to the endpoints specified in this config.
+                type: object
+              hosts:
+                description: |-
+                  The list of public host names of the services protected by this authentication/authorization scheme.
+                  Authorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.
+                items:
+                  type: string
+                type: array
+              metadata:
+                additionalProperties:
+                  oneOf:
+                  - properties:
+                      userInfo: {}
+                    required:
+                    - userInfo
+                  - properties:
+                      uma: {}
+                    required:
+                    - uma
+                  - properties:
+                      http: {}
+                    required:
+                    - http
+                  properties:
+                    cache:
+                      description: |-
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
+                      properties:
+                        key:
+                          description: |-
+                            Key used to store the entry in the cache.
+                            The resolved key must be unique within the scope of this particular config.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    http:
+                      description: External source of auth metadata via HTTP request
+                      properties:
+                        body:
+                          description: |-
+                            Raw body of the HTTP request.
+                            Supersedes 'bodyParameters'; use either one or the other.
+                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        bodyParameters:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: |-
+                            Custom parameters to encode in the body of the HTTP request.
+                            Superseded by 'body'; use either one or the other.
+                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                          type: object
+                        contentType:
+                          default: application/x-www-form-urlencoded
+                          description: |-
+                            Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                            Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                          enum:
+                          - application/x-www-form-urlencoded
+                          - application/json
+                          type: string
+                        credentials:
+                          description: |-
+                            Defines where client credentials will be passed in the request to the service.
+                            If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                          properties:
+                            authorizationHeader:
+                              properties:
+                                prefix:
+                                  type: string
+                              type: object
+                            cookie:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            customHeader:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            queryString:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          type: object
+                        headers:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: Custom headers in the HTTP request.
+                          type: object
+                        method:
+                          default: GET
+                          description: |-
+                            HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                            When the request method is POST, the authorization JSON is passed in the body of the request.
+                          enum:
+                          - GET
+                          - POST
+                          - PUT
+                          - PATCH
+                          - DELETE
+                          - HEAD
+                          - OPTIONS
+                          - CONNECT
+                          - TRACE
+                          type: string
+                        oauth2:
+                          description: Authentication with the HTTP service by OAuth2
+                            Client Credentials grant.
+                          properties:
+                            cache:
+                              default: true
+                              description: |-
+                                Caches and reuses the token until expired.
+                                Set it to false to force fetch the token at every authorization request regardless of expiration.
+                              type: boolean
+                            clientId:
+                              description: OAuth2 Client ID.
+                              type: string
+                            clientSecretRef:
+                              description: Reference to a Kuberentes Secret key that
+                                stores that OAuth2 Client Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            extraParams:
+                              additionalProperties:
+                                type: string
+                              description: Optional extra parameters for the requests
+                                to the token URL.
+                              type: object
+                            scopes:
+                              description: Optional scopes for the client credentials
+                                grant, if supported by he OAuth2 server.
+                              items:
+                                type: string
+                              type: array
+                            tokenUrl:
+                              description: Token endpoint URL of the OAuth2 resource
+                                server.
+                              type: string
+                          required:
+                          - clientId
+                          - clientSecretRef
+                          - tokenUrl
+                          type: object
+                        sharedSecretRef:
+                          description: |-
+                            Reference to a Secret key whose value will be passed by Authorino in the request.
+                            The HTTP service can use the shared secret to authenticate the origin of the request.
+                            Ignored if used together with oauth2.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        url:
+                          description: |-
+                            Endpoint URL of the HTTP service.
+                            The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                            E.g. https://ext-auth-server.io/metadata?p={request.path}
+                          type: string
+                      required:
+                      - url
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
                     priority:
                       default: 0
                       description: |-
@@ -1873,252 +1696,20 @@ spec:
                       - endpoint
                       type: object
                     userInfo:
-                      description: OpendID Connect UserInfo linked to an OIDC identity
-                        config of this same spec.
+                      description: OpendID Connect UserInfo linked to an OIDC authentication
+                        config specified in this same AuthConfig.
                       properties:
                         identitySource:
-                          description: The name of an OIDC identity source included
-                            in the "identity" section and whose OpenID Connect configuration
-                            discovered includes the OIDC "userinfo_endpoint" claim.
+                          description: The name of an OIDC-enabled JWT authentication
+                            config whose OpenID Connect configuration discovered includes
+                            the OIDC "userinfo_endpoint" claim.
                           type: string
                       required:
                       - identitySource
                       type: object
                     when:
                       description: |-
-                        Conditions for Authorino to apply this metadata config.
-                        If omitted, the config will be applied for all requests.
-                        If present, all conditions must match for the config to be applied; otherwise, the config will be skipped.
-                      items:
-                        oneOf:
-                        - properties:
-                            patternRef: {}
-                          required:
-                          - patternRef
-                        - properties:
-                            operator: {}
-                            selector: {}
-                            value: {}
-                          required:
-                          - operator
-                          - selector
-                        - properties:
-                            all: {}
-                          required:
-                          - all
-                        - properties:
-                            any: {}
-                          required:
-                          - any
-                        properties:
-                          all:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical AND.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          any:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical OR.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          operator:
-                            description: |-
-                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
-                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
-                            enum:
-                            - eq
-                            - neq
-                            - incl
-                            - excl
-                            - matches
-                            type: string
-                          patternRef:
-                            description: Name of a named pattern
-                            type: string
-                          selector:
-                            description: |-
-                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
-                            type: string
-                          value:
-                            description: |-
-                              The value of reference for the comparison with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must compile to a valid Golang regex.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - name
-                  type: object
-                type: array
-              patterns:
-                additionalProperties:
-                  items:
-                    properties:
-                      operator:
-                        description: |-
-                          The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
-                          Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
-                        enum:
-                        - eq
-                        - neq
-                        - incl
-                        - excl
-                        - matches
-                        type: string
-                      selector:
-                        description: |-
-                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                          The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
-                        type: string
-                      value:
-                        description: |-
-                          The value of reference for the comparison with the content fetched from the authorization JSON.
-                          If used with the "matches" operator, the value must compile to a valid Golang regex.
-                        type: string
-                    type: object
-                  type: array
-                description: Named sets of JSON patterns that can be referred in `when`
-                  conditionals and in JSON-pattern matching policy rules.
-                type: object
-              response:
-                description: |-
-                  List of response configs.
-                  Authorino gathers data from the auth pipeline to build custom responses for the client.
-                items:
-                  description: |-
-                    Dynamic response to return to the client.
-                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "wristband" or "json".
-                  oneOf:
-                  - properties:
-                      name: {}
-                      wristband: {}
-                    required:
-                    - name
-                    - wristband
-                  - properties:
-                      json: {}
-                      name: {}
-                    required:
-                    - name
-                    - json
-                  - properties:
-                      name: {}
-                      plain: {}
-                    required:
-                    - name
-                    - plain
-                  properties:
-                    cache:
-                      description: |-
-                        Caching options for dynamic responses built when applying this config.
-                        Omit it to avoid caching dynamic responses for this config.
-                      properties:
-                        key:
-                          description: |-
-                            Key used to store the entry in the cache.
-                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
-                          properties:
-                            value:
-                              description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          type: object
-                        ttl:
-                          default: 60
-                          description: Duration (in seconds) of the external data
-                            in the cache before pulled again from the source.
-                          type: integer
-                      required:
-                      - key
-                      type: object
-                    json:
-                      properties:
-                        properties:
-                          description: List of JSON property-value pairs to be added
-                            to the dynamic response.
-                          items:
-                            properties:
-                              name:
-                                description: The name of the JSON property
-                                type: string
-                              value:
-                                description: Static value of the JSON property
-                                x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
-                                properties:
-                                  authJSON:
-                                    description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                      required:
-                      - properties
-                      type: object
-                    metrics:
-                      default: false
-                      description: Whether this response config should generate individual
-                        observability metrics
-                      type: boolean
-                    name:
-                      description: |-
-                        Name of the custom response.
-                        It can be used to refer to the resolved response object in other configs.
-                      type: string
-                    plain:
-                      description: StaticOrDynamicValue is either a constant static
-                        string value or a config for fetching a value from a dynamic
-                        source (e.g. a path pattern of authorization JSON)
-                      properties:
-                        value:
-                          description: Static value
-                          type: string
-                        valueFrom:
-                          description: Dynamic value
-                          properties:
-                            authJSON:
-                              description: |-
-                                Selector to fetch a value from the authorization JSON.
-                                It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                              type: string
-                          type: object
-                      type: object
-                    priority:
-                      default: 0
-                      description: |-
-                        Priority group of the config.
-                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
-                      type: integer
-                    when:
-                      description: |-
-                        Conditions for Authorino to enforce this custom response config.
+                        Conditions for Authorino to enforce this config.
                         If omitted, the config will be enforced for all requests.
                         If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
                       items:
@@ -2169,12 +1760,13 @@ spec:
                             - matches
                             type: string
                           patternRef:
-                            description: Name of a named pattern
+                            description: Reference to a named set of pattern expressions
                             type: string
                           selector:
                             description: |-
-                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
                             type: string
                           value:
                             description: |-
@@ -2183,99 +1775,637 @@ spec:
                             type: string
                         type: object
                       type: array
-                    wrapper:
-                      default: httpHeader
-                      description: |-
-                        How Authorino wraps the response.
-                        Use "httpHeader" (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata" to wrap the response as Envoy Dynamic Metadata
-                      enum:
-                      - httpHeader
-                      - envoyDynamicMetadata
-                      type: string
-                    wrapperKey:
-                      description: |-
-                        The name of key used in the wrapped response (name of the HTTP header or property of the Envoy Dynamic Metadata JSON).
-                        If omitted, it will be set to the name of the configuration.
-                      type: string
-                    wristband:
-                      properties:
-                        customClaims:
-                          description: Any claims to be added to the wristband token
-                            apart from the standard JWT claims (iss, iat, exp) added
-                            by default.
-                          items:
-                            properties:
-                              name:
-                                description: The name of the JSON property
-                                type: string
-                              value:
-                                description: Static value of the JSON property
-                                x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
+                  type: object
+                description: |-
+                  Metadata sources.
+                  Authorino fetches auth metadata as JSON from sources specified in this config.
+                type: object
+              patterns:
+                additionalProperties:
+                  items:
+                    properties:
+                      operator:
+                        description: |-
+                          The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                          Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                        enum:
+                        - eq
+                        - neq
+                        - incl
+                        - excl
+                        - matches
+                        type: string
+                      selector:
+                        description: |-
+                          Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                          Authorino custom JSON path modifiers are also supported.
+                        type: string
+                      value:
+                        description: |-
+                          The value of reference for the comparison with the content fetched from the authorization JSON.
+                          If used with the "matches" operator, the value must compile to a valid Golang regex.
+                        type: string
+                    type: object
+                  type: array
+                description: Named sets of patterns that can be referred in `when`
+                  conditions and in pattern-matching authorization policy rules.
+                type: object
+              response:
+                description: |-
+                  Response items.
+                  Authorino builds custom responses to the client of the auth request.
+                properties:
+                  success:
+                    description: |-
+                      Response items to be included in the auth response when the request is authenticated and authorized.
+                      For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata and/or inject data in the request.
+                    properties:
+                      dynamicMetadata:
+                        additionalProperties:
+                          description: Settings of the success custom response item.
+                          oneOf:
+                          - properties:
+                              wristband: {}
+                            required:
+                            - wristband
+                          - properties:
+                              json: {}
+                            required:
+                            - json
+                          - properties:
+                              plain: {}
+                            required:
+                            - plain
+                          properties:
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            json:
+                              description: |-
+                                JSON object
+                                Specify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.
+                              properties:
                                 properties:
-                                  authJSON:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: object
+                              required:
+                              - properties
+                              type: object
+                            key:
+                              description: |-
+                                The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object).
+                                If omitted, it will be set to the name of the response config.
+                              type: string
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            plain:
+                              description: Plain text content
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                oneOf:
+                                - properties:
+                                    patternRef: {}
+                                  required:
+                                  - patternRef
+                                - properties:
+                                    operator: {}
+                                    selector: {}
+                                    value: {}
+                                  required:
+                                  - operator
+                                  - selector
+                                - properties:
+                                    all: {}
+                                  required:
+                                  - all
+                                - properties:
+                                    any: {}
+                                  required:
+                                  - any
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
                                     description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
                                     type: string
                                 type: object
+                              type: array
+                            wristband:
+                              description: Authorino Festival Wristband token
+                              properties:
+                                customClaims:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Any claims to be added to the wristband
+                                    token apart from the standard JWT claims (iss,
+                                    iat, exp) added by default.
+                                  type: object
+                                issuer:
+                                  description: 'The endpoint to the Authorino service
+                                    that issues the wristband (format: <scheme>://<host>:<port>/<realm>,
+                                    where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                  type: string
+                                signingKeyRefs:
+                                  description: |-
+                                    Reference by name to Kubernetes secrets and corresponding signing algorithms.
+                                    The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                                  items:
+                                    properties:
+                                      algorithm:
+                                        description: Algorithm to sign the wristband
+                                          token using the signing key provided
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - ES512
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the signing key.
+                                          The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                                        type: string
+                                    required:
+                                    - algorithm
+                                    - name
+                                    type: object
+                                  type: array
+                                tokenDuration:
+                                  description: Time span of the wristband token, in
+                                    seconds.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - issuer
+                              - signingKeyRefs
+                              type: object
+                          type: object
+                        description: |-
+                          Custom success response items wrapped as HTTP headers.
+                          For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata.
+                          See https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata
+                        type: object
+                      headers:
+                        additionalProperties:
+                          oneOf:
+                          - properties:
+                              wristband: {}
                             required:
-                            - name
-                            type: object
-                          type: array
-                        issuer:
-                          description: 'The endpoint to the Authorino service that
-                            issues the wristband (format: <scheme>://<host>:<port>/<realm>,
-                            where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
-                          type: string
-                        signingKeyRefs:
-                          description: |-
-                            Reference by name to Kubernetes secrets and corresponding signing algorithms.
-                            The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
-                          items:
-                            properties:
-                              algorithm:
-                                description: Algorithm to sign the wristband token
-                                  using the signing key provided
-                                enum:
-                                - ES256
-                                - ES384
-                                - ES512
-                                - RS256
-                                - RS384
-                                - RS512
-                                type: string
-                              name:
-                                description: |-
-                                  Name of the signing key.
-                                  The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
-                                type: string
+                            - wristband
+                          - properties:
+                              json: {}
                             required:
-                            - algorithm
-                            - name
-                            type: object
-                          type: array
-                        tokenDuration:
-                          description: Time span of the wristband token, in seconds.
-                          format: int64
-                          type: integer
-                      required:
-                      - issuer
-                      - signingKeyRefs
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
+                            - json
+                          - properties:
+                              plain: {}
+                            required:
+                            - plain
+                          properties:
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            json:
+                              description: |-
+                                JSON object
+                                Specify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.
+                              properties:
+                                properties:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: object
+                              required:
+                              - properties
+                              type: object
+                            key:
+                              description: |-
+                                The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object).
+                                If omitted, it will be set to the name of the response config.
+                              type: string
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            plain:
+                              description: Plain text content
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                oneOf:
+                                - properties:
+                                    patternRef: {}
+                                  required:
+                                  - patternRef
+                                - properties:
+                                    operator: {}
+                                    selector: {}
+                                    value: {}
+                                  required:
+                                  - operator
+                                  - selector
+                                - properties:
+                                    all: {}
+                                  required:
+                                  - all
+                                - properties:
+                                    any: {}
+                                  required:
+                                  - any
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
+                                    description: |-
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                            wristband:
+                              description: Authorino Festival Wristband token
+                              properties:
+                                customClaims:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Any claims to be added to the wristband
+                                    token apart from the standard JWT claims (iss,
+                                    iat, exp) added by default.
+                                  type: object
+                                issuer:
+                                  description: 'The endpoint to the Authorino service
+                                    that issues the wristband (format: <scheme>://<host>:<port>/<realm>,
+                                    where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                  type: string
+                                signingKeyRefs:
+                                  description: |-
+                                    Reference by name to Kubernetes secrets and corresponding signing algorithms.
+                                    The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                                  items:
+                                    properties:
+                                      algorithm:
+                                        description: Algorithm to sign the wristband
+                                          token using the signing key provided
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - ES512
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the signing key.
+                                          The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                                        type: string
+                                    required:
+                                    - algorithm
+                                    - name
+                                    type: object
+                                  type: array
+                                tokenDuration:
+                                  description: Time span of the wristband token, in
+                                    seconds.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - issuer
+                              - signingKeyRefs
+                              type: object
+                          type: object
+                        description: |-
+                          Custom success response items wrapped as HTTP headers.
+                          For integration of Authorino via proxy, the proxy must use these settings to inject data in the request.
+                        type: object
+                    type: object
+                  unauthenticated:
+                    description: |-
+                      Customizations on the denial status attributes when the request is unauthenticated.
+                      For integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config.
+                      Default: 401 Unauthorized
+                    properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      code:
+                        description: HTTP status code to override the default denial
+                          status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        additionalProperties:
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        description: HTTP response headers to override the default
+                          denial headers.
+                        type: object
+                      message:
+                        description: HTTP message to override the default denial message.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                  unauthorized:
+                    description: |-
+                      Customizations on the denial status attributes when the request is unauthorized.
+                      For integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config.
+                      Default: 403 Forbidden
+                    properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      code:
+                        description: HTTP status code to override the default denial
+                          status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        additionalProperties:
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        description: HTTP response headers to override the default
+                          denial headers.
+                        type: object
+                      message:
+                        description: HTTP message to override the default denial message.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                type: object
               when:
                 description: |-
-                  Conditions for the AuthConfig to be enforced.
-                  If omitted, the AuthConfig will be enforced for all requests.
-                  If present, all conditions must match for the AuthConfig to be enforced; otherwise, Authorino skips the AuthConfig and returns immediately with status OK.
+                  Overall conditions for the AuthConfig to be enforced.
+                  If omitted, the AuthConfig will be enforced at all requests.
+                  If present, all conditions must match for the AuthConfig to be enforced; otherwise, Authorino skips the AuthConfig and returns to the auth request with status OK.
                 items:
                   oneOf:
                   - properties:
@@ -2324,12 +2454,13 @@ spec:
                       - matches
                       type: string
                     patternRef:
-                      description: Name of a named pattern
+                      description: Reference to a named set of pattern expressions
                       type: string
                     selector:
                       description: |-
-                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                        The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                        Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                        Authorino custom JSON path modifiers are also supported.
                       type: string
                     value:
                       description: |-
@@ -2463,7 +2594,7 @@ spec:
       name: Wristband
       priority: 2
       type: boolean
-    name: v1beta2
+    name: v1beta3
     schema:
       openAPIV3Schema:
         description: AuthConfig is the schema for Authorino's AuthConfig API

--- a/charts/authorino-operator/templates/manifests.yaml
+++ b/charts/authorino-operator/templates/manifests.yaml
@@ -59,7 +59,7 @@ spec:
       name: Wristband
       priority: 2
       type: boolean
-    name: v1beta1
+    name: v1beta2
     schema:
       openAPIV3Schema:
         description: AuthConfig is the schema for Authorino's AuthConfig API
@@ -86,1130 +86,51 @@ spec:
               the authencation/authorization scheme to be applied to protect the matching
               service hosts.
             properties:
-              authorization:
-                description: |-
-                  Authorization is the list of authorization policies.
-                  All policies in this list MUST evaluate to "true" for a request be successful in the authorization phase.
-                items:
-                  description: |-
-                    Authorization policy to be enforced.
-                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "opa", "json" or "kubernetes".
-                  oneOf:
-                  - properties:
-                      name: {}
-                      opa: {}
-                    required:
-                    - name
-                    - opa
-                  - properties:
-                      json: {}
-                      name: {}
-                    required:
-                    - name
-                    - json
-                  - properties:
-                      kubernetes: {}
-                      name: {}
-                    required:
-                    - name
-                    - kubernetes
-                  - properties:
-                      authzed: {}
-                      name: {}
-                    required:
-                    - name
-                    - authzed
-                  properties:
-                    authzed:
-                      description: Authzed authorization
-                      properties:
-                        endpoint:
-                          description: Endpoint of the Authzed service.
-                          type: string
-                        insecure:
-                          description: Insecure HTTP connection (i.e. disables TLS
-                            verification)
-                          type: boolean
-                        permission:
-                          description: The name of the permission (or relation) on
-                            which to execute the check.
-                          properties:
-                            value:
-                              description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          type: object
-                        resource:
-                          description: The resource on which to check the permission
-                            or relation.
-                          properties:
-                            kind:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            name:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                        sharedSecretRef:
-                          description: Reference to a Secret key whose value will
-                            be used by Authorino to authenticate with the Authzed
-                            service.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: The name of the secret in the Authorino's
-                                namespace to select from.
-                              type: string
-                          required:
-                          - key
-                          - name
-                          type: object
-                        subject:
-                          description: The subject that will be checked for the permission
-                            or relation.
-                          properties:
-                            kind:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            name:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                      required:
-                      - endpoint
-                      type: object
-                    cache:
-                      description: |-
-                        Caching options for the policy evaluation results when enforcing this config.
-                        Omit it to avoid caching policy evaluation results for this config.
-                      properties:
-                        key:
-                          description: |-
-                            Key used to store the entry in the cache.
-                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
-                          properties:
-                            value:
-                              description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          type: object
-                        ttl:
-                          default: 60
-                          description: Duration (in seconds) of the external data
-                            in the cache before pulled again from the source.
-                          type: integer
-                      required:
-                      - key
-                      type: object
-                    json:
-                      description: JSON pattern matching authorization policy.
-                      properties:
-                        rules:
-                          description: The rules that must all evaluate to "true"
-                            for the request to be authorized.
-                          items:
-                            oneOf:
-                            - properties:
-                                patternRef: {}
-                              required:
-                              - patternRef
-                            - properties:
-                                operator: {}
-                                selector: {}
-                                value: {}
-                              required:
-                              - operator
-                              - selector
-                            - properties:
-                                all: {}
-                              required:
-                              - all
-                            - properties:
-                                any: {}
-                              required:
-                              - any
-                            properties:
-                              all:
-                                description: A list of pattern expressions to be evaluated
-                                  as a logical AND.
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                type: array
-                              any:
-                                description: A list of pattern expressions to be evaluated
-                                  as a logical OR.
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                type: array
-                              operator:
-                                description: |-
-                                  The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
-                                  Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
-                                enum:
-                                - eq
-                                - neq
-                                - incl
-                                - excl
-                                - matches
-                                type: string
-                              patternRef:
-                                description: Name of a named pattern
-                                type: string
-                              selector:
-                                description: |-
-                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                                  The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
-                                type: string
-                              value:
-                                description: |-
-                                  The value of reference for the comparison with the content fetched from the authorization JSON.
-                                  If used with the "matches" operator, the value must compile to a valid Golang regex.
-                                type: string
-                            type: object
-                          type: array
-                      required:
-                      - rules
-                      type: object
-                    kubernetes:
-                      description: |-
-                        Kubernetes authorization policy based on `SubjectAccessReview`
-                        Path and Verb are inferred from the request.
-                      properties:
-                        groups:
-                          description: Groups to test for.
-                          items:
-                            type: string
-                          type: array
-                        resourceAttributes:
-                          description: |-
-                            Use ResourceAttributes for checking permissions on Kubernetes resources
-                            If omitted, it performs a non-resource `SubjectAccessReview`, with verb and path inferred from the request.
-                          properties:
-                            group:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            name:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            namespace:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            resource:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            subresource:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            verb:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                        user:
-                          description: |-
-                            User to test for.
-                            If without "Groups", then is it interpreted as "What if User were not a member of any groups"
-                          properties:
-                            value:
-                              description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          type: object
-                      required:
-                      - user
-                      type: object
-                    metrics:
-                      default: false
-                      description: Whether this authorization config should generate
-                        individual observability metrics
-                      type: boolean
-                    name:
-                      description: |-
-                        Name of the authorization policy.
-                        It can be used to refer to the resolved authorization object in other configs.
-                      type: string
-                    opa:
-                      description: Open Policy Agent (OPA) authorization policy.
-                      properties:
-                        allValues:
-                          default: false
-                          description: |-
-                            Returns the value of all Rego rules in the virtual document. Values can be read in subsequent evaluators/phases of the Auth Pipeline.
-                            Otherwise, only the default `allow` rule will be exposed.
-                            Returning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.
-                          type: boolean
-                        externalRegistry:
-                          description: External registry of OPA policies.
-                          properties:
-                            credentials:
-                              description: |-
-                                Defines where client credentials will be passed in the request to the service.
-                                If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
-                              properties:
-                                in:
-                                  default: authorization_header
-                                  description: The location in the request where client
-                                    credentials shall be passed on requests authenticating
-                                    with this identity source/authentication mode.
-                                  enum:
-                                  - authorization_header
-                                  - custom_header
-                                  - query
-                                  - cookie
-                                  type: string
-                                keySelector:
-                                  description: |-
-                                    Used in conjunction with the `in` parameter.
-                                    When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
-                                    When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
-                                  type: string
-                              required:
-                              - keySelector
-                              type: object
-                            endpoint:
-                              description: |-
-                                Endpoint of the HTTP external registry.
-                                The endpoint must respond with either plain/text or application/json content-type.
-                                In the latter case, the JSON returned in the body must include a path `result.raw`, where the raw Rego policy will be extracted from. This complies with the specification of the OPA REST API (https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
-                              type: string
-                            sharedSecretRef:
-                              description: |-
-                                Reference to a Secret key whose value will be passed by Authorino in the request.
-                                The HTTP service can use the shared secret to authenticate the origin of the request.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: The name of the secret in the Authorino's
-                                    namespace to select from.
-                                  type: string
-                              required:
-                              - key
-                              - name
-                              type: object
-                            ttl:
-                              description: Duration (in seconds) of the external data
-                                in the cache before pulled again from the source.
-                              type: integer
-                          type: object
-                        inlineRego:
-                          description: |-
-                            Authorization policy as a Rego language document.
-                            The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed).
-                            The Rego document must NOT include the "package" declaration in line 1.
-                          type: string
-                      type: object
-                    priority:
-                      default: 0
-                      description: |-
-                        Priority group of the config.
-                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
-                      type: integer
-                    when:
-                      description: |-
-                        Conditions for Authorino to enforce this authorization policy.
-                        If omitted, the config will be enforced for all requests.
-                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
-                      items:
-                        oneOf:
-                        - properties:
-                            patternRef: {}
-                          required:
-                          - patternRef
-                        - properties:
-                            operator: {}
-                            selector: {}
-                            value: {}
-                          required:
-                          - operator
-                          - selector
-                        - properties:
-                            all: {}
-                          required:
-                          - all
-                        - properties:
-                            any: {}
-                          required:
-                          - any
-                        properties:
-                          all:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical AND.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          any:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical OR.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          operator:
-                            description: |-
-                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
-                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
-                            enum:
-                            - eq
-                            - neq
-                            - incl
-                            - excl
-                            - matches
-                            type: string
-                          patternRef:
-                            description: Name of a named pattern
-                            type: string
-                          selector:
-                            description: |-
-                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
-                            type: string
-                          value:
-                            description: |-
-                              The value of reference for the comparison with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must compile to a valid Golang regex.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - name
-                  type: object
-                type: array
-              callbacks:
-                description: |-
-                  List of callback configs.
-                  Authorino sends callbacks to specified endpoints at the end of the auth pipeline.
-                items:
-                  description: Endpoints to callback at the end of each auth pipeline.
-                  properties:
-                    http:
-                      description: Generic HTTP interface to obtain authorization
-                        metadata from a HTTP service.
-                      properties:
-                        body:
-                          description: |-
-                            Raw body of the HTTP request.
-                            Supersedes 'bodyParameters'; use either one or the other.
-                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
-                          properties:
-                            value:
-                              description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          type: object
-                        bodyParameters:
-                          description: |-
-                            Custom parameters to encode in the body of the HTTP request.
-                            Superseded by 'body'; use either one or the other.
-                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
-                          items:
-                            properties:
-                              name:
-                                description: The name of the JSON property
-                                type: string
-                              value:
-                                description: Static value of the JSON property
-                                x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
-                                properties:
-                                  authJSON:
-                                    description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        contentType:
-                          default: application/x-www-form-urlencoded
-                          description: |-
-                            Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
-                            Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
-                          enum:
-                          - application/x-www-form-urlencoded
-                          - application/json
-                          type: string
-                        credentials:
-                          description: |-
-                            Defines where client credentials will be passed in the request to the service.
-                            If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
-                          properties:
-                            in:
-                              default: authorization_header
-                              description: The location in the request where client
-                                credentials shall be passed on requests authenticating
-                                with this identity source/authentication mode.
-                              enum:
-                              - authorization_header
-                              - custom_header
-                              - query
-                              - cookie
-                              type: string
-                            keySelector:
-                              description: |-
-                                Used in conjunction with the `in` parameter.
-                                When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
-                                When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
-                              type: string
-                          required:
-                          - keySelector
-                          type: object
-                        endpoint:
-                          description: |-
-                            Endpoint of the HTTP service.
-                            The endpoint accepts variable placeholders in the format "{selector}", where "selector" is any pattern supported
-                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
-                            E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
-                          type: string
-                        headers:
-                          description: Custom headers in the HTTP request.
-                          items:
-                            properties:
-                              name:
-                                description: The name of the JSON property
-                                type: string
-                              value:
-                                description: Static value of the JSON property
-                                x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
-                                properties:
-                                  authJSON:
-                                    description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        method:
-                          default: GET
-                          description: |-
-                            HTTP verb used in the request to the service. Accepted values: GET (default), POST.
-                            When the request method is POST, the authorization JSON is passed in the body of the request.
-                          enum:
-                          - GET
-                          - POST
-                          type: string
-                        oauth2:
-                          description: Authentication with the HTTP service by OAuth2
-                            Client Credentials grant.
-                          properties:
-                            cache:
-                              default: true
-                              description: |-
-                                Caches and reuses the token until expired.
-                                Set it to false to force fetch the token at every authorization request regardless of expiration.
-                              type: boolean
-                            clientId:
-                              description: OAuth2 Client ID.
-                              type: string
-                            clientSecretRef:
-                              description: Reference to a Kubernetes Secret key that
-                                stores that OAuth2 Client Secret.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: The name of the secret in the Authorino's
-                                    namespace to select from.
-                                  type: string
-                              required:
-                              - key
-                              - name
-                              type: object
-                            extraParams:
-                              additionalProperties:
-                                type: string
-                              description: Optional extra parameters for the requests
-                                to the token URL.
-                              type: object
-                            scopes:
-                              description: Optional scopes for the client credentials
-                                grant, if supported by he OAuth2 server.
-                              items:
-                                type: string
-                              type: array
-                            tokenUrl:
-                              description: Token endpoint URL of the OAuth2 resource
-                                server.
-                              type: string
-                          required:
-                          - clientId
-                          - clientSecretRef
-                          - tokenUrl
-                          type: object
-                        sharedSecretRef:
-                          description: |-
-                            Reference to a Secret key whose value will be passed by Authorino in the request.
-                            The HTTP service can use the shared secret to authenticate the origin of the request.
-                            Ignored if used together with oauth2.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: The name of the secret in the Authorino's
-                                namespace to select from.
-                              type: string
-                          required:
-                          - key
-                          - name
-                          type: object
-                      required:
-                      - endpoint
-                      type: object
-                    metrics:
-                      default: false
-                      description: Whether this callback config should generate individual
-                        observability metrics
-                      type: boolean
-                    name:
-                      description: |-
-                        Name of the callback.
-                        It can be used to refer to the resolved callback response in other configs.
-                      type: string
-                    priority:
-                      default: 0
-                      description: |-
-                        Priority group of the config.
-                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
-                      type: integer
-                    when:
-                      description: |-
-                        Conditions for Authorino to perform this callback.
-                        If omitted, the callback will be attempted for all requests.
-                        If present, all conditions must match for the callback to be attempted; otherwise, the callback will be skipped.
-                      items:
-                        properties:
-                          all:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical AND.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          any:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical OR.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          operator:
-                            description: |-
-                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
-                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
-                            enum:
-                            - eq
-                            - neq
-                            - incl
-                            - excl
-                            - matches
-                            type: string
-                          patternRef:
-                            description: Name of a named pattern
-                            type: string
-                          selector:
-                            description: |-
-                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
-                            type: string
-                          value:
-                            description: |-
-                              The value of reference for the comparison with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must compile to a valid Golang regex.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - http
-                  - name
-                  type: object
-                type: array
-              denyWith:
-                description: Custom denial response codes, statuses and headers to
-                  override default 40x's.
-                properties:
-                  unauthenticated:
-                    description: Denial status customization when the request is unauthenticated.
-                    properties:
-                      body:
-                        description: HTTP response body to override the default denial
-                          body.
-                        properties:
-                          value:
-                            description: Static value
-                            type: string
-                          valueFrom:
-                            description: Dynamic value
-                            properties:
-                              authJSON:
-                                description: |-
-                                  Selector to fetch a value from the authorization JSON.
-                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                type: string
-                            type: object
-                        type: object
-                      code:
-                        description: HTTP status code to override the default denial
-                          status code.
-                        format: int64
-                        maximum: 599
-                        minimum: 300
-                        type: integer
-                      headers:
-                        description: HTTP response headers to override the default
-                          denial headers.
-                        items:
-                          properties:
-                            name:
-                              description: The name of the JSON property
-                              type: string
-                            value:
-                              description: Static value of the JSON property
-                              x-kubernetes-preserve-unknown-fields: true
-                            valueFrom:
-                              description: Dynamic value of the JSON property
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      message:
-                        description: HTTP message to override the default denial message.
-                        properties:
-                          value:
-                            description: Static value
-                            type: string
-                          valueFrom:
-                            description: Dynamic value
-                            properties:
-                              authJSON:
-                                description: |-
-                                  Selector to fetch a value from the authorization JSON.
-                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                type: string
-                            type: object
-                        type: object
-                    type: object
-                  unauthorized:
-                    description: Denial status customization when the request is unauthorized.
-                    properties:
-                      body:
-                        description: HTTP response body to override the default denial
-                          body.
-                        properties:
-                          value:
-                            description: Static value
-                            type: string
-                          valueFrom:
-                            description: Dynamic value
-                            properties:
-                              authJSON:
-                                description: |-
-                                  Selector to fetch a value from the authorization JSON.
-                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                type: string
-                            type: object
-                        type: object
-                      code:
-                        description: HTTP status code to override the default denial
-                          status code.
-                        format: int64
-                        maximum: 599
-                        minimum: 300
-                        type: integer
-                      headers:
-                        description: HTTP response headers to override the default
-                          denial headers.
-                        items:
-                          properties:
-                            name:
-                              description: The name of the JSON property
-                              type: string
-                            value:
-                              description: Static value of the JSON property
-                              x-kubernetes-preserve-unknown-fields: true
-                            valueFrom:
-                              description: Dynamic value of the JSON property
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      message:
-                        description: HTTP message to override the default denial message.
-                        properties:
-                          value:
-                            description: Static value
-                            type: string
-                          valueFrom:
-                            description: Dynamic value
-                            properties:
-                              authJSON:
-                                description: |-
-                                  Selector to fetch a value from the authorization JSON.
-                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                type: string
-                            type: object
-                        type: object
-                    type: object
-                type: object
-              hosts:
-                description: |-
-                  The list of public host names of the services protected by this authentication/authorization scheme.
-                  Authorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.
-                items:
-                  type: string
-                type: array
-              identity:
-                description: |-
-                  List of identity sources/authentication modes.
-                  At least one config of this list MUST evaluate to a valid identity for a request to be successful in the identity verification phase.
-                items:
-                  description: |-
-                    The identity source/authentication mode config.
-                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "oicd", "apiKey" or "kubernetes".
+              authentication:
+                additionalProperties:
                   oneOf:
                   - properties:
                       credentials: {}
-                      name: {}
-                      oauth2: {}
+                      oauth2Introspection: {}
                     required:
-                    - name
-                    - oauth2
+                    - oauth2Introspection
                   - properties:
                       credentials: {}
-                      name: {}
-                      oidc: {}
+                      jwt: {}
                     required:
-                    - name
-                    - oidc
+                    - jwt
                   - properties:
                       apiKey: {}
                       credentials: {}
-                      name: {}
                     required:
-                    - name
                     - apiKey
                   - properties:
                       credentials: {}
-                      mtls: {}
-                      name: {}
+                      x509: {}
                     required:
-                    - name
-                    - mtls
+                    - x509
                   - properties:
                       credentials: {}
-                      kubernetes: {}
-                      name: {}
+                      kubernetesTokenReview: {}
                     required:
-                    - name
-                    - kubernetes
+                    - kubernetesTokenReview
                   - properties:
                       anonymous: {}
                       credentials: {}
-                      name: {}
                     required:
-                    - name
                     - anonymous
                   - properties:
                       credentials: {}
-                      name: {}
                       plain: {}
                     required:
-                    - name
                     - plain
                   properties:
                     anonymous:
+                      description: Anonymous access.
                       type: object
                     apiKey:
+                      description: Authentication based on API keys stored in Kubernetes
+                        secrets.
                       properties:
                         allNamespaces:
                           default: false
@@ -1268,29 +189,23 @@ spec:
                       type: object
                     cache:
                       description: |-
-                        Caching options for the identity resolved when applying this config.
-                        Omit it to avoid caching identity objects for this config.
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
                       properties:
                         key:
                           description: |-
                             Key used to store the entry in the cache.
-                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                            The resolved key must be unique within the scope of this particular config.
                           properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
                             value:
                               description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                           type: object
                         ttl:
                           default: 60
@@ -1302,63 +217,74 @@ spec:
                       type: object
                     credentials:
                       description: |-
-                        Defines where client credentials are required to be passed in the request for this identity source/authentication mode.
-                        If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the credentials value (token, API key, etc).
+                        Defines where credentials are required to be passed in the request for authentication based on this config.
+                        If omitted, it defaults to credentials passed in the HTTP Authorization header and the "Bearer" prefix prepended to the secret credential value.
                       properties:
-                        in:
-                          default: authorization_header
-                          description: The location in the request where client credentials
-                            shall be passed on requests authenticating with this identity
-                            source/authentication mode.
-                          enum:
-                          - authorization_header
-                          - custom_header
-                          - query
-                          - cookie
-                          type: string
-                        keySelector:
-                          description: |-
-                            Used in conjunction with the `in` parameter.
-                            When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
-                            When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
-                          type: string
-                      required:
-                      - keySelector
+                        authorizationHeader:
+                          properties:
+                            prefix:
+                              type: string
+                          type: object
+                        cookie:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        customHeader:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        queryString:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
                       type: object
-                    extendedProperties:
-                      description: |-
-                        Extends the resolved identity object with additional custom properties before appending to the authorization JSON.
-                        It requires the resolved identity object to always be of the JSON type 'object'. Other JSON types (array, string, etc) will break.
-                      items:
+                    defaults:
+                      additionalProperties:
                         properties:
-                          name:
-                            description: The name of the JSON property
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                             type: string
-                          overwrite:
-                            default: false
-                            description: Whether the value should overwrite the value
-                              of an existing property with the same name.
-                            type: boolean
                           value:
-                            description: Static value of the JSON property
+                            description: Static value
                             x-kubernetes-preserve-unknown-fields: true
-                          valueFrom:
-                            description: Dynamic value of the JSON property
-                            properties:
-                              authJSON:
-                                description: |-
-                                  Selector to fetch a value from the authorization JSON.
-                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                type: string
-                            type: object
-                        required:
-                        - name
                         type: object
-                      type: array
-                    kubernetes:
+                      description: |-
+                        Set default property values (claims) for the resolved identity object, that are set before appending the object to
+                        the authorization JSON. If the property is already present in the resolved identity object, the default value is ignored.
+                        It requires the resolved identity object to always be a JSON object.
+                        Do not use this option with identity objects of other JSON types (array, string, etc).
+                      type: object
+                    jwt:
+                      description: Authentication based on JWT tokens.
+                      properties:
+                        issuerUrl:
+                          description: |-
+                            URL of the issuer of the JWT.
+                            If `jwksUrl` is omitted, Authorino will append the path to the OpenID Connect Well-Known Discovery endpoint
+                            (i.e. "/.well-known/openid-configuration") to this URL, to discover the OIDC configuration where to obtain
+                            the "jkws_uri" claim from.
+                            The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
+                          type: string
+                        ttl:
+                          description: |-
+                            Decides how long to wait before refreshing the JWKS (in seconds).
+                            If omitted, Authorino will never refresh the JWKS.
+                          type: integer
+                      type: object
+                    kubernetesTokenReview:
+                      description: Authentication by Kubernetes token review.
                       properties:
                         audiences:
                           description: |-
@@ -1370,73 +296,11 @@ spec:
                       type: object
                     metrics:
                       default: false
-                      description: Whether this identity config should generate individual
+                      description: Whether this config should generate individual
                         observability metrics
                       type: boolean
-                    mtls:
-                      properties:
-                        allNamespaces:
-                          default: false
-                          description: |-
-                            Whether Authorino should look for TLS secrets in all namespaces or only in the same namespace as the AuthConfig.
-                            Enabling this option in namespaced Authorino instances has no effect.
-                          type: boolean
-                        selector:
-                          description: Label selector used by Authorino to match secrets
-                            from the cluster storing trusted CA certificates to validate
-                            clients trying to authenticate to this service
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                          x-kubernetes-map-type: atomic
-                      required:
-                      - selector
-                      type: object
-                    name:
-                      description: |-
-                        The name of this identity source/authentication mode.
-                        It usually identifies a source of identities or group of users/clients of the protected service.
-                        It can be used to refer to the resolved identity object in other configs.
-                      type: string
-                    oauth2:
+                    oauth2Introspection:
+                      description: Authentication by OAuth2 token introspection.
                       properties:
                         credentialsRef:
                           description: Reference to a Kubernetes secret in the same
@@ -1451,7 +315,7 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
-                        tokenIntrospectionUrl:
+                        endpoint:
                           description: The full URL of the token introspection endpoint.
                           type: string
                         tokenTypeHint:
@@ -1461,33 +325,40 @@ spec:
                           type: string
                       required:
                       - credentialsRef
-                      - tokenIntrospectionUrl
-                      type: object
-                    oidc:
-                      properties:
-                        endpoint:
-                          description: |-
-                            Endpoint of the OIDC issuer.
-                            Authorino will append to this value the well-known path to the OpenID Connect discovery endpoint (i.e. "/.well-known/openid-configuration"), used to automatically discover the OpenID Connect configuration, whose set of claims is expected to include (among others) the "jkws_uri" claim.
-                            The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
-                          type: string
-                        ttl:
-                          description: Decides how long to wait before refreshing
-                            the OIDC configuration (in seconds).
-                          type: integer
-                      required:
                       - endpoint
                       type: object
+                    overrides:
+                      additionalProperties:
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      description: |-
+                        Overrides the resolved identity object by setting the additional properties (claims) specified in this config,
+                        before appending the object to the authorization JSON.
+                        It requires the resolved identity object to always be a JSON object.
+                        Do not use this option with identity objects of other JSON types (array, string, etc).
+                      type: object
                     plain:
+                      description: |-
+                        Identity object extracted from the context.
+                        Use this method when authentication is performed beforehand by a proxy and the resulting object passed to Authorino as JSON in the auth request.
                       properties:
-                        authJSON:
+                        selector:
                           description: |-
-                            Selector to fetch a value from the authorization JSON.
-                            It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                            or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                            Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                            The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                           type: string
+                      required:
+                      - selector
                       type: object
                     priority:
                       default: 0
@@ -1497,7 +368,7 @@ spec:
                       type: integer
                     when:
                       description: |-
-                        Conditions for Authorino to enforce this identity config.
+                        Conditions for Authorino to enforce this config.
                         If omitted, the config will be enforced for all requests.
                         If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
                       items:
@@ -1548,12 +419,13 @@ spec:
                             - matches
                             type: string
                           patternRef:
-                            description: Name of a named pattern
+                            description: Reference to a named set of pattern expressions
                             type: string
                           selector:
                             description: |-
-                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
                             type: string
                           value:
                             description: |-
@@ -1562,63 +434,730 @@ spec:
                             type: string
                         type: object
                       type: array
-                  required:
-                  - name
+                    x509:
+                      description: |-
+                        Authentication based on client X.509 certificates.
+                        The certificates presented by the clients must be signed by a trusted CA whose certificates are stored in Kubernetes secrets.
+                      properties:
+                        allNamespaces:
+                          default: false
+                          description: |-
+                            Whether Authorino should look for TLS secrets in all namespaces or only in the same namespace as the AuthConfig.
+                            Enabling this option in namespaced Authorino instances has no effect.
+                          type: boolean
+                        selector:
+                          description: |-
+                            Label selector used by Authorino to match secrets from the cluster storing trusted CA certificates to validate
+                            clients trying to authenticate to this service
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - selector
+                      type: object
                   type: object
-                type: array
-              metadata:
                 description: |-
-                  List of metadata source configs.
-                  Authorino fetches JSON content from sources on this list on every request.
-                items:
-                  description: |-
-                    The metadata config.
-                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "http", userInfo" or "uma".
+                  Authentication configs.
+                  At least one config MUST evaluate to a valid identity object for the auth request to be successful.
+                type: object
+              authorization:
+                additionalProperties:
                   oneOf:
                   - properties:
-                      name: {}
-                      userInfo: {}
+                      opa: {}
                     required:
-                    - name
-                    - userInfo
+                    - opa
                   - properties:
-                      name: {}
-                      uma: {}
+                      patternMatching: {}
                     required:
-                    - name
-                    - uma
+                    - patternMatching
                   - properties:
-                      http: {}
-                      name: {}
+                      kubernetesSubjectAccessReview: {}
                     required:
-                    - name
-                    - http
+                    - kubernetesSubjectAccessReview
+                  - properties:
+                      spicedb: {}
+                    required:
+                    - spicedb
                   properties:
                     cache:
                       description: |-
-                        Caching options for the external metadata fetched when applying this config.
-                        Omit it to avoid caching metadata from this source.
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
                       properties:
                         key:
                           description: |-
                             Key used to store the entry in the cache.
-                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                            The resolved key must be unique within the scope of this particular config.
                           properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
                             value:
                               description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    kubernetesSubjectAccessReview:
+                      description: Authorization by Kubernetes SubjectAccessReview
+                      properties:
+                        groups:
+                          description: Groups the user must be a member of or, if
+                            `user` is omitted, the groups to check for authorization
+                            in the Kubernetes RBAC.
+                          items:
+                            type: string
+                          type: array
+                        resourceAttributes:
+                          description: |-
+                            Use resourceAttributes to check permissions on Kubernetes resources.
+                            If omitted, it performs a non-resource SubjectAccessReview, with verb and path inferred from the request.
+                          properties:
+                            group:
+                              description: |-
+                                API group of the resource.
+                                Use '*' for all API groups.
                               properties:
-                                authJSON:
+                                selector:
                                   description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                   type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
                               type: object
+                            name:
+                              description: |-
+                                Resource name
+                                Omit it to check for authorization on all resources of the specified kind.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            namespace:
+                              description: Namespace where the user must have permissions
+                                on the resource.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            resource:
+                              description: |-
+                                Resource kind
+                                Use '*' for all resource kinds.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            subresource:
+                              description: Subresource kind
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            verb:
+                              description: |-
+                                Verb to check for authorization on the resource.
+                                Use '*' for all verbs.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                        user:
+                          description: |-
+                            User to check for authorization in the Kubernetes RBAC.
+                            Omit it to check for group authorization only.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
+                    opa:
+                      description: Open Policy Agent (OPA) Rego policy.
+                      properties:
+                        allValues:
+                          default: false
+                          description: |-
+                            Returns the value of all Rego rules in the virtual document. Values can be read in subsequent evaluators/phases of the Auth Pipeline.
+                            Otherwise, only the default `allow` rule will be exposed.
+                            Returning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.
+                          type: boolean
+                        externalPolicy:
+                          description: |-
+                            Settings for fetching the OPA policy from an external registry.
+                            Use it alternatively to 'rego'.
+                            For the configurations of the HTTP request, the following options are not implemented: 'method', 'body', 'bodyParameters',
+                            'contentType', 'headers', 'oauth2'. Use it only with: 'url', 'sharedSecret', 'credentials'.
+                          properties:
+                            body:
+                              description: |-
+                                Raw body of the HTTP request.
+                                Supersedes 'bodyParameters'; use either one or the other.
+                                Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            bodyParameters:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: |-
+                                Custom parameters to encode in the body of the HTTP request.
+                                Superseded by 'body'; use either one or the other.
+                                Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                              type: object
+                            contentType:
+                              default: application/x-www-form-urlencoded
+                              description: |-
+                                Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                                Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                              enum:
+                              - application/x-www-form-urlencoded
+                              - application/json
+                              type: string
+                            credentials:
+                              description: |-
+                                Defines where client credentials will be passed in the request to the service.
+                                If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                              properties:
+                                authorizationHeader:
+                                  properties:
+                                    prefix:
+                                      type: string
+                                  type: object
+                                cookie:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                customHeader:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                queryString:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                              type: object
+                            headers:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: Custom headers in the HTTP request.
+                              type: object
+                            method:
+                              default: GET
+                              description: |-
+                                HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                                When the request method is POST, the authorization JSON is passed in the body of the request.
+                              enum:
+                              - GET
+                              - POST
+                              - PUT
+                              - PATCH
+                              - DELETE
+                              - HEAD
+                              - OPTIONS
+                              - CONNECT
+                              - TRACE
+                              type: string
+                            oauth2:
+                              description: Authentication with the HTTP service by
+                                OAuth2 Client Credentials grant.
+                              properties:
+                                cache:
+                                  default: true
+                                  description: |-
+                                    Caches and reuses the token until expired.
+                                    Set it to false to force fetch the token at every authorization request regardless of expiration.
+                                  type: boolean
+                                clientId:
+                                  description: OAuth2 Client ID.
+                                  type: string
+                                clientSecretRef:
+                                  description: Reference to a Kuberentes Secret key
+                                    that stores that OAuth2 Client Secret.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: The name of the secret in the Authorino's
+                                        namespace to select from.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                extraParams:
+                                  additionalProperties:
+                                    type: string
+                                  description: Optional extra parameters for the requests
+                                    to the token URL.
+                                  type: object
+                                scopes:
+                                  description: Optional scopes for the client credentials
+                                    grant, if supported by he OAuth2 server.
+                                  items:
+                                    type: string
+                                  type: array
+                                tokenUrl:
+                                  description: Token endpoint URL of the OAuth2 resource
+                                    server.
+                                  type: string
+                              required:
+                              - clientId
+                              - clientSecretRef
+                              - tokenUrl
+                              type: object
+                            sharedSecretRef:
+                              description: |-
+                                Reference to a Secret key whose value will be passed by Authorino in the request.
+                                The HTTP service can use the shared secret to authenticate the origin of the request.
+                                Ignored if used together with oauth2.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            ttl:
+                              description: Duration (in seconds) of the external data
+                                in the cache before pulled again from the source.
+                              type: integer
+                            url:
+                              description: |-
+                                Endpoint URL of the HTTP service.
+                                The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                                by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                                E.g. https://ext-auth-server.io/metadata?p={request.path}
+                              type: string
+                          required:
+                          - url
+                          type: object
+                        rego:
+                          description: |-
+                            Authorization policy as a Rego language document.
+                            The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed).
+                            The Rego document must NOT include the "package" declaration in line 1.
+                          type: string
+                      type: object
+                    patternMatching:
+                      description: Pattern-matching authorization rules.
+                      properties:
+                        patterns:
+                          items:
+                            oneOf:
+                            - properties:
+                                patternRef: {}
+                              required:
+                              - patternRef
+                            - properties:
+                                operator: {}
+                                selector: {}
+                                value: {}
+                              required:
+                              - operator
+                              - selector
+                            - properties:
+                                all: {}
+                              required:
+                              - all
+                            - properties:
+                                any: {}
+                              required:
+                              - any
+                            properties:
+                              all:
+                                description: A list of pattern expressions to be evaluated
+                                  as a logical AND.
+                                items:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                type: array
+                              any:
+                                description: A list of pattern expressions to be evaluated
+                                  as a logical OR.
+                                items:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                type: array
+                              operator:
+                                description: |-
+                                  The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                  Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                enum:
+                                - eq
+                                - neq
+                                - incl
+                                - excl
+                                - matches
+                                type: string
+                              patternRef:
+                                description: Reference to a named set of pattern expressions
+                                type: string
+                              selector:
+                                description: |-
+                                  Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  Authorino custom JSON path modifiers are also supported.
+                                type: string
+                              value:
+                                description: |-
+                                  The value of reference for the comparison with the content fetched from the authorization JSON.
+                                  If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - patterns
+                      type: object
+                    priority:
+                      default: 0
+                      description: |-
+                        Priority group of the config.
+                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      type: integer
+                    spicedb:
+                      description: Authorization decision delegated to external Authzed/SpiceDB
+                        server.
+                      properties:
+                        endpoint:
+                          description: Hostname and port number to the GRPC interface
+                            of the SpiceDB server (e.g. spicedb:50051).
+                          type: string
+                        insecure:
+                          description: Insecure HTTP connection (i.e. disables TLS
+                            verification)
+                          type: boolean
+                        permission:
+                          description: The name of the permission (or relation) on
+                            which to execute the check.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        resource:
+                          description: The resource on which to check the permission
+                            or relation.
+                          properties:
+                            kind:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            name:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                        sharedSecretRef:
+                          description: Reference to a Secret key whose value will
+                            be used by Authorino to authenticate with the Authzed
+                            service.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        subject:
+                          description: The subject that will be checked for the permission
+                            or relation.
+                          properties:
+                            kind:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            name:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                      required:
+                      - endpoint
+                      type: object
+                    when:
+                      description: |-
+                        Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                      items:
+                        oneOf:
+                        - properties:
+                            patternRef: {}
+                          required:
+                          - patternRef
+                        - properties:
+                            operator: {}
+                            selector: {}
+                            value: {}
+                          required:
+                          - operator
+                          - selector
+                        - properties:
+                            all: {}
+                          required:
+                          - all
+                        - properties:
+                            any: {}
+                          required:
+                          - any
+                        properties:
+                          all:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical AND.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          any:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical OR.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          operator:
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: |-
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
+                            type: string
+                          value:
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                description: |-
+                  Authorization policies.
+                  All policies MUST evaluate to "allowed = true" for the auth request be successful.
+                type: object
+              callbacks:
+                additionalProperties:
+                  properties:
+                    cache:
+                      description: |-
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
+                      properties:
+                        key:
+                          description: |-
+                            Key used to store the entry in the cache.
+                            The resolved key must be unique within the scope of this particular config.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
                           type: object
                         ttl:
                           default: 60
@@ -1629,8 +1168,7 @@ spec:
                       - key
                       type: object
                     http:
-                      description: Generic HTTP interface to obtain authorization
-                        metadata from a HTTP service.
+                      description: Settings of the external HTTP request
                       properties:
                         body:
                           description: |-
@@ -1638,51 +1176,34 @@ spec:
                             Supersedes 'bodyParameters'; use either one or the other.
                             Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
                           properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
                             value:
                               description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                           type: object
                         bodyParameters:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
                           description: |-
                             Custom parameters to encode in the body of the HTTP request.
                             Superseded by 'body'; use either one or the other.
                             Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
-                          items:
-                            properties:
-                              name:
-                                description: The name of the JSON property
-                                type: string
-                              value:
-                                description: Static value of the JSON property
-                                x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
-                                properties:
-                                  authJSON:
-                                    description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
+                          type: object
                         contentType:
                           default: application/x-www-form-urlencoded
                           description: |-
@@ -1697,59 +1218,48 @@ spec:
                             Defines where client credentials will be passed in the request to the service.
                             If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
                           properties:
-                            in:
-                              default: authorization_header
-                              description: The location in the request where client
-                                credentials shall be passed on requests authenticating
-                                with this identity source/authentication mode.
-                              enum:
-                              - authorization_header
-                              - custom_header
-                              - query
-                              - cookie
-                              type: string
-                            keySelector:
-                              description: |-
-                                Used in conjunction with the `in` parameter.
-                                When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
-                                When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
-                              type: string
-                          required:
-                          - keySelector
+                            authorizationHeader:
+                              properties:
+                                prefix:
+                                  type: string
+                              type: object
+                            cookie:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            customHeader:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            queryString:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
                           type: object
-                        endpoint:
-                          description: |-
-                            Endpoint of the HTTP service.
-                            The endpoint accepts variable placeholders in the format "{selector}", where "selector" is any pattern supported
-                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
-                            E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
-                          type: string
                         headers:
-                          description: Custom headers in the HTTP request.
-                          items:
+                          additionalProperties:
                             properties:
-                              name:
-                                description: The name of the JSON property
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                 type: string
                               value:
-                                description: Static value of the JSON property
+                                description: Static value
                                 x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
-                                properties:
-                                  authJSON:
-                                    description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                    type: string
-                                type: object
-                            required:
-                            - name
                             type: object
-                          type: array
+                          description: Custom headers in the HTTP request.
+                          type: object
                         method:
                           default: GET
                           description: |-
@@ -1758,6 +1268,13 @@ spec:
                           enum:
                           - GET
                           - POST
+                          - PUT
+                          - PATCH
+                          - DELETE
+                          - HEAD
+                          - OPTIONS
+                          - CONNECT
+                          - TRACE
                           type: string
                         oauth2:
                           description: Authentication with the HTTP service by OAuth2
@@ -1773,7 +1290,7 @@ spec:
                               description: OAuth2 Client ID.
                               type: string
                             clientSecretRef:
-                              description: Reference to a Kubernetes Secret key that
+                              description: Reference to a Kuberentes Secret key that
                                 stores that OAuth2 Client Secret.
                               properties:
                                 key:
@@ -1827,19 +1344,325 @@ spec:
                           - key
                           - name
                           type: object
+                        url:
+                          description: |-
+                            Endpoint URL of the HTTP service.
+                            The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                            E.g. https://ext-auth-server.io/metadata?p={request.path}
+                          type: string
                       required:
-                      - endpoint
+                      - url
                       type: object
                     metrics:
                       default: false
-                      description: Whether this metadata config should generate individual
+                      description: Whether this config should generate individual
                         observability metrics
                       type: boolean
-                    name:
+                    priority:
+                      default: 0
                       description: |-
-                        The name of the metadata source.
-                        It can be used to refer to the resolved metadata object in other configs.
-                      type: string
+                        Priority group of the config.
+                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      type: integer
+                    when:
+                      description: |-
+                        Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                      items:
+                        properties:
+                          all:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical AND.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          any:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical OR.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          operator:
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: |-
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
+                            type: string
+                          value:
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - http
+                  type: object
+                description: |-
+                  Callback functions.
+                  Authorino sends callbacks at the end of the auth pipeline to the endpoints specified in this config.
+                type: object
+              hosts:
+                description: |-
+                  The list of public host names of the services protected by this authentication/authorization scheme.
+                  Authorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.
+                items:
+                  type: string
+                type: array
+              metadata:
+                additionalProperties:
+                  oneOf:
+                  - properties:
+                      userInfo: {}
+                    required:
+                    - userInfo
+                  - properties:
+                      uma: {}
+                    required:
+                    - uma
+                  - properties:
+                      http: {}
+                    required:
+                    - http
+                  properties:
+                    cache:
+                      description: |-
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
+                      properties:
+                        key:
+                          description: |-
+                            Key used to store the entry in the cache.
+                            The resolved key must be unique within the scope of this particular config.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    http:
+                      description: External source of auth metadata via HTTP request
+                      properties:
+                        body:
+                          description: |-
+                            Raw body of the HTTP request.
+                            Supersedes 'bodyParameters'; use either one or the other.
+                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        bodyParameters:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: |-
+                            Custom parameters to encode in the body of the HTTP request.
+                            Superseded by 'body'; use either one or the other.
+                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                          type: object
+                        contentType:
+                          default: application/x-www-form-urlencoded
+                          description: |-
+                            Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                            Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                          enum:
+                          - application/x-www-form-urlencoded
+                          - application/json
+                          type: string
+                        credentials:
+                          description: |-
+                            Defines where client credentials will be passed in the request to the service.
+                            If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                          properties:
+                            authorizationHeader:
+                              properties:
+                                prefix:
+                                  type: string
+                              type: object
+                            cookie:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            customHeader:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            queryString:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          type: object
+                        headers:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: Custom headers in the HTTP request.
+                          type: object
+                        method:
+                          default: GET
+                          description: |-
+                            HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                            When the request method is POST, the authorization JSON is passed in the body of the request.
+                          enum:
+                          - GET
+                          - POST
+                          - PUT
+                          - PATCH
+                          - DELETE
+                          - HEAD
+                          - OPTIONS
+                          - CONNECT
+                          - TRACE
+                          type: string
+                        oauth2:
+                          description: Authentication with the HTTP service by OAuth2
+                            Client Credentials grant.
+                          properties:
+                            cache:
+                              default: true
+                              description: |-
+                                Caches and reuses the token until expired.
+                                Set it to false to force fetch the token at every authorization request regardless of expiration.
+                              type: boolean
+                            clientId:
+                              description: OAuth2 Client ID.
+                              type: string
+                            clientSecretRef:
+                              description: Reference to a Kuberentes Secret key that
+                                stores that OAuth2 Client Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            extraParams:
+                              additionalProperties:
+                                type: string
+                              description: Optional extra parameters for the requests
+                                to the token URL.
+                              type: object
+                            scopes:
+                              description: Optional scopes for the client credentials
+                                grant, if supported by he OAuth2 server.
+                              items:
+                                type: string
+                              type: array
+                            tokenUrl:
+                              description: Token endpoint URL of the OAuth2 resource
+                                server.
+                              type: string
+                          required:
+                          - clientId
+                          - clientSecretRef
+                          - tokenUrl
+                          type: object
+                        sharedSecretRef:
+                          description: |-
+                            Reference to a Secret key whose value will be passed by Authorino in the request.
+                            The HTTP service can use the shared secret to authenticate the origin of the request.
+                            Ignored if used together with oauth2.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        url:
+                          description: |-
+                            Endpoint URL of the HTTP service.
+                            The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                            E.g. https://ext-auth-server.io/metadata?p={request.path}
+                          type: string
+                      required:
+                      - url
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
                     priority:
                       default: 0
                       description: |-
@@ -1872,252 +1695,20 @@ spec:
                       - endpoint
                       type: object
                     userInfo:
-                      description: OpendID Connect UserInfo linked to an OIDC identity
-                        config of this same spec.
+                      description: OpendID Connect UserInfo linked to an OIDC authentication
+                        config specified in this same AuthConfig.
                       properties:
                         identitySource:
-                          description: The name of an OIDC identity source included
-                            in the "identity" section and whose OpenID Connect configuration
-                            discovered includes the OIDC "userinfo_endpoint" claim.
+                          description: The name of an OIDC-enabled JWT authentication
+                            config whose OpenID Connect configuration discovered includes
+                            the OIDC "userinfo_endpoint" claim.
                           type: string
                       required:
                       - identitySource
                       type: object
                     when:
                       description: |-
-                        Conditions for Authorino to apply this metadata config.
-                        If omitted, the config will be applied for all requests.
-                        If present, all conditions must match for the config to be applied; otherwise, the config will be skipped.
-                      items:
-                        oneOf:
-                        - properties:
-                            patternRef: {}
-                          required:
-                          - patternRef
-                        - properties:
-                            operator: {}
-                            selector: {}
-                            value: {}
-                          required:
-                          - operator
-                          - selector
-                        - properties:
-                            all: {}
-                          required:
-                          - all
-                        - properties:
-                            any: {}
-                          required:
-                          - any
-                        properties:
-                          all:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical AND.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          any:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical OR.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          operator:
-                            description: |-
-                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
-                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
-                            enum:
-                            - eq
-                            - neq
-                            - incl
-                            - excl
-                            - matches
-                            type: string
-                          patternRef:
-                            description: Name of a named pattern
-                            type: string
-                          selector:
-                            description: |-
-                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
-                            type: string
-                          value:
-                            description: |-
-                              The value of reference for the comparison with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must compile to a valid Golang regex.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - name
-                  type: object
-                type: array
-              patterns:
-                additionalProperties:
-                  items:
-                    properties:
-                      operator:
-                        description: |-
-                          The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
-                          Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
-                        enum:
-                        - eq
-                        - neq
-                        - incl
-                        - excl
-                        - matches
-                        type: string
-                      selector:
-                        description: |-
-                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                          The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
-                        type: string
-                      value:
-                        description: |-
-                          The value of reference for the comparison with the content fetched from the authorization JSON.
-                          If used with the "matches" operator, the value must compile to a valid Golang regex.
-                        type: string
-                    type: object
-                  type: array
-                description: Named sets of JSON patterns that can be referred in `when`
-                  conditionals and in JSON-pattern matching policy rules.
-                type: object
-              response:
-                description: |-
-                  List of response configs.
-                  Authorino gathers data from the auth pipeline to build custom responses for the client.
-                items:
-                  description: |-
-                    Dynamic response to return to the client.
-                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "wristband" or "json".
-                  oneOf:
-                  - properties:
-                      name: {}
-                      wristband: {}
-                    required:
-                    - name
-                    - wristband
-                  - properties:
-                      json: {}
-                      name: {}
-                    required:
-                    - name
-                    - json
-                  - properties:
-                      name: {}
-                      plain: {}
-                    required:
-                    - name
-                    - plain
-                  properties:
-                    cache:
-                      description: |-
-                        Caching options for dynamic responses built when applying this config.
-                        Omit it to avoid caching dynamic responses for this config.
-                      properties:
-                        key:
-                          description: |-
-                            Key used to store the entry in the cache.
-                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
-                          properties:
-                            value:
-                              description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          type: object
-                        ttl:
-                          default: 60
-                          description: Duration (in seconds) of the external data
-                            in the cache before pulled again from the source.
-                          type: integer
-                      required:
-                      - key
-                      type: object
-                    json:
-                      properties:
-                        properties:
-                          description: List of JSON property-value pairs to be added
-                            to the dynamic response.
-                          items:
-                            properties:
-                              name:
-                                description: The name of the JSON property
-                                type: string
-                              value:
-                                description: Static value of the JSON property
-                                x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
-                                properties:
-                                  authJSON:
-                                    description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                      required:
-                      - properties
-                      type: object
-                    metrics:
-                      default: false
-                      description: Whether this response config should generate individual
-                        observability metrics
-                      type: boolean
-                    name:
-                      description: |-
-                        Name of the custom response.
-                        It can be used to refer to the resolved response object in other configs.
-                      type: string
-                    plain:
-                      description: StaticOrDynamicValue is either a constant static
-                        string value or a config for fetching a value from a dynamic
-                        source (e.g. a path pattern of authorization JSON)
-                      properties:
-                        value:
-                          description: Static value
-                          type: string
-                        valueFrom:
-                          description: Dynamic value
-                          properties:
-                            authJSON:
-                              description: |-
-                                Selector to fetch a value from the authorization JSON.
-                                It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                              type: string
-                          type: object
-                      type: object
-                    priority:
-                      default: 0
-                      description: |-
-                        Priority group of the config.
-                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
-                      type: integer
-                    when:
-                      description: |-
-                        Conditions for Authorino to enforce this custom response config.
+                        Conditions for Authorino to enforce this config.
                         If omitted, the config will be enforced for all requests.
                         If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
                       items:
@@ -2168,12 +1759,13 @@ spec:
                             - matches
                             type: string
                           patternRef:
-                            description: Name of a named pattern
+                            description: Reference to a named set of pattern expressions
                             type: string
                           selector:
                             description: |-
-                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
                             type: string
                           value:
                             description: |-
@@ -2182,99 +1774,637 @@ spec:
                             type: string
                         type: object
                       type: array
-                    wrapper:
-                      default: httpHeader
-                      description: |-
-                        How Authorino wraps the response.
-                        Use "httpHeader" (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata" to wrap the response as Envoy Dynamic Metadata
-                      enum:
-                      - httpHeader
-                      - envoyDynamicMetadata
-                      type: string
-                    wrapperKey:
-                      description: |-
-                        The name of key used in the wrapped response (name of the HTTP header or property of the Envoy Dynamic Metadata JSON).
-                        If omitted, it will be set to the name of the configuration.
-                      type: string
-                    wristband:
-                      properties:
-                        customClaims:
-                          description: Any claims to be added to the wristband token
-                            apart from the standard JWT claims (iss, iat, exp) added
-                            by default.
-                          items:
-                            properties:
-                              name:
-                                description: The name of the JSON property
-                                type: string
-                              value:
-                                description: Static value of the JSON property
-                                x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
+                  type: object
+                description: |-
+                  Metadata sources.
+                  Authorino fetches auth metadata as JSON from sources specified in this config.
+                type: object
+              patterns:
+                additionalProperties:
+                  items:
+                    properties:
+                      operator:
+                        description: |-
+                          The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                          Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                        enum:
+                        - eq
+                        - neq
+                        - incl
+                        - excl
+                        - matches
+                        type: string
+                      selector:
+                        description: |-
+                          Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                          Authorino custom JSON path modifiers are also supported.
+                        type: string
+                      value:
+                        description: |-
+                          The value of reference for the comparison with the content fetched from the authorization JSON.
+                          If used with the "matches" operator, the value must compile to a valid Golang regex.
+                        type: string
+                    type: object
+                  type: array
+                description: Named sets of patterns that can be referred in `when`
+                  conditions and in pattern-matching authorization policy rules.
+                type: object
+              response:
+                description: |-
+                  Response items.
+                  Authorino builds custom responses to the client of the auth request.
+                properties:
+                  success:
+                    description: |-
+                      Response items to be included in the auth response when the request is authenticated and authorized.
+                      For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata and/or inject data in the request.
+                    properties:
+                      dynamicMetadata:
+                        additionalProperties:
+                          description: Settings of the success custom response item.
+                          oneOf:
+                          - properties:
+                              wristband: {}
+                            required:
+                            - wristband
+                          - properties:
+                              json: {}
+                            required:
+                            - json
+                          - properties:
+                              plain: {}
+                            required:
+                            - plain
+                          properties:
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            json:
+                              description: |-
+                                JSON object
+                                Specify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.
+                              properties:
                                 properties:
-                                  authJSON:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: object
+                              required:
+                              - properties
+                              type: object
+                            key:
+                              description: |-
+                                The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object).
+                                If omitted, it will be set to the name of the response config.
+                              type: string
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            plain:
+                              description: Plain text content
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                oneOf:
+                                - properties:
+                                    patternRef: {}
+                                  required:
+                                  - patternRef
+                                - properties:
+                                    operator: {}
+                                    selector: {}
+                                    value: {}
+                                  required:
+                                  - operator
+                                  - selector
+                                - properties:
+                                    all: {}
+                                  required:
+                                  - all
+                                - properties:
+                                    any: {}
+                                  required:
+                                  - any
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
                                     description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
                                     type: string
                                 type: object
+                              type: array
+                            wristband:
+                              description: Authorino Festival Wristband token
+                              properties:
+                                customClaims:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Any claims to be added to the wristband
+                                    token apart from the standard JWT claims (iss,
+                                    iat, exp) added by default.
+                                  type: object
+                                issuer:
+                                  description: 'The endpoint to the Authorino service
+                                    that issues the wristband (format: <scheme>://<host>:<port>/<realm>,
+                                    where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                  type: string
+                                signingKeyRefs:
+                                  description: |-
+                                    Reference by name to Kubernetes secrets and corresponding signing algorithms.
+                                    The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                                  items:
+                                    properties:
+                                      algorithm:
+                                        description: Algorithm to sign the wristband
+                                          token using the signing key provided
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - ES512
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the signing key.
+                                          The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                                        type: string
+                                    required:
+                                    - algorithm
+                                    - name
+                                    type: object
+                                  type: array
+                                tokenDuration:
+                                  description: Time span of the wristband token, in
+                                    seconds.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - issuer
+                              - signingKeyRefs
+                              type: object
+                          type: object
+                        description: |-
+                          Custom success response items wrapped as HTTP headers.
+                          For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata.
+                          See https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata
+                        type: object
+                      headers:
+                        additionalProperties:
+                          oneOf:
+                          - properties:
+                              wristband: {}
                             required:
-                            - name
-                            type: object
-                          type: array
-                        issuer:
-                          description: 'The endpoint to the Authorino service that
-                            issues the wristband (format: <scheme>://<host>:<port>/<realm>,
-                            where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
-                          type: string
-                        signingKeyRefs:
-                          description: |-
-                            Reference by name to Kubernetes secrets and corresponding signing algorithms.
-                            The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
-                          items:
-                            properties:
-                              algorithm:
-                                description: Algorithm to sign the wristband token
-                                  using the signing key provided
-                                enum:
-                                - ES256
-                                - ES384
-                                - ES512
-                                - RS256
-                                - RS384
-                                - RS512
-                                type: string
-                              name:
-                                description: |-
-                                  Name of the signing key.
-                                  The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
-                                type: string
+                            - wristband
+                          - properties:
+                              json: {}
                             required:
-                            - algorithm
-                            - name
-                            type: object
-                          type: array
-                        tokenDuration:
-                          description: Time span of the wristband token, in seconds.
-                          format: int64
-                          type: integer
-                      required:
-                      - issuer
-                      - signingKeyRefs
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
+                            - json
+                          - properties:
+                              plain: {}
+                            required:
+                            - plain
+                          properties:
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            json:
+                              description: |-
+                                JSON object
+                                Specify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.
+                              properties:
+                                properties:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: object
+                              required:
+                              - properties
+                              type: object
+                            key:
+                              description: |-
+                                The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object).
+                                If omitted, it will be set to the name of the response config.
+                              type: string
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            plain:
+                              description: Plain text content
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                oneOf:
+                                - properties:
+                                    patternRef: {}
+                                  required:
+                                  - patternRef
+                                - properties:
+                                    operator: {}
+                                    selector: {}
+                                    value: {}
+                                  required:
+                                  - operator
+                                  - selector
+                                - properties:
+                                    all: {}
+                                  required:
+                                  - all
+                                - properties:
+                                    any: {}
+                                  required:
+                                  - any
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
+                                    description: |-
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                            wristband:
+                              description: Authorino Festival Wristband token
+                              properties:
+                                customClaims:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Any claims to be added to the wristband
+                                    token apart from the standard JWT claims (iss,
+                                    iat, exp) added by default.
+                                  type: object
+                                issuer:
+                                  description: 'The endpoint to the Authorino service
+                                    that issues the wristband (format: <scheme>://<host>:<port>/<realm>,
+                                    where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                  type: string
+                                signingKeyRefs:
+                                  description: |-
+                                    Reference by name to Kubernetes secrets and corresponding signing algorithms.
+                                    The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                                  items:
+                                    properties:
+                                      algorithm:
+                                        description: Algorithm to sign the wristband
+                                          token using the signing key provided
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - ES512
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the signing key.
+                                          The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                                        type: string
+                                    required:
+                                    - algorithm
+                                    - name
+                                    type: object
+                                  type: array
+                                tokenDuration:
+                                  description: Time span of the wristband token, in
+                                    seconds.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - issuer
+                              - signingKeyRefs
+                              type: object
+                          type: object
+                        description: |-
+                          Custom success response items wrapped as HTTP headers.
+                          For integration of Authorino via proxy, the proxy must use these settings to inject data in the request.
+                        type: object
+                    type: object
+                  unauthenticated:
+                    description: |-
+                      Customizations on the denial status attributes when the request is unauthenticated.
+                      For integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config.
+                      Default: 401 Unauthorized
+                    properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      code:
+                        description: HTTP status code to override the default denial
+                          status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        additionalProperties:
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        description: HTTP response headers to override the default
+                          denial headers.
+                        type: object
+                      message:
+                        description: HTTP message to override the default denial message.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                  unauthorized:
+                    description: |-
+                      Customizations on the denial status attributes when the request is unauthorized.
+                      For integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config.
+                      Default: 403 Forbidden
+                    properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      code:
+                        description: HTTP status code to override the default denial
+                          status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        additionalProperties:
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        description: HTTP response headers to override the default
+                          denial headers.
+                        type: object
+                      message:
+                        description: HTTP message to override the default denial message.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                type: object
               when:
                 description: |-
-                  Conditions for the AuthConfig to be enforced.
-                  If omitted, the AuthConfig will be enforced for all requests.
-                  If present, all conditions must match for the AuthConfig to be enforced; otherwise, Authorino skips the AuthConfig and returns immediately with status OK.
+                  Overall conditions for the AuthConfig to be enforced.
+                  If omitted, the AuthConfig will be enforced at all requests.
+                  If present, all conditions must match for the AuthConfig to be enforced; otherwise, Authorino skips the AuthConfig and returns to the auth request with status OK.
                 items:
                   oneOf:
                   - properties:
@@ -2323,12 +2453,13 @@ spec:
                       - matches
                       type: string
                     patternRef:
-                      description: Name of a named pattern
+                      description: Reference to a named set of pattern expressions
                       type: string
                     selector:
                       description: |-
-                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                        The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                        Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                        Authorino custom JSON path modifiers are also supported.
                       type: string
                     value:
                       description: |-
@@ -2462,7 +2593,7 @@ spec:
       name: Wristband
       priority: 2
       type: boolean
-    name: v1beta2
+    name: v1beta3
     schema:
       openAPIV3Schema:
         description: AuthConfig is the schema for Authorino's AuthConfig API

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -66,7 +66,7 @@ spec:
       name: Wristband
       priority: 2
       type: boolean
-    name: v1beta1
+    name: v1beta2
     schema:
       openAPIV3Schema:
         description: AuthConfig is the schema for Authorino's AuthConfig API
@@ -93,1130 +93,51 @@ spec:
               the authencation/authorization scheme to be applied to protect the matching
               service hosts.
             properties:
-              authorization:
-                description: |-
-                  Authorization is the list of authorization policies.
-                  All policies in this list MUST evaluate to "true" for a request be successful in the authorization phase.
-                items:
-                  description: |-
-                    Authorization policy to be enforced.
-                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "opa", "json" or "kubernetes".
-                  oneOf:
-                  - properties:
-                      name: {}
-                      opa: {}
-                    required:
-                    - name
-                    - opa
-                  - properties:
-                      json: {}
-                      name: {}
-                    required:
-                    - name
-                    - json
-                  - properties:
-                      kubernetes: {}
-                      name: {}
-                    required:
-                    - name
-                    - kubernetes
-                  - properties:
-                      authzed: {}
-                      name: {}
-                    required:
-                    - name
-                    - authzed
-                  properties:
-                    authzed:
-                      description: Authzed authorization
-                      properties:
-                        endpoint:
-                          description: Endpoint of the Authzed service.
-                          type: string
-                        insecure:
-                          description: Insecure HTTP connection (i.e. disables TLS
-                            verification)
-                          type: boolean
-                        permission:
-                          description: The name of the permission (or relation) on
-                            which to execute the check.
-                          properties:
-                            value:
-                              description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          type: object
-                        resource:
-                          description: The resource on which to check the permission
-                            or relation.
-                          properties:
-                            kind:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            name:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                        sharedSecretRef:
-                          description: Reference to a Secret key whose value will
-                            be used by Authorino to authenticate with the Authzed
-                            service.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: The name of the secret in the Authorino's
-                                namespace to select from.
-                              type: string
-                          required:
-                          - key
-                          - name
-                          type: object
-                        subject:
-                          description: The subject that will be checked for the permission
-                            or relation.
-                          properties:
-                            kind:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            name:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                      required:
-                      - endpoint
-                      type: object
-                    cache:
-                      description: |-
-                        Caching options for the policy evaluation results when enforcing this config.
-                        Omit it to avoid caching policy evaluation results for this config.
-                      properties:
-                        key:
-                          description: |-
-                            Key used to store the entry in the cache.
-                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
-                          properties:
-                            value:
-                              description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          type: object
-                        ttl:
-                          default: 60
-                          description: Duration (in seconds) of the external data
-                            in the cache before pulled again from the source.
-                          type: integer
-                      required:
-                      - key
-                      type: object
-                    json:
-                      description: JSON pattern matching authorization policy.
-                      properties:
-                        rules:
-                          description: The rules that must all evaluate to "true"
-                            for the request to be authorized.
-                          items:
-                            oneOf:
-                            - properties:
-                                patternRef: {}
-                              required:
-                              - patternRef
-                            - properties:
-                                operator: {}
-                                selector: {}
-                                value: {}
-                              required:
-                              - operator
-                              - selector
-                            - properties:
-                                all: {}
-                              required:
-                              - all
-                            - properties:
-                                any: {}
-                              required:
-                              - any
-                            properties:
-                              all:
-                                description: A list of pattern expressions to be evaluated
-                                  as a logical AND.
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                type: array
-                              any:
-                                description: A list of pattern expressions to be evaluated
-                                  as a logical OR.
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                type: array
-                              operator:
-                                description: |-
-                                  The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
-                                  Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
-                                enum:
-                                - eq
-                                - neq
-                                - incl
-                                - excl
-                                - matches
-                                type: string
-                              patternRef:
-                                description: Name of a named pattern
-                                type: string
-                              selector:
-                                description: |-
-                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                                  The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
-                                type: string
-                              value:
-                                description: |-
-                                  The value of reference for the comparison with the content fetched from the authorization JSON.
-                                  If used with the "matches" operator, the value must compile to a valid Golang regex.
-                                type: string
-                            type: object
-                          type: array
-                      required:
-                      - rules
-                      type: object
-                    kubernetes:
-                      description: |-
-                        Kubernetes authorization policy based on `SubjectAccessReview`
-                        Path and Verb are inferred from the request.
-                      properties:
-                        groups:
-                          description: Groups to test for.
-                          items:
-                            type: string
-                          type: array
-                        resourceAttributes:
-                          description: |-
-                            Use ResourceAttributes for checking permissions on Kubernetes resources
-                            If omitted, it performs a non-resource `SubjectAccessReview`, with verb and path inferred from the request.
-                          properties:
-                            group:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            name:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            namespace:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            resource:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            subresource:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                            verb:
-                              description: StaticOrDynamicValue is either a constant
-                                static string value or a config for fetching a value
-                                from a dynamic source (e.g. a path pattern of authorization
-                                JSON)
-                              properties:
-                                value:
-                                  description: Static value
-                                  type: string
-                                valueFrom:
-                                  description: Dynamic value
-                                  properties:
-                                    authJSON:
-                                      description: |-
-                                        Selector to fetch a value from the authorization JSON.
-                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                        user:
-                          description: |-
-                            User to test for.
-                            If without "Groups", then is it interpreted as "What if User were not a member of any groups"
-                          properties:
-                            value:
-                              description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          type: object
-                      required:
-                      - user
-                      type: object
-                    metrics:
-                      default: false
-                      description: Whether this authorization config should generate
-                        individual observability metrics
-                      type: boolean
-                    name:
-                      description: |-
-                        Name of the authorization policy.
-                        It can be used to refer to the resolved authorization object in other configs.
-                      type: string
-                    opa:
-                      description: Open Policy Agent (OPA) authorization policy.
-                      properties:
-                        allValues:
-                          default: false
-                          description: |-
-                            Returns the value of all Rego rules in the virtual document. Values can be read in subsequent evaluators/phases of the Auth Pipeline.
-                            Otherwise, only the default `allow` rule will be exposed.
-                            Returning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.
-                          type: boolean
-                        externalRegistry:
-                          description: External registry of OPA policies.
-                          properties:
-                            credentials:
-                              description: |-
-                                Defines where client credentials will be passed in the request to the service.
-                                If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
-                              properties:
-                                in:
-                                  default: authorization_header
-                                  description: The location in the request where client
-                                    credentials shall be passed on requests authenticating
-                                    with this identity source/authentication mode.
-                                  enum:
-                                  - authorization_header
-                                  - custom_header
-                                  - query
-                                  - cookie
-                                  type: string
-                                keySelector:
-                                  description: |-
-                                    Used in conjunction with the `in` parameter.
-                                    When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
-                                    When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
-                                  type: string
-                              required:
-                              - keySelector
-                              type: object
-                            endpoint:
-                              description: |-
-                                Endpoint of the HTTP external registry.
-                                The endpoint must respond with either plain/text or application/json content-type.
-                                In the latter case, the JSON returned in the body must include a path `result.raw`, where the raw Rego policy will be extracted from. This complies with the specification of the OPA REST API (https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
-                              type: string
-                            sharedSecretRef:
-                              description: |-
-                                Reference to a Secret key whose value will be passed by Authorino in the request.
-                                The HTTP service can use the shared secret to authenticate the origin of the request.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: The name of the secret in the Authorino's
-                                    namespace to select from.
-                                  type: string
-                              required:
-                              - key
-                              - name
-                              type: object
-                            ttl:
-                              description: Duration (in seconds) of the external data
-                                in the cache before pulled again from the source.
-                              type: integer
-                          type: object
-                        inlineRego:
-                          description: |-
-                            Authorization policy as a Rego language document.
-                            The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed).
-                            The Rego document must NOT include the "package" declaration in line 1.
-                          type: string
-                      type: object
-                    priority:
-                      default: 0
-                      description: |-
-                        Priority group of the config.
-                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
-                      type: integer
-                    when:
-                      description: |-
-                        Conditions for Authorino to enforce this authorization policy.
-                        If omitted, the config will be enforced for all requests.
-                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
-                      items:
-                        oneOf:
-                        - properties:
-                            patternRef: {}
-                          required:
-                          - patternRef
-                        - properties:
-                            operator: {}
-                            selector: {}
-                            value: {}
-                          required:
-                          - operator
-                          - selector
-                        - properties:
-                            all: {}
-                          required:
-                          - all
-                        - properties:
-                            any: {}
-                          required:
-                          - any
-                        properties:
-                          all:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical AND.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          any:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical OR.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          operator:
-                            description: |-
-                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
-                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
-                            enum:
-                            - eq
-                            - neq
-                            - incl
-                            - excl
-                            - matches
-                            type: string
-                          patternRef:
-                            description: Name of a named pattern
-                            type: string
-                          selector:
-                            description: |-
-                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
-                            type: string
-                          value:
-                            description: |-
-                              The value of reference for the comparison with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must compile to a valid Golang regex.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - name
-                  type: object
-                type: array
-              callbacks:
-                description: |-
-                  List of callback configs.
-                  Authorino sends callbacks to specified endpoints at the end of the auth pipeline.
-                items:
-                  description: Endpoints to callback at the end of each auth pipeline.
-                  properties:
-                    http:
-                      description: Generic HTTP interface to obtain authorization
-                        metadata from a HTTP service.
-                      properties:
-                        body:
-                          description: |-
-                            Raw body of the HTTP request.
-                            Supersedes 'bodyParameters'; use either one or the other.
-                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
-                          properties:
-                            value:
-                              description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          type: object
-                        bodyParameters:
-                          description: |-
-                            Custom parameters to encode in the body of the HTTP request.
-                            Superseded by 'body'; use either one or the other.
-                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
-                          items:
-                            properties:
-                              name:
-                                description: The name of the JSON property
-                                type: string
-                              value:
-                                description: Static value of the JSON property
-                                x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
-                                properties:
-                                  authJSON:
-                                    description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        contentType:
-                          default: application/x-www-form-urlencoded
-                          description: |-
-                            Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
-                            Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
-                          enum:
-                          - application/x-www-form-urlencoded
-                          - application/json
-                          type: string
-                        credentials:
-                          description: |-
-                            Defines where client credentials will be passed in the request to the service.
-                            If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
-                          properties:
-                            in:
-                              default: authorization_header
-                              description: The location in the request where client
-                                credentials shall be passed on requests authenticating
-                                with this identity source/authentication mode.
-                              enum:
-                              - authorization_header
-                              - custom_header
-                              - query
-                              - cookie
-                              type: string
-                            keySelector:
-                              description: |-
-                                Used in conjunction with the `in` parameter.
-                                When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
-                                When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
-                              type: string
-                          required:
-                          - keySelector
-                          type: object
-                        endpoint:
-                          description: |-
-                            Endpoint of the HTTP service.
-                            The endpoint accepts variable placeholders in the format "{selector}", where "selector" is any pattern supported
-                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
-                            E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
-                          type: string
-                        headers:
-                          description: Custom headers in the HTTP request.
-                          items:
-                            properties:
-                              name:
-                                description: The name of the JSON property
-                                type: string
-                              value:
-                                description: Static value of the JSON property
-                                x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
-                                properties:
-                                  authJSON:
-                                    description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        method:
-                          default: GET
-                          description: |-
-                            HTTP verb used in the request to the service. Accepted values: GET (default), POST.
-                            When the request method is POST, the authorization JSON is passed in the body of the request.
-                          enum:
-                          - GET
-                          - POST
-                          type: string
-                        oauth2:
-                          description: Authentication with the HTTP service by OAuth2
-                            Client Credentials grant.
-                          properties:
-                            cache:
-                              default: true
-                              description: |-
-                                Caches and reuses the token until expired.
-                                Set it to false to force fetch the token at every authorization request regardless of expiration.
-                              type: boolean
-                            clientId:
-                              description: OAuth2 Client ID.
-                              type: string
-                            clientSecretRef:
-                              description: Reference to a Kubernetes Secret key that
-                                stores that OAuth2 Client Secret.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: The name of the secret in the Authorino's
-                                    namespace to select from.
-                                  type: string
-                              required:
-                              - key
-                              - name
-                              type: object
-                            extraParams:
-                              additionalProperties:
-                                type: string
-                              description: Optional extra parameters for the requests
-                                to the token URL.
-                              type: object
-                            scopes:
-                              description: Optional scopes for the client credentials
-                                grant, if supported by he OAuth2 server.
-                              items:
-                                type: string
-                              type: array
-                            tokenUrl:
-                              description: Token endpoint URL of the OAuth2 resource
-                                server.
-                              type: string
-                          required:
-                          - clientId
-                          - clientSecretRef
-                          - tokenUrl
-                          type: object
-                        sharedSecretRef:
-                          description: |-
-                            Reference to a Secret key whose value will be passed by Authorino in the request.
-                            The HTTP service can use the shared secret to authenticate the origin of the request.
-                            Ignored if used together with oauth2.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: The name of the secret in the Authorino's
-                                namespace to select from.
-                              type: string
-                          required:
-                          - key
-                          - name
-                          type: object
-                      required:
-                      - endpoint
-                      type: object
-                    metrics:
-                      default: false
-                      description: Whether this callback config should generate individual
-                        observability metrics
-                      type: boolean
-                    name:
-                      description: |-
-                        Name of the callback.
-                        It can be used to refer to the resolved callback response in other configs.
-                      type: string
-                    priority:
-                      default: 0
-                      description: |-
-                        Priority group of the config.
-                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
-                      type: integer
-                    when:
-                      description: |-
-                        Conditions for Authorino to perform this callback.
-                        If omitted, the callback will be attempted for all requests.
-                        If present, all conditions must match for the callback to be attempted; otherwise, the callback will be skipped.
-                      items:
-                        properties:
-                          all:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical AND.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          any:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical OR.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          operator:
-                            description: |-
-                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
-                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
-                            enum:
-                            - eq
-                            - neq
-                            - incl
-                            - excl
-                            - matches
-                            type: string
-                          patternRef:
-                            description: Name of a named pattern
-                            type: string
-                          selector:
-                            description: |-
-                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
-                            type: string
-                          value:
-                            description: |-
-                              The value of reference for the comparison with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must compile to a valid Golang regex.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - http
-                  - name
-                  type: object
-                type: array
-              denyWith:
-                description: Custom denial response codes, statuses and headers to
-                  override default 40x's.
-                properties:
-                  unauthenticated:
-                    description: Denial status customization when the request is unauthenticated.
-                    properties:
-                      body:
-                        description: HTTP response body to override the default denial
-                          body.
-                        properties:
-                          value:
-                            description: Static value
-                            type: string
-                          valueFrom:
-                            description: Dynamic value
-                            properties:
-                              authJSON:
-                                description: |-
-                                  Selector to fetch a value from the authorization JSON.
-                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                type: string
-                            type: object
-                        type: object
-                      code:
-                        description: HTTP status code to override the default denial
-                          status code.
-                        format: int64
-                        maximum: 599
-                        minimum: 300
-                        type: integer
-                      headers:
-                        description: HTTP response headers to override the default
-                          denial headers.
-                        items:
-                          properties:
-                            name:
-                              description: The name of the JSON property
-                              type: string
-                            value:
-                              description: Static value of the JSON property
-                              x-kubernetes-preserve-unknown-fields: true
-                            valueFrom:
-                              description: Dynamic value of the JSON property
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      message:
-                        description: HTTP message to override the default denial message.
-                        properties:
-                          value:
-                            description: Static value
-                            type: string
-                          valueFrom:
-                            description: Dynamic value
-                            properties:
-                              authJSON:
-                                description: |-
-                                  Selector to fetch a value from the authorization JSON.
-                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                type: string
-                            type: object
-                        type: object
-                    type: object
-                  unauthorized:
-                    description: Denial status customization when the request is unauthorized.
-                    properties:
-                      body:
-                        description: HTTP response body to override the default denial
-                          body.
-                        properties:
-                          value:
-                            description: Static value
-                            type: string
-                          valueFrom:
-                            description: Dynamic value
-                            properties:
-                              authJSON:
-                                description: |-
-                                  Selector to fetch a value from the authorization JSON.
-                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                type: string
-                            type: object
-                        type: object
-                      code:
-                        description: HTTP status code to override the default denial
-                          status code.
-                        format: int64
-                        maximum: 599
-                        minimum: 300
-                        type: integer
-                      headers:
-                        description: HTTP response headers to override the default
-                          denial headers.
-                        items:
-                          properties:
-                            name:
-                              description: The name of the JSON property
-                              type: string
-                            value:
-                              description: Static value of the JSON property
-                              x-kubernetes-preserve-unknown-fields: true
-                            valueFrom:
-                              description: Dynamic value of the JSON property
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      message:
-                        description: HTTP message to override the default denial message.
-                        properties:
-                          value:
-                            description: Static value
-                            type: string
-                          valueFrom:
-                            description: Dynamic value
-                            properties:
-                              authJSON:
-                                description: |-
-                                  Selector to fetch a value from the authorization JSON.
-                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                type: string
-                            type: object
-                        type: object
-                    type: object
-                type: object
-              hosts:
-                description: |-
-                  The list of public host names of the services protected by this authentication/authorization scheme.
-                  Authorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.
-                items:
-                  type: string
-                type: array
-              identity:
-                description: |-
-                  List of identity sources/authentication modes.
-                  At least one config of this list MUST evaluate to a valid identity for a request to be successful in the identity verification phase.
-                items:
-                  description: |-
-                    The identity source/authentication mode config.
-                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "oicd", "apiKey" or "kubernetes".
+              authentication:
+                additionalProperties:
                   oneOf:
                   - properties:
                       credentials: {}
-                      name: {}
-                      oauth2: {}
+                      oauth2Introspection: {}
                     required:
-                    - name
-                    - oauth2
+                    - oauth2Introspection
                   - properties:
                       credentials: {}
-                      name: {}
-                      oidc: {}
+                      jwt: {}
                     required:
-                    - name
-                    - oidc
+                    - jwt
                   - properties:
                       apiKey: {}
                       credentials: {}
-                      name: {}
                     required:
-                    - name
                     - apiKey
                   - properties:
                       credentials: {}
-                      mtls: {}
-                      name: {}
+                      x509: {}
                     required:
-                    - name
-                    - mtls
+                    - x509
                   - properties:
                       credentials: {}
-                      kubernetes: {}
-                      name: {}
+                      kubernetesTokenReview: {}
                     required:
-                    - name
-                    - kubernetes
+                    - kubernetesTokenReview
                   - properties:
                       anonymous: {}
                       credentials: {}
-                      name: {}
                     required:
-                    - name
                     - anonymous
                   - properties:
                       credentials: {}
-                      name: {}
                       plain: {}
                     required:
-                    - name
                     - plain
                   properties:
                     anonymous:
+                      description: Anonymous access.
                       type: object
                     apiKey:
+                      description: Authentication based on API keys stored in Kubernetes
+                        secrets.
                       properties:
                         allNamespaces:
                           default: false
@@ -1275,29 +196,23 @@ spec:
                       type: object
                     cache:
                       description: |-
-                        Caching options for the identity resolved when applying this config.
-                        Omit it to avoid caching identity objects for this config.
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
                       properties:
                         key:
                           description: |-
                             Key used to store the entry in the cache.
-                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                            The resolved key must be unique within the scope of this particular config.
                           properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
                             value:
                               description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                           type: object
                         ttl:
                           default: 60
@@ -1309,63 +224,74 @@ spec:
                       type: object
                     credentials:
                       description: |-
-                        Defines where client credentials are required to be passed in the request for this identity source/authentication mode.
-                        If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the credentials value (token, API key, etc).
+                        Defines where credentials are required to be passed in the request for authentication based on this config.
+                        If omitted, it defaults to credentials passed in the HTTP Authorization header and the "Bearer" prefix prepended to the secret credential value.
                       properties:
-                        in:
-                          default: authorization_header
-                          description: The location in the request where client credentials
-                            shall be passed on requests authenticating with this identity
-                            source/authentication mode.
-                          enum:
-                          - authorization_header
-                          - custom_header
-                          - query
-                          - cookie
-                          type: string
-                        keySelector:
-                          description: |-
-                            Used in conjunction with the `in` parameter.
-                            When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
-                            When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
-                          type: string
-                      required:
-                      - keySelector
+                        authorizationHeader:
+                          properties:
+                            prefix:
+                              type: string
+                          type: object
+                        cookie:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        customHeader:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        queryString:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
                       type: object
-                    extendedProperties:
-                      description: |-
-                        Extends the resolved identity object with additional custom properties before appending to the authorization JSON.
-                        It requires the resolved identity object to always be of the JSON type 'object'. Other JSON types (array, string, etc) will break.
-                      items:
+                    defaults:
+                      additionalProperties:
                         properties:
-                          name:
-                            description: The name of the JSON property
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                             type: string
-                          overwrite:
-                            default: false
-                            description: Whether the value should overwrite the value
-                              of an existing property with the same name.
-                            type: boolean
                           value:
-                            description: Static value of the JSON property
+                            description: Static value
                             x-kubernetes-preserve-unknown-fields: true
-                          valueFrom:
-                            description: Dynamic value of the JSON property
-                            properties:
-                              authJSON:
-                                description: |-
-                                  Selector to fetch a value from the authorization JSON.
-                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                type: string
-                            type: object
-                        required:
-                        - name
                         type: object
-                      type: array
-                    kubernetes:
+                      description: |-
+                        Set default property values (claims) for the resolved identity object, that are set before appending the object to
+                        the authorization JSON. If the property is already present in the resolved identity object, the default value is ignored.
+                        It requires the resolved identity object to always be a JSON object.
+                        Do not use this option with identity objects of other JSON types (array, string, etc).
+                      type: object
+                    jwt:
+                      description: Authentication based on JWT tokens.
+                      properties:
+                        issuerUrl:
+                          description: |-
+                            URL of the issuer of the JWT.
+                            If `jwksUrl` is omitted, Authorino will append the path to the OpenID Connect Well-Known Discovery endpoint
+                            (i.e. "/.well-known/openid-configuration") to this URL, to discover the OIDC configuration where to obtain
+                            the "jkws_uri" claim from.
+                            The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
+                          type: string
+                        ttl:
+                          description: |-
+                            Decides how long to wait before refreshing the JWKS (in seconds).
+                            If omitted, Authorino will never refresh the JWKS.
+                          type: integer
+                      type: object
+                    kubernetesTokenReview:
+                      description: Authentication by Kubernetes token review.
                       properties:
                         audiences:
                           description: |-
@@ -1377,73 +303,11 @@ spec:
                       type: object
                     metrics:
                       default: false
-                      description: Whether this identity config should generate individual
+                      description: Whether this config should generate individual
                         observability metrics
                       type: boolean
-                    mtls:
-                      properties:
-                        allNamespaces:
-                          default: false
-                          description: |-
-                            Whether Authorino should look for TLS secrets in all namespaces or only in the same namespace as the AuthConfig.
-                            Enabling this option in namespaced Authorino instances has no effect.
-                          type: boolean
-                        selector:
-                          description: Label selector used by Authorino to match secrets
-                            from the cluster storing trusted CA certificates to validate
-                            clients trying to authenticate to this service
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                          x-kubernetes-map-type: atomic
-                      required:
-                      - selector
-                      type: object
-                    name:
-                      description: |-
-                        The name of this identity source/authentication mode.
-                        It usually identifies a source of identities or group of users/clients of the protected service.
-                        It can be used to refer to the resolved identity object in other configs.
-                      type: string
-                    oauth2:
+                    oauth2Introspection:
+                      description: Authentication by OAuth2 token introspection.
                       properties:
                         credentialsRef:
                           description: Reference to a Kubernetes secret in the same
@@ -1458,7 +322,7 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
-                        tokenIntrospectionUrl:
+                        endpoint:
                           description: The full URL of the token introspection endpoint.
                           type: string
                         tokenTypeHint:
@@ -1468,33 +332,40 @@ spec:
                           type: string
                       required:
                       - credentialsRef
-                      - tokenIntrospectionUrl
-                      type: object
-                    oidc:
-                      properties:
-                        endpoint:
-                          description: |-
-                            Endpoint of the OIDC issuer.
-                            Authorino will append to this value the well-known path to the OpenID Connect discovery endpoint (i.e. "/.well-known/openid-configuration"), used to automatically discover the OpenID Connect configuration, whose set of claims is expected to include (among others) the "jkws_uri" claim.
-                            The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
-                          type: string
-                        ttl:
-                          description: Decides how long to wait before refreshing
-                            the OIDC configuration (in seconds).
-                          type: integer
-                      required:
                       - endpoint
                       type: object
+                    overrides:
+                      additionalProperties:
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      description: |-
+                        Overrides the resolved identity object by setting the additional properties (claims) specified in this config,
+                        before appending the object to the authorization JSON.
+                        It requires the resolved identity object to always be a JSON object.
+                        Do not use this option with identity objects of other JSON types (array, string, etc).
+                      type: object
                     plain:
+                      description: |-
+                        Identity object extracted from the context.
+                        Use this method when authentication is performed beforehand by a proxy and the resulting object passed to Authorino as JSON in the auth request.
                       properties:
-                        authJSON:
+                        selector:
                           description: |-
-                            Selector to fetch a value from the authorization JSON.
-                            It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                            or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                            Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                            The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                           type: string
+                      required:
+                      - selector
                       type: object
                     priority:
                       default: 0
@@ -1504,7 +375,7 @@ spec:
                       type: integer
                     when:
                       description: |-
-                        Conditions for Authorino to enforce this identity config.
+                        Conditions for Authorino to enforce this config.
                         If omitted, the config will be enforced for all requests.
                         If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
                       items:
@@ -1555,12 +426,13 @@ spec:
                             - matches
                             type: string
                           patternRef:
-                            description: Name of a named pattern
+                            description: Reference to a named set of pattern expressions
                             type: string
                           selector:
                             description: |-
-                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
                             type: string
                           value:
                             description: |-
@@ -1569,63 +441,730 @@ spec:
                             type: string
                         type: object
                       type: array
-                  required:
-                  - name
+                    x509:
+                      description: |-
+                        Authentication based on client X.509 certificates.
+                        The certificates presented by the clients must be signed by a trusted CA whose certificates are stored in Kubernetes secrets.
+                      properties:
+                        allNamespaces:
+                          default: false
+                          description: |-
+                            Whether Authorino should look for TLS secrets in all namespaces or only in the same namespace as the AuthConfig.
+                            Enabling this option in namespaced Authorino instances has no effect.
+                          type: boolean
+                        selector:
+                          description: |-
+                            Label selector used by Authorino to match secrets from the cluster storing trusted CA certificates to validate
+                            clients trying to authenticate to this service
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - selector
+                      type: object
                   type: object
-                type: array
-              metadata:
                 description: |-
-                  List of metadata source configs.
-                  Authorino fetches JSON content from sources on this list on every request.
-                items:
-                  description: |-
-                    The metadata config.
-                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "http", userInfo" or "uma".
+                  Authentication configs.
+                  At least one config MUST evaluate to a valid identity object for the auth request to be successful.
+                type: object
+              authorization:
+                additionalProperties:
                   oneOf:
                   - properties:
-                      name: {}
-                      userInfo: {}
+                      opa: {}
                     required:
-                    - name
-                    - userInfo
+                    - opa
                   - properties:
-                      name: {}
-                      uma: {}
+                      patternMatching: {}
                     required:
-                    - name
-                    - uma
+                    - patternMatching
                   - properties:
-                      http: {}
-                      name: {}
+                      kubernetesSubjectAccessReview: {}
                     required:
-                    - name
-                    - http
+                    - kubernetesSubjectAccessReview
+                  - properties:
+                      spicedb: {}
+                    required:
+                    - spicedb
                   properties:
                     cache:
                       description: |-
-                        Caching options for the external metadata fetched when applying this config.
-                        Omit it to avoid caching metadata from this source.
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
                       properties:
                         key:
                           description: |-
                             Key used to store the entry in the cache.
-                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                            The resolved key must be unique within the scope of this particular config.
                           properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
                             value:
                               description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    kubernetesSubjectAccessReview:
+                      description: Authorization by Kubernetes SubjectAccessReview
+                      properties:
+                        groups:
+                          description: Groups the user must be a member of or, if
+                            `user` is omitted, the groups to check for authorization
+                            in the Kubernetes RBAC.
+                          items:
+                            type: string
+                          type: array
+                        resourceAttributes:
+                          description: |-
+                            Use resourceAttributes to check permissions on Kubernetes resources.
+                            If omitted, it performs a non-resource SubjectAccessReview, with verb and path inferred from the request.
+                          properties:
+                            group:
+                              description: |-
+                                API group of the resource.
+                                Use '*' for all API groups.
                               properties:
-                                authJSON:
+                                selector:
                                   description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                   type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
                               type: object
+                            name:
+                              description: |-
+                                Resource name
+                                Omit it to check for authorization on all resources of the specified kind.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            namespace:
+                              description: Namespace where the user must have permissions
+                                on the resource.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            resource:
+                              description: |-
+                                Resource kind
+                                Use '*' for all resource kinds.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            subresource:
+                              description: Subresource kind
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            verb:
+                              description: |-
+                                Verb to check for authorization on the resource.
+                                Use '*' for all verbs.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                        user:
+                          description: |-
+                            User to check for authorization in the Kubernetes RBAC.
+                            Omit it to check for group authorization only.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
+                    opa:
+                      description: Open Policy Agent (OPA) Rego policy.
+                      properties:
+                        allValues:
+                          default: false
+                          description: |-
+                            Returns the value of all Rego rules in the virtual document. Values can be read in subsequent evaluators/phases of the Auth Pipeline.
+                            Otherwise, only the default `allow` rule will be exposed.
+                            Returning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.
+                          type: boolean
+                        externalPolicy:
+                          description: |-
+                            Settings for fetching the OPA policy from an external registry.
+                            Use it alternatively to 'rego'.
+                            For the configurations of the HTTP request, the following options are not implemented: 'method', 'body', 'bodyParameters',
+                            'contentType', 'headers', 'oauth2'. Use it only with: 'url', 'sharedSecret', 'credentials'.
+                          properties:
+                            body:
+                              description: |-
+                                Raw body of the HTTP request.
+                                Supersedes 'bodyParameters'; use either one or the other.
+                                Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            bodyParameters:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: |-
+                                Custom parameters to encode in the body of the HTTP request.
+                                Superseded by 'body'; use either one or the other.
+                                Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                              type: object
+                            contentType:
+                              default: application/x-www-form-urlencoded
+                              description: |-
+                                Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                                Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                              enum:
+                              - application/x-www-form-urlencoded
+                              - application/json
+                              type: string
+                            credentials:
+                              description: |-
+                                Defines where client credentials will be passed in the request to the service.
+                                If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                              properties:
+                                authorizationHeader:
+                                  properties:
+                                    prefix:
+                                      type: string
+                                  type: object
+                                cookie:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                customHeader:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                queryString:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                              type: object
+                            headers:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: Custom headers in the HTTP request.
+                              type: object
+                            method:
+                              default: GET
+                              description: |-
+                                HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                                When the request method is POST, the authorization JSON is passed in the body of the request.
+                              enum:
+                              - GET
+                              - POST
+                              - PUT
+                              - PATCH
+                              - DELETE
+                              - HEAD
+                              - OPTIONS
+                              - CONNECT
+                              - TRACE
+                              type: string
+                            oauth2:
+                              description: Authentication with the HTTP service by
+                                OAuth2 Client Credentials grant.
+                              properties:
+                                cache:
+                                  default: true
+                                  description: |-
+                                    Caches and reuses the token until expired.
+                                    Set it to false to force fetch the token at every authorization request regardless of expiration.
+                                  type: boolean
+                                clientId:
+                                  description: OAuth2 Client ID.
+                                  type: string
+                                clientSecretRef:
+                                  description: Reference to a Kuberentes Secret key
+                                    that stores that OAuth2 Client Secret.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: The name of the secret in the Authorino's
+                                        namespace to select from.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                extraParams:
+                                  additionalProperties:
+                                    type: string
+                                  description: Optional extra parameters for the requests
+                                    to the token URL.
+                                  type: object
+                                scopes:
+                                  description: Optional scopes for the client credentials
+                                    grant, if supported by he OAuth2 server.
+                                  items:
+                                    type: string
+                                  type: array
+                                tokenUrl:
+                                  description: Token endpoint URL of the OAuth2 resource
+                                    server.
+                                  type: string
+                              required:
+                              - clientId
+                              - clientSecretRef
+                              - tokenUrl
+                              type: object
+                            sharedSecretRef:
+                              description: |-
+                                Reference to a Secret key whose value will be passed by Authorino in the request.
+                                The HTTP service can use the shared secret to authenticate the origin of the request.
+                                Ignored if used together with oauth2.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            ttl:
+                              description: Duration (in seconds) of the external data
+                                in the cache before pulled again from the source.
+                              type: integer
+                            url:
+                              description: |-
+                                Endpoint URL of the HTTP service.
+                                The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                                by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                                E.g. https://ext-auth-server.io/metadata?p={request.path}
+                              type: string
+                          required:
+                          - url
+                          type: object
+                        rego:
+                          description: |-
+                            Authorization policy as a Rego language document.
+                            The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed).
+                            The Rego document must NOT include the "package" declaration in line 1.
+                          type: string
+                      type: object
+                    patternMatching:
+                      description: Pattern-matching authorization rules.
+                      properties:
+                        patterns:
+                          items:
+                            oneOf:
+                            - properties:
+                                patternRef: {}
+                              required:
+                              - patternRef
+                            - properties:
+                                operator: {}
+                                selector: {}
+                                value: {}
+                              required:
+                              - operator
+                              - selector
+                            - properties:
+                                all: {}
+                              required:
+                              - all
+                            - properties:
+                                any: {}
+                              required:
+                              - any
+                            properties:
+                              all:
+                                description: A list of pattern expressions to be evaluated
+                                  as a logical AND.
+                                items:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                type: array
+                              any:
+                                description: A list of pattern expressions to be evaluated
+                                  as a logical OR.
+                                items:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                type: array
+                              operator:
+                                description: |-
+                                  The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                  Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                enum:
+                                - eq
+                                - neq
+                                - incl
+                                - excl
+                                - matches
+                                type: string
+                              patternRef:
+                                description: Reference to a named set of pattern expressions
+                                type: string
+                              selector:
+                                description: |-
+                                  Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  Authorino custom JSON path modifiers are also supported.
+                                type: string
+                              value:
+                                description: |-
+                                  The value of reference for the comparison with the content fetched from the authorization JSON.
+                                  If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - patterns
+                      type: object
+                    priority:
+                      default: 0
+                      description: |-
+                        Priority group of the config.
+                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      type: integer
+                    spicedb:
+                      description: Authorization decision delegated to external Authzed/SpiceDB
+                        server.
+                      properties:
+                        endpoint:
+                          description: Hostname and port number to the GRPC interface
+                            of the SpiceDB server (e.g. spicedb:50051).
+                          type: string
+                        insecure:
+                          description: Insecure HTTP connection (i.e. disables TLS
+                            verification)
+                          type: boolean
+                        permission:
+                          description: The name of the permission (or relation) on
+                            which to execute the check.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        resource:
+                          description: The resource on which to check the permission
+                            or relation.
+                          properties:
+                            kind:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            name:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                        sharedSecretRef:
+                          description: Reference to a Secret key whose value will
+                            be used by Authorino to authenticate with the Authzed
+                            service.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        subject:
+                          description: The subject that will be checked for the permission
+                            or relation.
+                          properties:
+                            kind:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            name:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                      required:
+                      - endpoint
+                      type: object
+                    when:
+                      description: |-
+                        Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                      items:
+                        oneOf:
+                        - properties:
+                            patternRef: {}
+                          required:
+                          - patternRef
+                        - properties:
+                            operator: {}
+                            selector: {}
+                            value: {}
+                          required:
+                          - operator
+                          - selector
+                        - properties:
+                            all: {}
+                          required:
+                          - all
+                        - properties:
+                            any: {}
+                          required:
+                          - any
+                        properties:
+                          all:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical AND.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          any:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical OR.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          operator:
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: |-
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
+                            type: string
+                          value:
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                description: |-
+                  Authorization policies.
+                  All policies MUST evaluate to "allowed = true" for the auth request be successful.
+                type: object
+              callbacks:
+                additionalProperties:
+                  properties:
+                    cache:
+                      description: |-
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
+                      properties:
+                        key:
+                          description: |-
+                            Key used to store the entry in the cache.
+                            The resolved key must be unique within the scope of this particular config.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
                           type: object
                         ttl:
                           default: 60
@@ -1636,8 +1175,7 @@ spec:
                       - key
                       type: object
                     http:
-                      description: Generic HTTP interface to obtain authorization
-                        metadata from a HTTP service.
+                      description: Settings of the external HTTP request
                       properties:
                         body:
                           description: |-
@@ -1645,51 +1183,34 @@ spec:
                             Supersedes 'bodyParameters'; use either one or the other.
                             Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
                           properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
                             value:
                               description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                           type: object
                         bodyParameters:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
                           description: |-
                             Custom parameters to encode in the body of the HTTP request.
                             Superseded by 'body'; use either one or the other.
                             Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
-                          items:
-                            properties:
-                              name:
-                                description: The name of the JSON property
-                                type: string
-                              value:
-                                description: Static value of the JSON property
-                                x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
-                                properties:
-                                  authJSON:
-                                    description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
+                          type: object
                         contentType:
                           default: application/x-www-form-urlencoded
                           description: |-
@@ -1704,59 +1225,48 @@ spec:
                             Defines where client credentials will be passed in the request to the service.
                             If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
                           properties:
-                            in:
-                              default: authorization_header
-                              description: The location in the request where client
-                                credentials shall be passed on requests authenticating
-                                with this identity source/authentication mode.
-                              enum:
-                              - authorization_header
-                              - custom_header
-                              - query
-                              - cookie
-                              type: string
-                            keySelector:
-                              description: |-
-                                Used in conjunction with the `in` parameter.
-                                When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
-                                When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
-                              type: string
-                          required:
-                          - keySelector
+                            authorizationHeader:
+                              properties:
+                                prefix:
+                                  type: string
+                              type: object
+                            cookie:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            customHeader:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            queryString:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
                           type: object
-                        endpoint:
-                          description: |-
-                            Endpoint of the HTTP service.
-                            The endpoint accepts variable placeholders in the format "{selector}", where "selector" is any pattern supported
-                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
-                            E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
-                          type: string
                         headers:
-                          description: Custom headers in the HTTP request.
-                          items:
+                          additionalProperties:
                             properties:
-                              name:
-                                description: The name of the JSON property
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                 type: string
                               value:
-                                description: Static value of the JSON property
+                                description: Static value
                                 x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
-                                properties:
-                                  authJSON:
-                                    description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                    type: string
-                                type: object
-                            required:
-                            - name
                             type: object
-                          type: array
+                          description: Custom headers in the HTTP request.
+                          type: object
                         method:
                           default: GET
                           description: |-
@@ -1765,6 +1275,13 @@ spec:
                           enum:
                           - GET
                           - POST
+                          - PUT
+                          - PATCH
+                          - DELETE
+                          - HEAD
+                          - OPTIONS
+                          - CONNECT
+                          - TRACE
                           type: string
                         oauth2:
                           description: Authentication with the HTTP service by OAuth2
@@ -1780,7 +1297,7 @@ spec:
                               description: OAuth2 Client ID.
                               type: string
                             clientSecretRef:
-                              description: Reference to a Kubernetes Secret key that
+                              description: Reference to a Kuberentes Secret key that
                                 stores that OAuth2 Client Secret.
                               properties:
                                 key:
@@ -1834,19 +1351,325 @@ spec:
                           - key
                           - name
                           type: object
+                        url:
+                          description: |-
+                            Endpoint URL of the HTTP service.
+                            The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                            E.g. https://ext-auth-server.io/metadata?p={request.path}
+                          type: string
                       required:
-                      - endpoint
+                      - url
                       type: object
                     metrics:
                       default: false
-                      description: Whether this metadata config should generate individual
+                      description: Whether this config should generate individual
                         observability metrics
                       type: boolean
-                    name:
+                    priority:
+                      default: 0
                       description: |-
-                        The name of the metadata source.
-                        It can be used to refer to the resolved metadata object in other configs.
-                      type: string
+                        Priority group of the config.
+                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      type: integer
+                    when:
+                      description: |-
+                        Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                      items:
+                        properties:
+                          all:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical AND.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          any:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical OR.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          operator:
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: |-
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
+                            type: string
+                          value:
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - http
+                  type: object
+                description: |-
+                  Callback functions.
+                  Authorino sends callbacks at the end of the auth pipeline to the endpoints specified in this config.
+                type: object
+              hosts:
+                description: |-
+                  The list of public host names of the services protected by this authentication/authorization scheme.
+                  Authorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.
+                items:
+                  type: string
+                type: array
+              metadata:
+                additionalProperties:
+                  oneOf:
+                  - properties:
+                      userInfo: {}
+                    required:
+                    - userInfo
+                  - properties:
+                      uma: {}
+                    required:
+                    - uma
+                  - properties:
+                      http: {}
+                    required:
+                    - http
+                  properties:
+                    cache:
+                      description: |-
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
+                      properties:
+                        key:
+                          description: |-
+                            Key used to store the entry in the cache.
+                            The resolved key must be unique within the scope of this particular config.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    http:
+                      description: External source of auth metadata via HTTP request
+                      properties:
+                        body:
+                          description: |-
+                            Raw body of the HTTP request.
+                            Supersedes 'bodyParameters'; use either one or the other.
+                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        bodyParameters:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: |-
+                            Custom parameters to encode in the body of the HTTP request.
+                            Superseded by 'body'; use either one or the other.
+                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                          type: object
+                        contentType:
+                          default: application/x-www-form-urlencoded
+                          description: |-
+                            Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                            Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                          enum:
+                          - application/x-www-form-urlencoded
+                          - application/json
+                          type: string
+                        credentials:
+                          description: |-
+                            Defines where client credentials will be passed in the request to the service.
+                            If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                          properties:
+                            authorizationHeader:
+                              properties:
+                                prefix:
+                                  type: string
+                              type: object
+                            cookie:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            customHeader:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            queryString:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          type: object
+                        headers:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: Custom headers in the HTTP request.
+                          type: object
+                        method:
+                          default: GET
+                          description: |-
+                            HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                            When the request method is POST, the authorization JSON is passed in the body of the request.
+                          enum:
+                          - GET
+                          - POST
+                          - PUT
+                          - PATCH
+                          - DELETE
+                          - HEAD
+                          - OPTIONS
+                          - CONNECT
+                          - TRACE
+                          type: string
+                        oauth2:
+                          description: Authentication with the HTTP service by OAuth2
+                            Client Credentials grant.
+                          properties:
+                            cache:
+                              default: true
+                              description: |-
+                                Caches and reuses the token until expired.
+                                Set it to false to force fetch the token at every authorization request regardless of expiration.
+                              type: boolean
+                            clientId:
+                              description: OAuth2 Client ID.
+                              type: string
+                            clientSecretRef:
+                              description: Reference to a Kuberentes Secret key that
+                                stores that OAuth2 Client Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            extraParams:
+                              additionalProperties:
+                                type: string
+                              description: Optional extra parameters for the requests
+                                to the token URL.
+                              type: object
+                            scopes:
+                              description: Optional scopes for the client credentials
+                                grant, if supported by he OAuth2 server.
+                              items:
+                                type: string
+                              type: array
+                            tokenUrl:
+                              description: Token endpoint URL of the OAuth2 resource
+                                server.
+                              type: string
+                          required:
+                          - clientId
+                          - clientSecretRef
+                          - tokenUrl
+                          type: object
+                        sharedSecretRef:
+                          description: |-
+                            Reference to a Secret key whose value will be passed by Authorino in the request.
+                            The HTTP service can use the shared secret to authenticate the origin of the request.
+                            Ignored if used together with oauth2.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        url:
+                          description: |-
+                            Endpoint URL of the HTTP service.
+                            The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                            E.g. https://ext-auth-server.io/metadata?p={request.path}
+                          type: string
+                      required:
+                      - url
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
                     priority:
                       default: 0
                       description: |-
@@ -1879,252 +1702,20 @@ spec:
                       - endpoint
                       type: object
                     userInfo:
-                      description: OpendID Connect UserInfo linked to an OIDC identity
-                        config of this same spec.
+                      description: OpendID Connect UserInfo linked to an OIDC authentication
+                        config specified in this same AuthConfig.
                       properties:
                         identitySource:
-                          description: The name of an OIDC identity source included
-                            in the "identity" section and whose OpenID Connect configuration
-                            discovered includes the OIDC "userinfo_endpoint" claim.
+                          description: The name of an OIDC-enabled JWT authentication
+                            config whose OpenID Connect configuration discovered includes
+                            the OIDC "userinfo_endpoint" claim.
                           type: string
                       required:
                       - identitySource
                       type: object
                     when:
                       description: |-
-                        Conditions for Authorino to apply this metadata config.
-                        If omitted, the config will be applied for all requests.
-                        If present, all conditions must match for the config to be applied; otherwise, the config will be skipped.
-                      items:
-                        oneOf:
-                        - properties:
-                            patternRef: {}
-                          required:
-                          - patternRef
-                        - properties:
-                            operator: {}
-                            selector: {}
-                            value: {}
-                          required:
-                          - operator
-                          - selector
-                        - properties:
-                            all: {}
-                          required:
-                          - all
-                        - properties:
-                            any: {}
-                          required:
-                          - any
-                        properties:
-                          all:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical AND.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          any:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical OR.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          operator:
-                            description: |-
-                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
-                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
-                            enum:
-                            - eq
-                            - neq
-                            - incl
-                            - excl
-                            - matches
-                            type: string
-                          patternRef:
-                            description: Name of a named pattern
-                            type: string
-                          selector:
-                            description: |-
-                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
-                            type: string
-                          value:
-                            description: |-
-                              The value of reference for the comparison with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must compile to a valid Golang regex.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - name
-                  type: object
-                type: array
-              patterns:
-                additionalProperties:
-                  items:
-                    properties:
-                      operator:
-                        description: |-
-                          The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
-                          Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
-                        enum:
-                        - eq
-                        - neq
-                        - incl
-                        - excl
-                        - matches
-                        type: string
-                      selector:
-                        description: |-
-                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                          The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
-                        type: string
-                      value:
-                        description: |-
-                          The value of reference for the comparison with the content fetched from the authorization JSON.
-                          If used with the "matches" operator, the value must compile to a valid Golang regex.
-                        type: string
-                    type: object
-                  type: array
-                description: Named sets of JSON patterns that can be referred in `when`
-                  conditionals and in JSON-pattern matching policy rules.
-                type: object
-              response:
-                description: |-
-                  List of response configs.
-                  Authorino gathers data from the auth pipeline to build custom responses for the client.
-                items:
-                  description: |-
-                    Dynamic response to return to the client.
-                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "wristband" or "json".
-                  oneOf:
-                  - properties:
-                      name: {}
-                      wristband: {}
-                    required:
-                    - name
-                    - wristband
-                  - properties:
-                      json: {}
-                      name: {}
-                    required:
-                    - name
-                    - json
-                  - properties:
-                      name: {}
-                      plain: {}
-                    required:
-                    - name
-                    - plain
-                  properties:
-                    cache:
-                      description: |-
-                        Caching options for dynamic responses built when applying this config.
-                        Omit it to avoid caching dynamic responses for this config.
-                      properties:
-                        key:
-                          description: |-
-                            Key used to store the entry in the cache.
-                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
-                          properties:
-                            value:
-                              description: Static value
-                              type: string
-                            valueFrom:
-                              description: Dynamic value
-                              properties:
-                                authJSON:
-                                  description: |-
-                                    Selector to fetch a value from the authorization JSON.
-                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                  type: string
-                              type: object
-                          type: object
-                        ttl:
-                          default: 60
-                          description: Duration (in seconds) of the external data
-                            in the cache before pulled again from the source.
-                          type: integer
-                      required:
-                      - key
-                      type: object
-                    json:
-                      properties:
-                        properties:
-                          description: List of JSON property-value pairs to be added
-                            to the dynamic response.
-                          items:
-                            properties:
-                              name:
-                                description: The name of the JSON property
-                                type: string
-                              value:
-                                description: Static value of the JSON property
-                                x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
-                                properties:
-                                  authJSON:
-                                    description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                      required:
-                      - properties
-                      type: object
-                    metrics:
-                      default: false
-                      description: Whether this response config should generate individual
-                        observability metrics
-                      type: boolean
-                    name:
-                      description: |-
-                        Name of the custom response.
-                        It can be used to refer to the resolved response object in other configs.
-                      type: string
-                    plain:
-                      description: StaticOrDynamicValue is either a constant static
-                        string value or a config for fetching a value from a dynamic
-                        source (e.g. a path pattern of authorization JSON)
-                      properties:
-                        value:
-                          description: Static value
-                          type: string
-                        valueFrom:
-                          description: Dynamic value
-                          properties:
-                            authJSON:
-                              description: |-
-                                Selector to fetch a value from the authorization JSON.
-                                It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
-                              type: string
-                          type: object
-                      type: object
-                    priority:
-                      default: 0
-                      description: |-
-                        Priority group of the config.
-                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
-                      type: integer
-                    when:
-                      description: |-
-                        Conditions for Authorino to enforce this custom response config.
+                        Conditions for Authorino to enforce this config.
                         If omitted, the config will be enforced for all requests.
                         If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
                       items:
@@ -2175,12 +1766,13 @@ spec:
                             - matches
                             type: string
                           patternRef:
-                            description: Name of a named pattern
+                            description: Reference to a named set of pattern expressions
                             type: string
                           selector:
                             description: |-
-                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
                             type: string
                           value:
                             description: |-
@@ -2189,99 +1781,637 @@ spec:
                             type: string
                         type: object
                       type: array
-                    wrapper:
-                      default: httpHeader
-                      description: |-
-                        How Authorino wraps the response.
-                        Use "httpHeader" (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata" to wrap the response as Envoy Dynamic Metadata
-                      enum:
-                      - httpHeader
-                      - envoyDynamicMetadata
-                      type: string
-                    wrapperKey:
-                      description: |-
-                        The name of key used in the wrapped response (name of the HTTP header or property of the Envoy Dynamic Metadata JSON).
-                        If omitted, it will be set to the name of the configuration.
-                      type: string
-                    wristband:
-                      properties:
-                        customClaims:
-                          description: Any claims to be added to the wristband token
-                            apart from the standard JWT claims (iss, iat, exp) added
-                            by default.
-                          items:
-                            properties:
-                              name:
-                                description: The name of the JSON property
-                                type: string
-                              value:
-                                description: Static value of the JSON property
-                                x-kubernetes-preserve-unknown-fields: true
-                              valueFrom:
-                                description: Dynamic value of the JSON property
+                  type: object
+                description: |-
+                  Metadata sources.
+                  Authorino fetches auth metadata as JSON from sources specified in this config.
+                type: object
+              patterns:
+                additionalProperties:
+                  items:
+                    properties:
+                      operator:
+                        description: |-
+                          The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                          Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                        enum:
+                        - eq
+                        - neq
+                        - incl
+                        - excl
+                        - matches
+                        type: string
+                      selector:
+                        description: |-
+                          Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                          Authorino custom JSON path modifiers are also supported.
+                        type: string
+                      value:
+                        description: |-
+                          The value of reference for the comparison with the content fetched from the authorization JSON.
+                          If used with the "matches" operator, the value must compile to a valid Golang regex.
+                        type: string
+                    type: object
+                  type: array
+                description: Named sets of patterns that can be referred in `when`
+                  conditions and in pattern-matching authorization policy rules.
+                type: object
+              response:
+                description: |-
+                  Response items.
+                  Authorino builds custom responses to the client of the auth request.
+                properties:
+                  success:
+                    description: |-
+                      Response items to be included in the auth response when the request is authenticated and authorized.
+                      For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata and/or inject data in the request.
+                    properties:
+                      dynamicMetadata:
+                        additionalProperties:
+                          description: Settings of the success custom response item.
+                          oneOf:
+                          - properties:
+                              wristband: {}
+                            required:
+                            - wristband
+                          - properties:
+                              json: {}
+                            required:
+                            - json
+                          - properties:
+                              plain: {}
+                            required:
+                            - plain
+                          properties:
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            json:
+                              description: |-
+                                JSON object
+                                Specify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.
+                              properties:
                                 properties:
-                                  authJSON:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: object
+                              required:
+                              - properties
+                              type: object
+                            key:
+                              description: |-
+                                The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object).
+                                If omitted, it will be set to the name of the response config.
+                              type: string
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            plain:
+                              description: Plain text content
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                oneOf:
+                                - properties:
+                                    patternRef: {}
+                                  required:
+                                  - patternRef
+                                - properties:
+                                    operator: {}
+                                    selector: {}
+                                    value: {}
+                                  required:
+                                  - operator
+                                  - selector
+                                - properties:
+                                    all: {}
+                                  required:
+                                  - all
+                                - properties:
+                                    any: {}
+                                  required:
+                                  - any
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
                                     description: |-
-                                      Selector to fetch a value from the authorization JSON.
-                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
-                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
-                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
                                     type: string
                                 type: object
+                              type: array
+                            wristband:
+                              description: Authorino Festival Wristband token
+                              properties:
+                                customClaims:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Any claims to be added to the wristband
+                                    token apart from the standard JWT claims (iss,
+                                    iat, exp) added by default.
+                                  type: object
+                                issuer:
+                                  description: 'The endpoint to the Authorino service
+                                    that issues the wristband (format: <scheme>://<host>:<port>/<realm>,
+                                    where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                  type: string
+                                signingKeyRefs:
+                                  description: |-
+                                    Reference by name to Kubernetes secrets and corresponding signing algorithms.
+                                    The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                                  items:
+                                    properties:
+                                      algorithm:
+                                        description: Algorithm to sign the wristband
+                                          token using the signing key provided
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - ES512
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the signing key.
+                                          The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                                        type: string
+                                    required:
+                                    - algorithm
+                                    - name
+                                    type: object
+                                  type: array
+                                tokenDuration:
+                                  description: Time span of the wristband token, in
+                                    seconds.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - issuer
+                              - signingKeyRefs
+                              type: object
+                          type: object
+                        description: |-
+                          Custom success response items wrapped as HTTP headers.
+                          For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata.
+                          See https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata
+                        type: object
+                      headers:
+                        additionalProperties:
+                          oneOf:
+                          - properties:
+                              wristband: {}
                             required:
-                            - name
-                            type: object
-                          type: array
-                        issuer:
-                          description: 'The endpoint to the Authorino service that
-                            issues the wristband (format: <scheme>://<host>:<port>/<realm>,
-                            where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
-                          type: string
-                        signingKeyRefs:
-                          description: |-
-                            Reference by name to Kubernetes secrets and corresponding signing algorithms.
-                            The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
-                          items:
-                            properties:
-                              algorithm:
-                                description: Algorithm to sign the wristband token
-                                  using the signing key provided
-                                enum:
-                                - ES256
-                                - ES384
-                                - ES512
-                                - RS256
-                                - RS384
-                                - RS512
-                                type: string
-                              name:
-                                description: |-
-                                  Name of the signing key.
-                                  The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
-                                type: string
+                            - wristband
+                          - properties:
+                              json: {}
                             required:
-                            - algorithm
-                            - name
-                            type: object
-                          type: array
-                        tokenDuration:
-                          description: Time span of the wristband token, in seconds.
-                          format: int64
-                          type: integer
-                      required:
-                      - issuer
-                      - signingKeyRefs
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
+                            - json
+                          - properties:
+                              plain: {}
+                            required:
+                            - plain
+                          properties:
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            json:
+                              description: |-
+                                JSON object
+                                Specify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.
+                              properties:
+                                properties:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: object
+                              required:
+                              - properties
+                              type: object
+                            key:
+                              description: |-
+                                The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object).
+                                If omitted, it will be set to the name of the response config.
+                              type: string
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            plain:
+                              description: Plain text content
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                oneOf:
+                                - properties:
+                                    patternRef: {}
+                                  required:
+                                  - patternRef
+                                - properties:
+                                    operator: {}
+                                    selector: {}
+                                    value: {}
+                                  required:
+                                  - operator
+                                  - selector
+                                - properties:
+                                    all: {}
+                                  required:
+                                  - all
+                                - properties:
+                                    any: {}
+                                  required:
+                                  - any
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
+                                    description: |-
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                            wristband:
+                              description: Authorino Festival Wristband token
+                              properties:
+                                customClaims:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Any claims to be added to the wristband
+                                    token apart from the standard JWT claims (iss,
+                                    iat, exp) added by default.
+                                  type: object
+                                issuer:
+                                  description: 'The endpoint to the Authorino service
+                                    that issues the wristband (format: <scheme>://<host>:<port>/<realm>,
+                                    where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                  type: string
+                                signingKeyRefs:
+                                  description: |-
+                                    Reference by name to Kubernetes secrets and corresponding signing algorithms.
+                                    The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                                  items:
+                                    properties:
+                                      algorithm:
+                                        description: Algorithm to sign the wristband
+                                          token using the signing key provided
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - ES512
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the signing key.
+                                          The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                                        type: string
+                                    required:
+                                    - algorithm
+                                    - name
+                                    type: object
+                                  type: array
+                                tokenDuration:
+                                  description: Time span of the wristband token, in
+                                    seconds.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - issuer
+                              - signingKeyRefs
+                              type: object
+                          type: object
+                        description: |-
+                          Custom success response items wrapped as HTTP headers.
+                          For integration of Authorino via proxy, the proxy must use these settings to inject data in the request.
+                        type: object
+                    type: object
+                  unauthenticated:
+                    description: |-
+                      Customizations on the denial status attributes when the request is unauthenticated.
+                      For integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config.
+                      Default: 401 Unauthorized
+                    properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      code:
+                        description: HTTP status code to override the default denial
+                          status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        additionalProperties:
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        description: HTTP response headers to override the default
+                          denial headers.
+                        type: object
+                      message:
+                        description: HTTP message to override the default denial message.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                  unauthorized:
+                    description: |-
+                      Customizations on the denial status attributes when the request is unauthorized.
+                      For integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config.
+                      Default: 403 Forbidden
+                    properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      code:
+                        description: HTTP status code to override the default denial
+                          status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        additionalProperties:
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        description: HTTP response headers to override the default
+                          denial headers.
+                        type: object
+                      message:
+                        description: HTTP message to override the default denial message.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                type: object
               when:
                 description: |-
-                  Conditions for the AuthConfig to be enforced.
-                  If omitted, the AuthConfig will be enforced for all requests.
-                  If present, all conditions must match for the AuthConfig to be enforced; otherwise, Authorino skips the AuthConfig and returns immediately with status OK.
+                  Overall conditions for the AuthConfig to be enforced.
+                  If omitted, the AuthConfig will be enforced at all requests.
+                  If present, all conditions must match for the AuthConfig to be enforced; otherwise, Authorino skips the AuthConfig and returns to the auth request with status OK.
                 items:
                   oneOf:
                   - properties:
@@ -2330,12 +2460,13 @@ spec:
                       - matches
                       type: string
                     patternRef:
-                      description: Name of a named pattern
+                      description: Reference to a named set of pattern expressions
                       type: string
                     selector:
                       description: |-
-                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                        The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                        Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                        Authorino custom JSON path modifiers are also supported.
                       type: string
                     value:
                       description: |-
@@ -2469,7 +2600,7 @@ spec:
       name: Wristband
       priority: 2
       type: boolean
-    name: v1beta2
+    name: v1beta3
     schema:
       openAPIV3Schema:
         description: AuthConfig is the schema for Authorino's AuthConfig API


### PR DESCRIPTION
# Description
Wtih https://github.com/Kuadrant/authorino/pull/493 being merged, [smoke tests](https://github.com/Kuadrant/authorino/actions/runs/11368728823) are broken since the AuthConfig CRD is installed by Authorino Operator but v1beta3 is missing, preventing authorino from started correctly 