### PR TITLE
RELATED_IMAGE_AUTHORINO env var

### DIFF
--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -83,7 +83,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/authorino-operator:latest
-    createdAt: "2024-10-30T16:22:39Z"
+    createdAt: "2024-11-14T11:17:40Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/authorino-operator
@@ -320,6 +320,9 @@ spec:
                       - --leader-elect
                     command:
                       - /manager
+                    env:
+                      - name: RELATED_IMAGE_AUTHORINO
+                        value: quay.io/kuadrant/authorino:latest
                     image: quay.io/kuadrant/authorino-operator:latest
                     livenessProbe:
                       httpGet:
@@ -422,4 +425,7 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
+  relatedImages:
+    - image: quay.io/kuadrant/authorino:latest
+      name: authorino
   version: 0.0.0

--- a/charts/authorino-operator/templates/manifests.yaml
+++ b/charts/authorino-operator/templates/manifests.yaml
@@ -5897,6 +5897,9 @@ spec:
         - --leader-elect
         command:
         - /manager
+        env:
+        - name: RELATED_IMAGE_AUTHORINO
+          value: quay.io/kuadrant/authorino:latest
         image: quay.io/kuadrant/authorino-operator:latest
         livenessProbe:
           httpGet:

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -5904,6 +5904,9 @@ spec:
         - --leader-elect
         command:
         - /manager
+        env:
+        - name: RELATED_IMAGE_AUTHORINO
+          value: quay.io/kuadrant/authorino:latest
         image: quay.io/kuadrant/authorino-operator:latest
         livenessProbe:
           httpGet:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,6 +20,9 @@ spec:
       containers:
       - command:
         - /manager
+        env:
+        - name: RELATED_IMAGE_AUTHORINO
+          value: quay.io/kuadrant/authorino:latest
         args:
         - --leader-elect
         image: controller:latest

--- a/controllers/authorino_controller.go
+++ b/controllers/authorino_controller.go
@@ -200,7 +200,7 @@ func (r *AuthorinoReconciler) buildAuthorinoDeployment(authorino *api.Authorino)
 
 	if image == "" {
 		// `DefaultAuthorinoImage can be empty string. But image cannot be or deployment will fail
-		image = "quay.io/kuadrant/authorino:latest"
+		panic("DefaultAuthorinoImage is empty")
 	}
 
 	var volumes []k8score.Volume


### PR DESCRIPTION
### What

Authorino image can be read from `RELATED_IMAGE_AUTHORINO` env var. Defaults to `quay.io/kuadrant/authorino:latest`

Required to specify the authorino image from the CSV manifest

The authorino image being used in the deployment is read from different sources with some order of precedence:
1. Authorino CR's `spec.image`
1. `RELATED_IMAGE_AUTHORINO` env var
1. Value set at  the operator  **compilation time** passed as ldflags `-X github.com/kuadrant/authorino-operator/controllers.DefaultAuthorinoImage=VALUE`
1. `quay.io/kuadrant/limitador:latest`
 
### Verification steps

run cluster
```
kind create cluster --name authorino-operator-system
```

install CRDs
```
make install
```

run operator locally with specific `RELATED_IMAGE_AUTHORINO` env var.

```
RELATED_IMAGE_AUTHORINO=quay.io/kuadrant/authorino:v0.18.0 make run
```

Create authorino object without `spec.image` to deploy version from env var.
```yaml
k apply -f - <<EOF
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino
spec:
  listener:
    tls:
      enabled: false
  oidcServer:
    tls:
      enabled: false
EOF
```

Check authorino's version is `quay.io/kuadrant/authorino:v0.18.0`
```sh
$ kubectl get deployments authorino -o jsonpath='{.spec.template.spec.containers[0].image}'
```

The response should be 

```
quay.io/kuadrant/authorino:v0.18.0
```

Clean up

```
kind delete cluster --name authorino-operator-system
```
