### PR TITLE
Helm docs

### DIFF
--- a/charts/authorino-operator/Chart.yaml
+++ b/charts/authorino-operator/Chart.yaml
@@ -19,6 +19,7 @@ kubeVersion: ">=1.19.0-0"
 type: application
 # The version will be properly set when the chart is released matching the operator version
 version: "0.0.0"
+appVersion: "0.0.0"
 maintainers:
   - email: mcassola@redhat.com
     name: Guilherme Cassolato

--- a/charts/authorino-operator/README.md
+++ b/charts/authorino-operator/README.md
@@ -1,0 +1,21 @@
+# Authorino Operator
+
+This is the Helm Chart to install the official Authorino Kubernetes Operator
+
+## Installation
+
+```sh
+helm repo add kuadrant https://kuadrant.io/helm-charts/ --force-update
+helm install \
+ authorino-operator kuadrant/authorino-operator \
+ --create-namespace \
+ --namespace authorino-system
+```
+
+### Parameters
+
+**Coming soon!** At the moment, there's no configuration parameters exposed.
+
+## Usage
+
+Read the documentation and user guides in the [Getting Started guide](https://github.com/Kuadrant/authorino/blob/main/docs/getting-started.md).

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -11,6 +11,7 @@ helm-build: $(YQ) kustomize manifests ## Build the helm chart from kustomize man
 	# Build the helm chart templates from kustomize manifests
 	$(KUSTOMIZE) build config/helm > charts/authorino-operator/templates/manifests.yaml
 	V="$(BUNDLE_VERSION)" $(YQ) -i e '.version = strenv(V)' charts/authorino-operator/Chart.yaml
+	V="$(BUNDLE_VERSION)" $(YQ) -i e '.appVersion = strenv(V)' charts/authorino-operator/Chart.yaml
 	# Roll back edit
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${DEFAULT_OPERATOR_IMAGE}
 	cd config/helm && $(KUSTOMIZE) edit set namespace authorino-operator


### PR DESCRIPTION
* Helm documentation displayed under the chart page in AritfactHub.io. Needed for the `Official` badge.
* appVersion added in order to shown in helm cli

