### PR TITLE
Signing Helm packages

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Package Helm Chart
         run: |
+          GPG_KEYRING_BASE64=${{ secrets.HELM_CHARTS_SIGNING_KEY }} \
+          GPG_KEY_UID="Kuadrant Development Team" \
           make helm-package
 
       - name: Parse Tag

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Package Helm Chart
         run: |
           GPG_KEY_UID="Kuadrant Development Team" \
-          make helm-package
+          make helm-package-sign
 
       - name: Parse Tag
         run: |

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -25,9 +25,14 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
+      - name: Configure GPG Key
+        run: |
+          echo -n "$GPG_SIGNING_KEY" | base64 -d | gpg --import
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.HELM_CHARTS_SIGNING_KEY }}
+
       - name: Package Helm Chart
         run: |
-          GPG_KEYRING_BASE64=${{ secrets.HELM_CHARTS_SIGNING_KEY }} \
           GPG_KEY_UID="Kuadrant Development Team" \
           make helm-package
 

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -47,6 +47,16 @@ jobs:
           tag: ${{ env.OPERATOR_TAG }}
           overwrite: true
 
+      - name: Upload provenance file to GitHub Release
+        uses: svenstaro/upload-release-action@v2
+        id: upload-prov-file
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: authorino-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
+          asset_name: chart-authorino-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
+          tag: ${{ env.OPERATOR_TAG }}
+          overwrite: true
+
       - name: Sync Helm Chart with repository
         run: |
           make helm-sync-package-created \

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ tmp
 # Catalogs
 /catalog/authorino-operator-catalog
 /catalog/authorino-operator-catalog.Dockerfile
+
+# Helm chart packages
+*operator*.tgz*

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -37,10 +37,18 @@ helm-upgrade: $(HELM) ## Upgrade the helm chart
 	# Upgrade the helm chart in the cluster
 	$(HELM) upgrade $(CHART_NAME) $(CHART_DIRECTORY)
 
+# GPG_KEY_UID: substring of the desired key's uid, the name or email
+GPG_KEY_UID ?= 'Kuadrant Development Team'
+# GPG_KEYRING_BASE64: the gpg keyring base64 encoded
+GPG_KEYRING_BASE64 ?= <KUADRANT_GPG_KEYRING_BASE64>
+
 .PHONY: helm-package
-helm-package: $(HELM) ## Package the helm chart
+helm-package: $(HELM) ## Package the helm chart and GPG sign it
+	# Store the key
+	mkdir -p .gpg
+	echo $(GPG_KEYRING_BASE64) | base64 -d > .gpg/kuadrantsecring.gpg  #storing base64 GPG key into keyring
 	# Package the helm chart
-	$(HELM) package $(CHART_DIRECTORY)
+	$(HELM) package --sign --key $(GPG_KEY_UID) --keyring .gpg/kuadrantsecring.gpg $(CHART_DIRECTORY)
 
 # GitHub Token with permissions to upload to the release assets
 HELM_WORKFLOWS_TOKEN ?= <YOUR-TOKEN>

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -1,5 +1,10 @@
 ##@ Helm Charts
 
+# Chart name
+CHART_NAME ?= authorino-operator
+# Chart directory
+CHART_DIRECTORY ?= charts/$(CHART_NAME)
+
 .PHONY: helm-build
 helm-build: $(YQ) kustomize manifests ## Build the helm chart from kustomize manifests
 	# Set desired authorino image
@@ -9,33 +14,33 @@ helm-build: $(YQ) kustomize manifests ## Build the helm chart from kustomize man
 	cd config/authorino/webhook && $(KUSTOMIZE) edit set namespace "{{ .Release.Namespace }}"
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(OPERATOR_IMAGE)
 	# Build the helm chart templates from kustomize manifests
-	$(KUSTOMIZE) build config/helm > charts/authorino-operator/templates/manifests.yaml
-	V="$(BUNDLE_VERSION)" $(YQ) -i e '.version = strenv(V)' charts/authorino-operator/Chart.yaml
-	V="$(BUNDLE_VERSION)" $(YQ) -i e '.appVersion = strenv(V)' charts/authorino-operator/Chart.yaml
+	$(KUSTOMIZE) build config/helm > $(CHART_DIRECTORY)/templates/manifests.yaml
+	V="$(BUNDLE_VERSION)" $(YQ) -i e '.version = strenv(V)' $(CHART_DIRECTORY)/Chart.yaml
+	V="$(BUNDLE_VERSION)" $(YQ) -i e '.appVersion = strenv(V)' $(CHART_DIRECTORY)/Chart.yaml
 	# Roll back edit
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${DEFAULT_OPERATOR_IMAGE}
-	cd config/helm && $(KUSTOMIZE) edit set namespace authorino-operator
-	cd config/authorino/webhook && $(KUSTOMIZE) edit set namespace authorino-operator
+	cd config/helm && $(KUSTOMIZE) edit set namespace $(CHART_NAME)
+	cd config/authorino/webhook && $(KUSTOMIZE) edit set namespace $(CHART_NAME)
 
 .PHONY: helm-install
 helm-install: $(HELM) ## Install the helm chart
 	# Install the helm chart in the cluster
-	$(HELM) install $(REPO) charts/$(REPO)
+	$(HELM) install $(CHART_NAME) $(CHART_DIRECTORY)
 
 .PHONY: helm-uninstall
 helm-uninstall: $(HELM) ## Uninstall the helm chart
 	# Uninstall the helm chart from the cluster
-	$(HELM) uninstall $(REPO)
+	$(HELM) uninstall $(CHART_NAME)
 
 .PHONY: helm-upgrade
 helm-upgrade: $(HELM) ## Upgrade the helm chart
 	# Upgrade the helm chart in the cluster
-	$(HELM) upgrade $(REPO) charts/$(REPO)
+	$(HELM) upgrade $(CHART_NAME) $(CHART_DIRECTORY)
 
 .PHONY: helm-package
 helm-package: $(HELM) ## Package the helm chart
 	# Package the helm chart
-	$(HELM) package charts/$(REPO)
+	$(HELM) package $(CHART_DIRECTORY)
 
 # GitHub Token with permissions to upload to the release assets
 HELM_WORKFLOWS_TOKEN ?= <YOUR-TOKEN>
@@ -54,7 +59,7 @@ helm-sync-package-created: ## Sync the helm chart package to the helm-charts rep
 	  -H "Authorization: Bearer $(HELM_WORKFLOWS_TOKEN)" \
 	  -H "X-GitHub-Api-Version: 2022-11-28" \
 	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
-	  -d '{"event_type":"chart-created","client_payload":{"chart":"$(REPO)","version":"$(CHART_VERSION)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'
+	  -d '{"event_type":"chart-created","client_payload":{"chart":"$(CHART_NAME)","version":"$(CHART_VERSION)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'
 
 .PHONY: helm-sync-package-deleted
 helm-sync-package-deleted: ## Sync the deleted helm chart package to the helm-charts repo
@@ -64,4 +69,4 @@ helm-sync-package-deleted: ## Sync the deleted helm chart package to the helm-ch
 	  -H "Authorization: Bearer $(HELM_WORKFLOWS_TOKEN)" \
 	  -H "X-GitHub-Api-Version: 2022-11-28" \
 	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
-	  -d '{"event_type":"chart-deleted","client_payload":{"chart":"$(REPO)","version":"$(CHART_VERSION)"}}'
+	  -d '{"event_type":"chart-deleted","client_payload":{"chart":"$(CHART_NAME)","version":"$(CHART_VERSION)"}}'

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -37,18 +37,18 @@ helm-upgrade: $(HELM) ## Upgrade the helm chart
 	# Upgrade the helm chart in the cluster
 	$(HELM) upgrade $(CHART_NAME) $(CHART_DIRECTORY)
 
+.PHONY: helm-package
+helm-package: $(HELM) ## Package the helm chart
+	# Package the helm chart
+	$(HELM) package $(CHART_DIRECTORY)
+
 # GPG_KEY_UID: substring of the desired key's uid, the name or email
 GPG_KEY_UID ?= 'Kuadrant Development Team'
-# GPG_KEYRING_BASE64: the gpg keyring base64 encoded
-GPG_KEYRING_BASE64 ?= <KUADRANT_GPG_KEYRING_BASE64>
-
-.PHONY: helm-package
-helm-package: $(HELM) ## Package the helm chart and GPG sign it
-	# Store the key
-	mkdir -p .gpg
-	echo $(GPG_KEYRING_BASE64) | base64 -d > .gpg/kuadrantsecring.gpg  #storing base64 GPG key into keyring
-	# Package the helm chart
-	$(HELM) package --sign --key $(GPG_KEY_UID) --keyring .gpg/kuadrantsecring.gpg $(CHART_DIRECTORY)
+# The keyring should've been imported before running this target
+.PHONY: helm-package-sign
+helm-package-sign: $(HELM) ## Package the helm chart and GPG sign it
+	# Package the helm chart and sign it
+	$(HELM) package --sign --key $(GPG_KEY_UID) $(CHART_DIRECTORY)
 
 # GitHub Token with permissions to upload to the release assets
 HELM_WORKFLOWS_TOKEN ?= <YOUR-TOKEN>


### PR DESCRIPTION
Part of the work needed for https://github.com/Kuadrant/helm-charts/issues/18

This PR introduces the GPG signing of Helm chart packages upon creation. It also uploads its provenance file to the GH release page.

The job now requires to be passed an environment variable GPG_KEYRING_BASE64 which represents the GPG keyring base64 encoded, in order to be stored as a GH action variable.