### PR TITLE
 [ArtifactHub.io] GPG public key annotation added

### DIFF
--- a/charts/authorino-operator/Chart.yaml
+++ b/charts/authorino-operator/Chart.yaml
@@ -78,3 +78,6 @@ annotations:
       url: https://github.com/Kuadrant/authorino-operator
   artifacthub.io/operator: "true"
   artifacthub.io/operatorCapabilities: Basic Install
+  artifacthub.io/signKey: |
+    fingerprint: 8A2150B44E1994E1E91ED9E5E19171BE516B79C7
+    url: https://kuadrant.io/helm-charts/kuadrant-public-key.asc


### PR DESCRIPTION
Part of the work needed for https://github.com/Kuadrant/helm-charts/issues/18

This PR adds a new annotation in the Helm Chart.yaml meant for displaying the public key used for signing its chart packages. More info in https://artifacthub.io/docs/topics/annotations/helm/