### PR TITLE
fix(labels): do not remove user added labels from Deployment's spec.template

### DIFF
--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -89,6 +89,7 @@ const (
 	statusTlsSecretNotProvided                    = "TlsSecretNotProvided"
 	statusUnableToUpdateDeployment                = "UnableToUpdateDeployment"
 	statusDeploymentNotReady                      = "DeploymentNotReady"
+	statusUnableToBuildDeploymentObject           = "UnableToBuildDeploymentObject"
 )
 
 // ldflags

--- a/pkg/resources/k8s_deployment.go
+++ b/pkg/resources/k8s_deployment.go
@@ -8,18 +8,17 @@ import (
 
 func GetDeployment(name, namespace, saName string, replicas *int32, containers []k8score.Container, vol []k8score.Volume, labels map[string]string) *k8sapps.Deployment {
 	objMeta := getObjectMeta(namespace, name, labels)
-	authorinoLabels := labelsForAuthorino(name)
 
 	return &k8sapps.Deployment{
 		ObjectMeta: objMeta,
 		Spec: k8sapps.DeploymentSpec{
 			Replicas: replicas,
 			Selector: &v1.LabelSelector{
-				MatchLabels: authorinoLabels,
+				MatchLabels: defaultAuthorinoLabels(name),
 			},
 			Template: k8score.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels: authorinoLabels,
+					Labels: defaultAuthorinoLabels(name),
 				},
 				Spec: k8score.PodSpec{
 					ServiceAccountName: saName,
@@ -74,4 +73,13 @@ func GetTlsVolume(certName, secretName string) k8score.Volume {
 			},
 		},
 	}
+}
+
+func MapUpdateNeeded(existing map[string]string, desired map[string]string) bool {
+	for k, v := range desired {
+		if existingVal, exists := (existing)[k]; !exists || v != existingVal {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/resources/k8s_services.go
+++ b/pkg/resources/k8s_services.go
@@ -57,7 +57,7 @@ func newService(serviceName, serviceNamespace, authorinoName string, labels map[
 	objMeta := getObjectMeta(serviceNamespace, authorinoName+"-"+serviceName, labels)
 	return &k8score.Service{
 		ObjectMeta: objMeta,
-		Spec:       newServiceSpec(labelsForAuthorino(authorinoName), servicePorts...),
+		Spec:       newServiceSpec(defaultAuthorinoLabels(authorinoName), servicePorts...),
 	}
 }
 

--- a/pkg/resources/k8s_util.go
+++ b/pkg/resources/k8s_util.go
@@ -10,7 +10,7 @@ func getObjectMeta(namespace, name string, labels map[string]string) v1.ObjectMe
 	return v1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels}
 }
 
-func labelsForAuthorino(name string) map[string]string {
+func defaultAuthorinoLabels(name string) map[string]string {
 	return map[string]string{
 		"control-plane":      "controller-manager",
 		"authorino-resource": name,


### PR DESCRIPTION
PR #91 brought the ability to propagate labels defined for Authorino CR down to Deployment. However, more often than not, it's more desired to have those labels propagated to template and therefore pods which are part of the deployment. This can simplify e.g. making Authorino part of service mesh, as injection label can be consistently added to relevant resources.

~When creating the deployment, instead of having fixed set of labels for Deployment's `spec.template` and objectmeta.lables this change appends Authorino CR labels as well.~

EDIT:  This change will now allow the ability to add a label via your chosen mechanism to the deployment.spec.template.labels without being overwritten by the operator. 

As per discussion at https://groups.google.com/a/redhat.com/g/kuadrant-dev/c/rbsY4kDaSnE

Closes https://github.com/Kuadrant/authorino-operator/issues/239
Replaces https://github.com/Kuadrant/authorino-operator/pull/236