### PR TITLE
Upgrade Go version to 1.22

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -90,10 +90,10 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') # We cannot use `env.MAIN_BRANCH_NAME` because `env` context is not available to `job.if`. See https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v3
@@ -164,10 +164,10 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') # We cannot use `env.MAIN_BRANCH_NAME` because `env` context is not available to `job.if`. See https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,10 +31,10 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gettext-base
-    - name: Set up Go 1.21.x
+    - name: Set up Go 1.22.x
       uses: actions/setup-go@v4
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
       id: go
     - name: Checkout code at git ref
       uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,10 +12,10 @@ jobs:
     name: Verify manifests
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v3
@@ -27,10 +27,10 @@ jobs:
     name: Verify bundle
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v3
@@ -42,10 +42,10 @@ jobs:
     name: Verify fmt
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v3
@@ -57,7 +57,7 @@ jobs:
     name: Test Scripts
     strategy:
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.22.x]
         platform: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.platform }}
     defaults:
@@ -79,7 +79,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.22.x]
         platform: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.platform }}
     defaults:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build the authorino binary
 # https://catalog.redhat.com/software/containers/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22 AS builder
 USER root
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino-operator
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.2.4
@@ -12,6 +12,7 @@ require (
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3
 	k8s.io/klog/v2 v2.100.1
+	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
 	sigs.k8s.io/controller-runtime v0.16.3
 )
 
@@ -67,7 +68,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.28.3 // indirect
 	k8s.io/component-base v0.28.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
-	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect


### PR DESCRIPTION
This also fixes [CVE-2025-22866](https://access.redhat.com/security/cve/CVE-2025-22866) (ppc64le arch)