### PR TITLE
Explicitly state Z stream go version in go.mod, version set to 1.22.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino-operator
 
-go 1.22
+go 1.22.5
 
 require (
 	github.com/go-logr/logr v1.2.4


### PR DESCRIPTION
This is to prevent compatibility issues with different go toolchain versions, similar to [kuadrant-operator](https://github.com/Kuadrant/kuadrant-operator/blob/main/go.mod)

Since Go 1.21 one can supply a toolchain version string for the minimum required version of Go in their go.mod file (e.g. go 1.21.4). While the old style "language" version string form continues to work in the Golang ecosystem, in context of Go 1.21+, reproducible builds and platform support, it is advised to use a toolchain version string instead of the language family version string. From practical point of view it makes no difference whether you declare your requirement as go 1.21 or go 1.21.0 in the go.mod file because in both cases any Go 1.21+ family toolchain will be able to build your project successfully. However, the former makes it impossible for post-1.21 toolchains to automatically download a toolchain from e.g. 1.22 language family (via the means of the GOTOOLCHAIN variable), because "1.22" as a string literal doesn't denote a toolchain (while 1.22.0 does).

Alternatively, we can specify a toolchain version separately like so:
`go 1.22`
`toolchain go1.22.N`