### PR TITLE
bump to golang 1.22.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino-operator
 
-go 1.21
+go 1.22.12
 
 require (
 	github.com/go-logr/logr v1.2.4


### PR DESCRIPTION
Signed-off-by: craig <cbrookes@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED