### PR TITLE
🔨 Fix pod template labels mutator 🔨

### DIFF
--- a/pkg/reconcilers/deployment_mutator.go
+++ b/pkg/reconcilers/deployment_mutator.go
@@ -136,19 +136,7 @@ func DeploymentLabelsMutator(desired, existing *k8sapps.Deployment) bool {
 }
 
 func DeploymentSpecTemplateLabelsMutator(desired, existing *k8sapps.Deployment) bool {
-	update := false
-
-	if !reflect.DeepEqual(existing.Spec.Template.Labels, desired.Spec.Template.Labels) {
-		// merge existing key/value pairs back into the desiredDeployment Spec Template Labels so as not to overwrite those.
-		for existingKey, existingValue := range existing.Spec.Template.Labels {
-			desired.Spec.Template.Labels[existingKey] = existingValue
-		}
-		existing.Spec.Template.Labels = desired.Spec.Template.Labels
-
-		update = true
-	}
-
-	return update
+	return authorinoResources.MergeMapStringString(&existing.Spec.Template.Labels, desired.Spec.Template.Labels)
 }
 
 func IsObjectTaggedToDelete(obj client.Object) bool {

--- a/pkg/reconcilers/deployment_mutator_test.go
+++ b/pkg/reconcilers/deployment_mutator_test.go
@@ -272,6 +272,28 @@ func TestDeploymentMutatorFunctions(t *testing.T) {
 			want: false,
 		},
 		{
+			name:    "SpecTemplateLabelsMutator - existing has few extra",
+			mutator: DeploymentSpecTemplateLabelsMutator,
+			desired: func() *appsv1.Deployment {
+				d := deployment.DeepCopy()
+				d.Spec.Template.Labels = map[string]string{
+					"foo":  "bar",
+					"foo2": "bar2",
+				}
+				return d
+			}(),
+			existing: func() *appsv1.Deployment {
+				d := deployment.DeepCopy()
+				d.Spec.Template.Labels = map[string]string{
+					"foo":       "bar",
+					"foo2":      "bar2",
+					"new-label": "new-value",
+				}
+				return d
+			}(),
+			want: false,
+		},
+		{
 			name:    "SpecTemplateLabelsMutator - change with merge",
 			mutator: DeploymentSpecTemplateLabelsMutator,
 			desired: func() *appsv1.Deployment {
@@ -293,8 +315,11 @@ func TestDeploymentMutatorFunctions(t *testing.T) {
 			want: true,
 			verify: func(t *testing.T, existing *appsv1.Deployment) {
 				labels := existing.Spec.Template.Labels
-				if labels["app"] != "authorino-pod" {
-					t.Errorf("expected app label not to be updated, got %s", labels["app"])
+				if len(labels) != 3 {
+					t.Errorf("expected num label to be 3, got %d", len(labels))
+				}
+				if labels["app"] != "authorino-pod-new" {
+					t.Errorf("expected app label to be updated, got %s", labels["app"])
 				}
 				if labels["new"] != "pod-label" {
 					t.Error("expected new label to be added")

--- a/pkg/resources/map_utils.go
+++ b/pkg/resources/map_utils.go
@@ -1,0 +1,22 @@
+package resources
+
+func MergeMapStringString(existing *map[string]string, desired map[string]string) bool {
+	if existing == nil {
+		return false
+	}
+	if *existing == nil {
+		*existing = map[string]string{}
+	}
+
+	// for each desired key value set, e.g. labels
+	// check if it's present in existing. if not add it to existing.
+	// e.g. preserving existing labels while adding those that are in the desired set.
+	modified := false
+	for desiredKey, desiredValue := range desired {
+		if existingValue, exists := (*existing)[desiredKey]; !exists || existingValue != desiredValue {
+			(*existing)[desiredKey] = desiredValue
+			modified = true
+		}
+	}
+	return modified
+}

--- a/pkg/resources/map_utils.go
+++ b/pkg/resources/map_utils.go
@@ -1,5 +1,17 @@
 package resources
 
+// MergeMapStringString merges key-value pairs from the desired map into the existing map.
+//
+// If a key in the desired map is not present in the existing map, or if its value differs,
+// the key-value pair is added or updated in the existing map. The function ensures that
+// the existing map is initialized if it is nil.
+//
+// The entries included in "existing" map that are not included in the "desired" map are preserved.
+//
+// It returns true if the existing map was modified (i.e., at least one key-value pair was added or updated),
+// and false otherwise.
+//
+// The existing map is passed as a pointer to allow modification in-place.
 func MergeMapStringString(existing *map[string]string, desired map[string]string) bool {
 	if existing == nil {
 		return false

--- a/pkg/resources/map_utils_test.go
+++ b/pkg/resources/map_utils_test.go
@@ -1,0 +1,97 @@
+package resources
+
+import "testing"
+
+func TestMergeMapStringString(t *testing.T) {
+	m := make(map[string]string)
+	var nilMap map[string]string
+
+	type args struct {
+		existing *map[string]string
+		desired  map[string]string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantUpdate bool
+	}{
+		{
+			name: "nil pointer to map",
+			args: args{
+				existing: nil,
+				desired: map[string]string{
+					"foo": "bar",
+					"qux": "quux",
+				},
+			},
+			wantUpdate: false,
+		},
+		{
+			name: "nil map",
+			args: args{
+				existing: &nilMap,
+				desired: map[string]string{
+					"foo": "bar",
+					"qux": "quux",
+				},
+			},
+			wantUpdate: true,
+		},
+		{
+			name: "empty map",
+			args: args{
+				existing: &m,
+				desired: map[string]string{
+					"foo": "bar",
+					"qux": "quux",
+				},
+			},
+			wantUpdate: true,
+		},
+		{
+			name: "desired keys not in existing",
+			args: args{
+				existing: &map[string]string{
+					"foo": "bar",
+				},
+				desired: map[string]string{
+					"qux": "quux",
+				},
+			},
+			wantUpdate: true,
+		},
+		{
+			name: "same maps",
+			args: args{
+				existing: &map[string]string{
+					"foo": "bar",
+					"qux": "quux",
+				},
+				desired: map[string]string{
+					"foo": "bar",
+					"qux": "quux",
+				},
+			},
+			wantUpdate: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(subT *testing.T) {
+			got := MergeMapStringString(tt.args.existing, tt.args.desired)
+			if got != tt.wantUpdate {
+				subT.Errorf("MergeMapStringString() got = %v, wantUpdate %v", got, tt.wantUpdate)
+			}
+
+			if tt.args.existing == nil {
+				return
+			}
+
+			for desiredKey, desiredValue := range tt.args.desired {
+				existingVal, ok := (*tt.args.existing)[desiredKey]
+				if !ok || existingVal != desiredValue {
+					t.Errorf("MergeMapStringString() the key does not match:  %v", desiredKey)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What

When the existing deployment template label has few extra labels, the pod template label mutator was returning `true` to update the resource even when there was no update to be done. The extra few labels are preserved by the mutator.  That apparently little issue of reporting "update" when it should not had secondary effects.  The status controller would never set the status as Ready because it is being told that there is an update still going on. 

### Verifications steps

* Checkout this branch

* Run cluster
```
kind create cluster --name authorino-operator-system
```

* Install CRDs
```
make install
```

* Run operator locally 

```
make run
```

* Create authorino object.
```yaml
k apply -f - <<EOF
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino
spec:
  listener:
    tls:
      enabled: false
  oidcServer:
    tls:
      enabled: false
EOF
```

* Wait for authorino instance to be ready
```shell
kubectl wait --timeout=300s --for=condition=Ready authorino authorino
```

* Add manually few extra pod template labels
```shell
kubectl patch deployment authorino --type=merge --patch '{"spec": {"template": {"metadata": {"labels": {"foo": "bar", "foo2": "bar2"}}}}}'
```
* Wait for authorino instance to be ready
```shell
kubectl wait --timeout=300s --for=condition=Ready authorino authorino
```

If authorino CR gets the `Ready` condition in status, the fix worked. If trying out the same verification steps with current HEAD of `main`, the authorino status looks like this:
```yaml
❯ k get authorino authorino -o jsonpath="{.status}" | yq e -P
conditions:
  - lastTransitionTime: "2025-04-14T17:19:18Z"
    message: Authorino Deployment resource updated
    reason: Updated
    status: "False"
    type: Ready
```