### PR TITLE
ubuntu 20.04 runner has been removed from github actions

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -28,7 +28,7 @@ env:
 jobs:
   build:
     name: Build and push image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -87,7 +87,7 @@ jobs:
   build-bundle:
     needs: build
     name: Build and push bundle image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') # We cannot use `env.MAIN_BRANCH_NAME` because `env` context is not available to `job.if`. See https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     steps:
       - name: Set up Go 1.22.x
@@ -161,7 +161,7 @@ jobs:
   build-catalog:
     name: Build and push catalog image
     needs: [build, build-bundle]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') # We cannot use `env.MAIN_BRANCH_NAME` because `env` context is not available to `job.if`. See https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     steps:
       - name: Set up Go 1.22.x

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   build:
     name: Release operator
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Install gettext-base
       run: |


### PR DESCRIPTION
### What

Move GH workflows runners to `ubuntu-latest`

From GH actions:
```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```