### PR TITLE
fix: use DefaultOidcTlsCertPath

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -46,6 +46,8 @@ var testEnv *envtest.Environment
 var cancel context.CancelFunc
 var ctx = context.Background()
 
+const testCertSecretName = "bkabk"
+
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
@@ -124,7 +126,7 @@ func getAuthorinoClusterRole(clusterRoleName string) *k8srbac.ClusterRole {
 func newCertSecret() *k8score.Secret {
 	return &k8score.Secret{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "bkabk",
+			Name:      testCertSecretName,
 			Namespace: testAuthorinoNamespace,
 		},
 	}

--- a/pkg/reconcilers/deployment_mutator.go
+++ b/pkg/reconcilers/deployment_mutator.go
@@ -301,7 +301,7 @@ func AuthorinoDeployment(authorino *api.Authorino) *k8sapps.Deployment {
 	// mount tls cert volume for the oidc listener if enabled
 	if enabled := authorino.Spec.OIDCServer.Tls.Enabled; enabled == nil || *enabled {
 		secretName := authorino.Spec.OIDCServer.Tls.CertSecret.Name
-		volumeMounts = append(volumeMounts, authorinoResources.GetTlsVolumeMount(AuthorinoOidcTlsCertVolumeName, DefaultTlsCertPath, DefaultOidcTlsCertKeyPath)...)
+		volumeMounts = append(volumeMounts, authorinoResources.GetTlsVolumeMount(AuthorinoOidcTlsCertVolumeName, DefaultOidcTlsCertPath, DefaultOidcTlsCertKeyPath)...)
 		volumes = append(volumes, authorinoResources.GetTlsVolume(AuthorinoOidcTlsCertVolumeName, secretName))
 	}
 


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/authorino-operator/issues/262

- Fixes deployment creation error when both listener and oidc tls is enabled. This was caused by `DefaultTlsCertPath` being instead of `DefaultOidcTlsCertPath` for oidc causing a mount path duplication
- Updated and added integration test to deployment is created successully for tls enabled permutations