### PR TITLE
gha: use go version from go.mod

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Add latest tag
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
         id: add-latest-tag
@@ -90,13 +90,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') # We cannot use `env.MAIN_BRANCH_NAME` because `env` context is not available to `job.if`. See https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     steps:
-      - name: Set up Go 1.23.x
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.23.x
+          go-version-file: go.mod
         id: go
-      - name: Check out code
-        uses: actions/checkout@v3
       - name: Add latest tag
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
         id: add-latest-tag
@@ -160,17 +160,17 @@ jobs:
 
   build-catalog:
     name: Build and push catalog image
-    needs: [build, build-bundle]
+    needs: [ build, build-bundle ]
     runs-on: ubuntu-latest
     if: github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') # We cannot use `env.MAIN_BRANCH_NAME` because `env` context is not available to `job.if`. See https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     steps:
-      - name: Set up Go 1.23.x
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.23.x
+          go-version-file: go.mod
         id: go
-      - name: Check out code
-        uses: actions/checkout@v3
       - name: Add latest tag
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
         id: add-latest-tag

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,42 +27,42 @@ jobs:
     name: Release operator
     runs-on: ubuntu-latest
     steps:
-    - name: Install gettext-base
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y gettext-base
-    - name: Set up Go 1.23.x
-      uses: actions/setup-go@v4
-      with:
-        go-version: 1.23.x
-      id: go
-    - name: Checkout code at git ref
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.inputs.gitRef }}
-    - name: Create release branch
-      if: ${{ !startsWith(github.event.inputs.gitRef, 'release-v') }}
-      run: |
-        git checkout -b release-v${{ github.event.inputs.operatorVersion }}
-    - name: Prepare release
-      run: |
-        VERSION=${{ github.event.inputs.operatorVersion }} \
-        AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }} \
-        CHANNELS=${{ github.event.inputs.channels }} \
-        DEFAULT_CHANNEL=stable \
-        make prepare-release
-    - name: Commit and push
-      run: |
-        git config --global user.name "github-actions[bot]"
-        git config --global user.email "github-actions[bot]@users.noreply.github.com"
-        git add -A && git commit -m "Prepared release v${{ github.event.inputs.operatorVersion }}"
-        git push origin release-v${{ github.event.inputs.operatorVersion }}
-    - name: Create release
-      uses: softprops/action-gh-release@v1
-      with:
-        name: v${{ github.event.inputs.operatorVersion }}
-        tag_name: v${{ github.event.inputs.operatorVersion }}
-        body: "**This release enables installations of Authorino v${{ github.event.inputs.authorinoVersion }}**"
-        generate_release_notes: true
-        target_commitish: release-v${{ github.event.inputs.operatorVersion }}
-        prerelease: ${{ github.event.inputs.prerelease }}
+      - name: Install gettext-base
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gettext-base
+      - name: Checkout code at git ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.gitRef }}
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+        id: go
+      - name: Create release branch
+        if: ${{ !startsWith(github.event.inputs.gitRef, 'release-v') }}
+        run: |
+          git checkout -b release-v${{ github.event.inputs.operatorVersion }}
+      - name: Prepare release
+        run: |
+          VERSION=${{ github.event.inputs.operatorVersion }} \
+          AUTHORINO_VERSION=${{ github.event.inputs.authorinoVersion }} \
+          CHANNELS=${{ github.event.inputs.channels }} \
+          DEFAULT_CHANNEL=stable \
+          make prepare-release
+      - name: Commit and push
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A && git commit -m "Prepared release v${{ github.event.inputs.operatorVersion }}"
+          git push origin release-v${{ github.event.inputs.operatorVersion }}
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: v${{ github.event.inputs.operatorVersion }}
+          tag_name: v${{ github.event.inputs.operatorVersion }}
+          body: "**This release enables installations of Authorino v${{ github.event.inputs.authorinoVersion }}**"
+          generate_release_notes: true
+          target_commitish: release-v${{ github.event.inputs.operatorVersion }}
+          prerelease: ${{ github.event.inputs.prerelease }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,20 +8,20 @@ on:
     branches: [ 'main', 'master' ]
 
   merge_group:
-    types: [checks_requested]
+    types: [ checks_requested ]
 
 jobs:
   verify-manifests:
     name: Verify manifests
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.23.x
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.23.x
+          go-version-file: go.mod
         id: go
-      - name: Check out code
-        uses: actions/checkout@v3
       - name: Run make verify-manifests
         run: |
           make verify-manifests
@@ -30,13 +30,13 @@ jobs:
     name: Verify bundle
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.23.x
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.23.x
+          go-version-file: go.mod
         id: go
-      - name: Check out code
-        uses: actions/checkout@v3
       - name: Verify the bundle
         run: |
           make verify-bundle
@@ -45,13 +45,13 @@ jobs:
     name: Verify fmt
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.23.x
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.23.x
+          go-version-file: go.mod
         id: go
-      - name: Check out code
-        uses: actions/checkout@v3
       - name: Run make verify-fmt
         run: |
           make verify-fmt
@@ -60,20 +60,19 @@ jobs:
     name: Test Scripts
     strategy:
       matrix:
-        go-version: [1.23.x]
         platform: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.platform }}
     defaults:
       run:
         shell: bash
     steps:
-      - name: Set up Go ${{ matrix.go-version }}
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
         id: go
-      - name: Check out code
-        uses: actions/checkout@v3
       - name: Run make operator-sdk
         run: |
           make operator-sdk
@@ -82,20 +81,19 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: [1.23.x]
         platform: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.platform }}
     defaults:
       run:
         shell: bash
     steps:
-      - name: Set up Go ${{ matrix.go-version }}
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
         id: go
-      - name: Check out code
-        uses: actions/checkout@v3
       - name: Run make test
         run: |
           make test


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/authorino-operator/issues/265

Uses go version from `go.mod` where possible

# Verification
- Passing github actions 