### PR TITLE
Add default labels to service metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ test: manifests generate fmt vet setup-envtest ## Run the tests.
 
 build: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 build: DIRTY=$(shell $(PROJECT_DIR)/utils/check-git-dirty.sh || echo "unknown")
-build: generate fmt vet ## Build manager binary.
+build: generate fmt vet $(YQ) ## Build manager binary.
 	go build -ldflags "-X main.version=$(VERSION) -X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY} -X github.com/kuadrant/authorino-operator/pkg/reconcilers.DefaultAuthorinoImage=$(ACTUAL_DEFAULT_AUTHORINO_IMAGE)" -o bin/manager main.go
 
 run: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")

--- a/pkg/resources/k8s_services.go
+++ b/pkg/resources/k8s_services.go
@@ -32,7 +32,14 @@ func NewMetricsService(authorinoName, serviceNamespace string, port int32, label
 	if port != 0 {
 		ports = append(ports, newServicePort("http", port))
 	}
-	return newService("controller-metrics", serviceNamespace, authorinoName, labels, ports...)
+
+	metricLabels := CopyMap(labels)
+	MergeMapStringString(&metricLabels, defaultAuthorinoLabels(authorinoName))
+	metricLabels["app.kubernetes.io/component"] = "metrics"
+	metricLabels["app.kubernetes.io/part-of"] = "authorino"
+	metricLabels["app.kubernetes.io/managed-by"] = "authorino-operator"
+
+	return newService("controller-metrics", serviceNamespace, authorinoName, metricLabels, ports...)
 }
 
 func EqualServices(s1, s2 *k8score.Service) bool {

--- a/pkg/resources/map_utils.go
+++ b/pkg/resources/map_utils.go
@@ -32,3 +32,16 @@ func MergeMapStringString(existing *map[string]string, desired map[string]string
 	}
 	return modified
 }
+
+func CopyMap[M ~map[K]V, K comparable, V any](m M) map[K]V {
+	if m == nil {
+		return nil
+	}
+
+	c := make(map[K]V, len(m))
+	for k, v := range m {
+		c[k] = v
+	}
+
+	return c
+}

--- a/pkg/resources/map_utils_test.go
+++ b/pkg/resources/map_utils_test.go
@@ -1,6 +1,9 @@
 package resources
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestMergeMapStringString(t *testing.T) {
 	m := make(map[string]string)
@@ -94,4 +97,49 @@ func TestMergeMapStringString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCopyMap(t *testing.T) {
+	// Test Case 1: A standard, non-empty map
+	t.Run("copy non-empty map", func(t *testing.T) {
+		original := map[string]string{
+			"hello": "world",
+			"go":    "lang",
+		}
+		copied := CopyMap(original)
+
+		// 1. Check if the copy is deeply equal to the original.
+		if !reflect.DeepEqual(original, copied) {
+			t.Errorf("Copied map is not equal to the original. Got %v, want %v", copied, original)
+		}
+
+		// 2. Check for independence: modifying the original should not affect the copy.
+		original["new_key"] = "new_value"
+		if _, exists := copied["new_key"]; exists {
+			t.Error("Copied map was modified when the original was changed.")
+		}
+	})
+
+	// Test Case 2: An empty map
+	t.Run("copy empty map", func(t *testing.T) {
+		original := map[string]string{}
+		copied := CopyMap(original)
+
+		if copied == nil {
+			t.Error("Copying an empty map should not result in a nil map.")
+		}
+		if len(copied) != 0 {
+			t.Errorf("Copied map of an empty map should be empty. Got length %d", len(copied))
+		}
+	})
+
+	// Test Case 3: A nil map
+	t.Run("copy nil map", func(t *testing.T) {
+		var original map[string]string = nil
+		copied := CopyMap(original)
+
+		if copied != nil {
+			t.Errorf("Copying a nil map should result in a nil map. Got %v", copied)
+		}
+	})
 }


### PR DESCRIPTION
### What

Metrics service only gets those labels propagated from the Authorino resource. A service monitor resource uses a label selector to reference monitored serves. Those propagated labels could be used for the label selector. The issue is that other authorino services, like OIDC, also get those propagated labels, so the service monitor is picking more services than needed. Only metrics service is needed. 

This PR adds some custom, default labels only to the metrics service to be used by the service monitor. 

### Verifications steps

* Checkout this branch

* Run cluster
```
make kind-create-cluster
```

* Install CRDs and other resources (cluster roles, ...)
```
make install
```

* Run operator locally 

```
make run
```

* Create authorino object.
```yaml
kubectl apply -f - <<EOF
apiVersion: operator.authorino.kuadrant.io/v1beta1
kind: Authorino
metadata:
  name: authorino
spec:
  clusterWide: true
  listener:
    tls:
      enabled: false
  oidcServer:
    tls:
      enabled: false
EOF
```

* Check metrics service labels
```shell
kubectl get service authorino-controller-metrics -o jsonpath='{.metadata.labels}' | yq e -P
```
Expected result is:
```
app.kubernetes.io/component: metrics
app.kubernetes.io/managed-by: authorino-operator
app.kubernetes.io/part-of: authorino
authorino-resource: authorino
control-plane: controller-manager
```

* clean up
```
make kind-delete-cluster
```