### PR TITLE
fix: trigger release-helm-chart also on push tags

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -6,6 +6,9 @@ on:
   release:
     types:
       - published
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       operatorTag:


### PR DESCRIPTION
closes #235
The workflow previously only ran on release.published, which failed for automated releases.
Added push: tags: v* so the Helm chart workflow always runs when a new version tag is created.