### PR TITLE
fixup: disable pprof server on opm

### DIFF
--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -10,6 +10,8 @@ OPM_DOCKERFILE_TAG ?= latest
 $(CATALOG_DOCKERFILE): $(OPM)
 	-mkdir -p $(PROJECT_DIR)/catalog/authorino-operator-catalog
 	cd $(PROJECT_DIR)/catalog && $(OPM) generate dockerfile authorino-operator-catalog -b "quay.io/operator-framework/opm:${OPM_DOCKERFILE_TAG}" -i "quay.io/operator-framework/opm:${OPM_DOCKERFILE_TAG}"
+	# Inject --pprof-addr="" into both RUN and CMD serve invocations to disable running the pprof server
+	sed -i.bak -E '/(opm".*"serve|^CMD \["serve)/s#\]$$#, "--pprof-addr="]#' $(CATALOG_DOCKERFILE) && rm -f $(CATALOG_DOCKERFILE).bak
 catalog-dockerfile: $(CATALOG_DOCKERFILE) ## Generate catalog dockerfile.
 
 $(CATALOG_FILE): $(OPM) $(YQ)


### PR DESCRIPTION
# Description
Build catalog is failing due to multiple pprof servers are started pointing to the same port since https://github.com/Kuadrant/authorino-operator/pull/274 was merged:
```
#18 [linux/s390x builder 3/3] RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
#18 1.032 time="2025-10-02T15:38:44Z" level=fatal msg="could not start pprof endpoint: listen tcp 127.0.0.1:6060: bind: address already in use"
#18 ERROR: process "/dev/.buildkit_qemu_emulator /bin/opm serve /configs --cache-dir=/tmp/cache --cache-only" did not complete successfully: exit code: 1

#21 [linux/ppc64le builder 3/3] RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
#21 1.200 time="2025-10-02T15:38:44Z" level=info msg="starting pprof endpoint" address="localhost:6060"
#21 1.203 time="2025-10-02T15:38:44Z" level=warning msg="unable to set termination log path" error="open /dev/termination-log: permission denied"
#21 1.209 time="2025-10-02T15:38:44Z" level=info msg="cache directory is empty, using preferred backend" backend=pogreb.v1 cache=/tmp/cache configs=/configs
#21 1.246 time="2025-10-02T15:38:44Z" level=info msg="building cache" cache=/tmp/cache configs=/configs
#21 CANCELED
```
- https://github.com/Kuadrant/authorino-operator/actions/runs/18194667806/job/51809222332

This PR adds the command to the generated catalog dockerfile to disable the pprof server in the opm commands in the dockerfile 

A successfull run was done on my fork at https://github.com/KevFan/authorino-operator/actions/runs/18202970128