### PR TITLE
fix: trigger release-helm-chart also on push tags and validation

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -8,7 +8,7 @@ on:
       - published
   push:
     tags:
-      - "v*"
+      - "v*.*.*"
   workflow_dispatch:
     inputs:
       operatorTag:
@@ -29,10 +29,9 @@ jobs:
           TAG="${{ github.ref }}"
           if [[ "$TAG" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
             echo "Valid semver tag: $TAG"
-            echo "valid=true" >> $GITHUB_OUTPUT
           else
             echo "::error::Invalid semver tag: $TAG"
-            echo "Expected format: v1.2.3 or v1.2.3-alpha"
+            echo "Expected a valid SemVer (https://semver.org/) format, i.e.: v1.2.3, v1.2.3-alpha1, v1.2.3-dev"
             exit 1  
           fi
 


### PR DESCRIPTION
closes #235 
The workflow previously only ran on release.published, which failed for automated releases.

- Add push trigger for v* tags to support automated releases
- Add semver validation step to reject invalid tag formats  
- Fix tag parsing to handle push events via github.ref_name
- Prevent workflow from running on non-semver tags"