### PR TITLE
makefile: refactor dependency tooling install

### DIFF
--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -7,14 +7,14 @@ CATALOG_FILE = $(PROJECT_DIR)/catalog/authorino-operator-catalog/operator.yaml
 CATALOG_DOCKERFILE = $(PROJECT_DIR)/catalog/authorino-operator-catalog.Dockerfile
 
 OPM_DOCKERFILE_TAG ?= latest
-$(CATALOG_DOCKERFILE): $(OPM)
+$(CATALOG_DOCKERFILE): opm
 	-mkdir -p $(PROJECT_DIR)/catalog/authorino-operator-catalog
 	cd $(PROJECT_DIR)/catalog && $(OPM) generate dockerfile authorino-operator-catalog -b "quay.io/operator-framework/opm:${OPM_DOCKERFILE_TAG}" -i "quay.io/operator-framework/opm:${OPM_DOCKERFILE_TAG}"
 	# Inject --pprof-addr="" into both RUN and CMD serve invocations to disable running the pprof server
 	sed -i.bak -E '/(opm".*"serve|^CMD \["serve)/s#\]$$#, "--pprof-addr="]#' $(CATALOG_DOCKERFILE) && rm -f $(CATALOG_DOCKERFILE).bak
 catalog-dockerfile: $(CATALOG_DOCKERFILE) ## Generate catalog dockerfile.
 
-$(CATALOG_FILE): $(OPM) $(YQ)
+$(CATALOG_FILE): opm yq
 	@echo "************************************************************"
 	@echo Build authorino operator catalog
 	@echo
@@ -27,7 +27,7 @@ $(CATALOG_FILE): $(OPM) $(YQ)
 	$(PROJECT_DIR)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $@ $(CHANNELS)
 
 .PHONY: catalog
-catalog: $(OPM) ## Generate catalog content and validate.
+catalog: opm ## Generate catalog content and validate.
 	# Initializing the Catalog
 	-rm -rf $(PROJECT_DIR)/catalog/authorino-operator-catalog
 	-rm -rf $(PROJECT_DIR)/catalog/authorino-operator-catalog.Dockerfile
@@ -47,9 +47,9 @@ catalog-build: ## Build a catalog image.
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
-deploy-catalog: $(KUSTOMIZE) $(YQ) ## Deploy operator to the K8s cluster specified in ~/.kube/config using OLM catalog image.
+deploy-catalog: kustomize yq ## Deploy operator to the K8s cluster specified in ~/.kube/config using OLM catalog image.
 	V="$(CATALOG_IMG)" $(YQ) eval '.spec.image = strenv(V)' -i config/deploy/olm/catalogsource.yaml
 	$(KUSTOMIZE) build config/deploy/olm | kubectl apply -f -
 
-undeploy-catalog: $(KUSTOMIZE) ## Undeploy controller from the K8s cluster specified in ~/.kube/config using OLM catalog image.
+undeploy-catalog: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config using OLM catalog image.
 	$(KUSTOMIZE) build config/deploy/olm | kubectl delete -f -

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -6,7 +6,7 @@ CHART_NAME ?= authorino-operator
 CHART_DIRECTORY ?= charts/$(CHART_NAME)
 
 .PHONY: helm-build
-helm-build: $(YQ) kustomize manifests ## Build the helm chart from kustomize manifests
+helm-build: yq kustomize manifests ## Build the helm chart from kustomize manifests
 	# Set desired authorino image
 	V="$(ACTUAL_DEFAULT_AUTHORINO_IMAGE)" $(YQ) eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_AUTHORINO").value) = strenv(V)' -i config/manager/manager.yaml
 	# Replace the controller image
@@ -23,22 +23,22 @@ helm-build: $(YQ) kustomize manifests ## Build the helm chart from kustomize man
 	cd config/authorino/webhook && $(KUSTOMIZE) edit set namespace $(CHART_NAME)
 
 .PHONY: helm-install
-helm-install: $(HELM) ## Install the helm chart
+helm-install: helm ## Install the helm chart
 	# Install the helm chart in the cluster
 	$(HELM) install $(CHART_NAME) $(CHART_DIRECTORY)
 
 .PHONY: helm-uninstall
-helm-uninstall: $(HELM) ## Uninstall the helm chart
+helm-uninstall: helm ## Uninstall the helm chart
 	# Uninstall the helm chart from the cluster
 	$(HELM) uninstall $(CHART_NAME)
 
 .PHONY: helm-upgrade
-helm-upgrade: $(HELM) ## Upgrade the helm chart
+helm-upgrade: helm ## Upgrade the helm chart
 	# Upgrade the helm chart in the cluster
 	$(HELM) upgrade $(CHART_NAME) $(CHART_DIRECTORY)
 
 .PHONY: helm-package
-helm-package: $(HELM) ## Package the helm chart
+helm-package: helm ## Package the helm chart
 	# Package the helm chart
 	$(HELM) package $(CHART_DIRECTORY)
 
@@ -46,7 +46,7 @@ helm-package: $(HELM) ## Package the helm chart
 GPG_KEY_UID ?= 'Kuadrant Development Team'
 # The keyring should've been imported before running this target
 .PHONY: helm-package-sign
-helm-package-sign: $(HELM) ## Package the helm chart and GPG sign it
+helm-package-sign: helm ## Package the helm chart and GPG sign it
 	# Package the helm chart and sign it
 	$(HELM) package --sign --key "$(GPG_KEY_UID)" $(CHART_DIRECTORY)
 


### PR DESCRIPTION
# Description
* Refactor makefile dependency tools using [Kubebuilder v4 project makefile as template](https://github.com/kubernetes-sigs/kubebuilder/blob/012e741d07a34da23451b9d0c946f89dddd43609/testdata/project-v4/Makefile#L168-L232)
* Bind tool version to "X-V_BINARY" that will be checked instead by `make`. This will ensure that should the version of the tool is changed/updated, `make` will download this new version and update the symlink