### PR TITLE
GH action release job uses KUADRANT_DEV_PAT to trigger other workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
           git add -A && git commit -m "Prepared release v${{ github.event.inputs.operatorVersion }}"
           git push origin release-v${{ github.event.inputs.operatorVersion }}
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: v${{ github.event.inputs.operatorVersion }}
           tag_name: v${{ github.event.inputs.operatorVersion }}
@@ -66,3 +66,4 @@ jobs:
           generate_release_notes: true
           target_commitish: release-v${{ github.event.inputs.operatorVersion }}
           prerelease: ${{ github.event.inputs.prerelease }}
+          token: ${{ secrets.KUADRANT_DEV_PAT }}


### PR DESCRIPTION
### What

GH releases were created using GITHUB_TOKEN. This prevented the trigger of the helm chart workflow. From GH doc https://docs.github.com/actions/using-workflows/triggering-a-workflow

```
When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run.
```

