### PR TITLE
Add quay image expiry to nightly and branch workflows

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -27,6 +27,10 @@ on:
         description: Bundle default channel (leave empty to keep existing annotations)
         default: ""
         type: string
+      quayImageExpiry:
+        description: When to expire the built quay images. The time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively, from the time the image is built.
+        default: never
+        type: string
   workflow_dispatch:
     inputs:
       operatorVersion:
@@ -53,12 +57,17 @@ on:
         description: Bundle default channel (leave empty to keep existing annotations)
         default: ""
         type: string
+      quayImageExpiry:
+        description: When to expire the built quay images. The time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively, from the time the image is built.
+        default: never
+        type: string
 
 env:
   IMG_REGISTRY_HOST: quay.io
   IMG_REGISTRY_ORG: kuadrant
   OPERATOR_NAME: authorino-operator
   BUILD_CONFIG_FILE: build.yaml
+  QUAY_IMAGE_EXPIRY: ${{ inputs.quayImageExpiry }}
 
 jobs:
   build:
@@ -102,6 +111,7 @@ jobs:
             GIT_SHA=${{ github.sha }}
             DIRTY=false
             DEFAULT_AUTHORINO_IMAGE=${{ inputs.relatedImageAuthorino }}
+            QUAY_IMAGE_EXPIRY=${{ inputs.quayImageExpiry }}
           provenance: false
       - name: Print image URL
         run: |
@@ -178,6 +188,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          build-args: QUAY_IMAGE_EXPIRY=${{ inputs.quayImageExpiry }}
           provenance: false
       - name: Print image URL
         run: |

--- a/.github/workflows/build-images-branches.yaml
+++ b/.github/workflows/build-images-branches.yaml
@@ -17,4 +17,3 @@ jobs:
       operatorTag: ${{ github.ref_name }}
       authorinoVersion: latest
       relatedImageAuthorino: quay.io/kuadrant/authorino:latest
-      quayImageExpiry: 1w

--- a/.github/workflows/build-images-branches.yaml
+++ b/.github/workflows/build-images-branches.yaml
@@ -17,3 +17,4 @@ jobs:
       operatorTag: ${{ github.ref_name }}
       authorinoVersion: latest
       relatedImageAuthorino: quay.io/kuadrant/authorino:latest
+      quayImageExpiry: 1w

--- a/.github/workflows/build-images-main.yaml
+++ b/.github/workflows/build-images-main.yaml
@@ -16,3 +16,4 @@ jobs:
       operatorTag: latest
       authorinoVersion: latest
       relatedImageAuthorino: quay.io/kuadrant/authorino:latest
+      quayImageExpiry: never

--- a/.github/workflows/build-images-nightly.yaml
+++ b/.github/workflows/build-images-nightly.yaml
@@ -38,3 +38,4 @@ jobs:
       operatorTag: ${{ needs.release-date.outputs.release_date }}
       authorinoVersion: latest
       relatedImageAuthorino: quay.io/kuadrant/authorino@${{ needs.authorino-latest-digest.outputs.authorino_digest }}
+      quayImageExpiry: 2w

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,7 @@ WORKDIR /
 COPY --from=builder /tmp/manager .
 USER 1001
 
+ARG QUAY_IMAGE_EXPIRY=never
+LABEL quay.expires-after=$QUAY_IMAGE_EXPIRY
+
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 docker-build: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 docker-build: DIRTY=$(shell $(PROJECT_DIR)/utils/check-git-dirty.sh || echo "unknown")
 docker-build:  ## Build docker image with the manager.
-	docker build --build-arg OPERATOR_VERSION=$(VERSION) --build-arg GIT_SHA=$(GIT_SHA) --build-arg DIRTY=$(DIRTY) --build-arg ACTUAL_DEFAULT_AUTHORINO_IMAGE=$(ACTUAL_DEFAULT_AUTHORINO_IMAGE) -t $(OPERATOR_IMAGE) .
+	docker build --build-arg OPERATOR_VERSION=$(VERSION) --build-arg GIT_SHA=$(GIT_SHA) --build-arg DIRTY=$(DIRTY) --build-arg ACTUAL_DEFAULT_AUTHORINO_IMAGE=$(ACTUAL_DEFAULT_AUTHORINO_IMAGE) --build-arg QUAY_IMAGE_EXPIRY=$(QUAY_IMAGE_EXPIRY) -t $(OPERATOR_IMAGE) .
 
 docker-push: ## Push docker image with the manager.
 	docker push ${OPERATOR_IMAGE}
@@ -326,6 +326,7 @@ bundle: manifests kustomize operator-sdk yq ## Generate bundle manifests and met
 	# Roll back edit
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${DEFAULT_OPERATOR_IMAGE}
 	$(MAKE) bundle-custom-modifications
+	echo "$$QUAY_EXPIRY_TIME_LABEL" >> bundle.Dockerfile
 
 .PHONY: bundle-custom-modifications
 OPENSHIFT_VERSIONS_ANNOTATION_KEY="com.redhat.openshift.versions"
@@ -342,7 +343,7 @@ bundle-custom-modifications:
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	docker build --build-arg QUAY_IMAGE_EXPIRY=$(QUAY_IMAGE_EXPIRY) -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.

--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,6 @@ bundle: manifests kustomize operator-sdk yq ## Generate bundle manifests and met
 	# Roll back edit
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${DEFAULT_OPERATOR_IMAGE}
 	$(MAKE) bundle-custom-modifications
-	echo "$$QUAY_EXPIRY_TIME_LABEL" >> bundle.Dockerfile
 
 .PHONY: bundle-custom-modifications
 OPENSHIFT_VERSIONS_ANNOTATION_KEY="com.redhat.openshift.versions"
@@ -340,6 +339,8 @@ bundle-custom-modifications:
 	@echo "" >> bundle.Dockerfile
 	@echo "# Custom labels" >> bundle.Dockerfile
 	@echo "LABEL $(OPENSHIFT_VERSIONS_ANNOTATION_KEY)=$(OPENSHIFT_SUPPORTED_VERSIONS)" >> bundle.Dockerfile
+	# Set Quay image expiry label in bundle Dockerfile
+	@echo "$$QUAY_EXPIRY_TIME_LABEL" >> bundle.Dockerfile
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -21,3 +21,6 @@ COPY bundle/tests/scorecard /tests/scorecard/
 
 # Custom labels
 LABEL com.redhat.openshift.versions=v4.12
+
+ARG QUAY_IMAGE_EXPIRY=never
+LABEL quay.expires-after=${QUAY_IMAGE_EXPIRY}

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -6,10 +6,22 @@ CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(IMAGE_TAG)
 CATALOG_FILE = $(PROJECT_DIR)/catalog/authorino-operator-catalog/operator.yaml
 CATALOG_DOCKERFILE = $(PROJECT_DIR)/catalog/authorino-operator-catalog.Dockerfile
 
+# Quay image default expiry
+QUAY_IMAGE_EXPIRY ?= never
+
+# A LABEL that can be appended to a generated Dockerfile to set the Quay image expiration through Docker arguments.
+define QUAY_EXPIRY_TIME_LABEL
+
+# Quay image expiry
+ARG QUAY_IMAGE_EXPIRY=never
+LABEL quay.expires-after=$${QUAY_IMAGE_EXPIRY}
+endef
+export QUAY_EXPIRY_TIME_LABEL
+
 OPM_DOCKERFILE_TAG ?= latest
 $(CATALOG_DOCKERFILE): opm
 	-mkdir -p $(PROJECT_DIR)/catalog/authorino-operator-catalog
-	cd $(PROJECT_DIR)/catalog && $(OPM) generate dockerfile authorino-operator-catalog -b "quay.io/operator-framework/opm:${OPM_DOCKERFILE_TAG}" -i "quay.io/operator-framework/opm:${OPM_DOCKERFILE_TAG}"
+	cd $(PROJECT_DIR)/catalog && $(OPM) generate dockerfile authorino-operator-catalog -l quay.expires-after=$(QUAY_IMAGE_EXPIRY) -b "quay.io/operator-framework/opm:${OPM_DOCKERFILE_TAG}" -i "quay.io/operator-framework/opm:${OPM_DOCKERFILE_TAG}"
 	# Inject --pprof-addr="" into both RUN and CMD serve invocations to disable running the pprof server
 	sed -i.bak -E '/(opm".*"serve|^CMD \["serve)/s#\]$$#, "--pprof-addr="]#' $(CATALOG_DOCKERFILE) && rm -f $(CATALOG_DOCKERFILE).bak
 catalog-dockerfile: $(CATALOG_DOCKERFILE) ## Generate catalog dockerfile.


### PR DESCRIPTION
Add quay image expiry parameter to the base image building workflow, and set following image expiries on workflows: 
| Image Type | Expiry |
  |---|---|
  | Nightly images | 2w |
  | All other images | never |

This setup was mirrored from https://github.com/Kuadrant/limitador-operator/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Configured container image expiration on the registry. Main releases persist indefinitely; nightly builds automatically expire after two weeks, reducing unnecessary storage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/authorino-operator/pull/306)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->