### PR TITLE
feat: add --pprof-bind-address flag for runtime profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,19 @@ spec:
             path: keycloak.crt
     defaultMode: 420
 ```
+
+## Profiling
+
+The operator supports runtime profiling via Go's built-in [pprof](https://pkg.go.dev/net/http/pprof) tooling. Enabled by default on `:8084`.
+
+Connect to a running instance:
+
+```bash
+kubectl port-forward -n authorino-operator deploy/authorino-operator-controller-manager 8084:8084
+go tool pprof -http=:8080 http://localhost:8084/debug/pprof/profile?seconds=30
+go tool pprof -http=:8080 http://localhost:8084/debug/pprof/heap
+```
+
 ## Removal
 
 ### Removing the operator installed via manifests

--- a/main.go
+++ b/main.go
@@ -74,10 +74,12 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var pprofAddr string
 	logOpts := logOptions{}
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&pprofAddr, "pprof-bind-address", ":8084", "The address the pprof endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -107,6 +109,7 @@ func main() {
 		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
 		WebhookServer:          webhook.NewServer(webhook.Options{Port: 9443}),
 		HealthProbeBindAddress: probeAddr,
+		PprofBindAddress:       pprofAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "aac3a15d.authorino.kuadrant.io",
 	})


### PR DESCRIPTION
## Summary

Adds runtime profiling support via Go's built-in [pprof](https://pkg.go.dev/net/http/pprof) using controller-runtime's `PprofBindAddress` option. Enabled by default on `:8084`.

## Motivation

pprof is the standard mechanism for diagnosing performance issues in Go applications. The Kubernetes [kube-apiserver](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) enables profiling via `--profiling` (default: `true`), exposing the same `/debug/pprof/` endpoints. OpenShift provides [built-in tooling](https://docs.openshift.com/container-platform/4.11/scalability_and_performance/node-observability-operator.html) for collecting pprof data from cluster components.

Port 8084 is used consistently across all Kuadrant Go components to avoid conflicts with existing services.

## Changes

- Added `--pprof-bind-address` flag (default `:8084`) to `main.go`
- Added `PprofBindAddress` to `ctrl.Options`
- Added `## Profiling` section to README.md