### PR TITLE
Adopt RFC 0018 release branch naming (release-X.Y)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Validate version input
         run: |
           version="${{ github.event.inputs.operatorVersion }}"
-          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$'; then
+          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].+)?$'; then
             echo "Error: version must be semver format (e.g., 0.24.1, 0.25.0-rc1)"
             exit 1
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,10 +40,15 @@ jobs:
         with:
           go-version-file: go.mod
         id: go
-      - name: Create release branch
-        if: ${{ !startsWith(github.event.inputs.gitRef, 'release-v') }}
+      - name: Derive release branch name
+        id: release-branch
         run: |
-          git checkout -b release-v${{ github.event.inputs.operatorVersion }}
+          release_branch=release-$(echo "${{ github.event.inputs.operatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
+          echo "name=$release_branch" >> $GITHUB_OUTPUT
+      - name: Create release branch
+        if: ${{ !startsWith(github.event.inputs.gitRef, 'release-') }}
+        run: |
+          git checkout -b ${{ steps.release-branch.outputs.name }}
       - name: Prepare release
         run: |
           VERSION=${{ github.event.inputs.operatorVersion }} \
@@ -56,7 +61,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add -A && git commit -m "Prepared release v${{ github.event.inputs.operatorVersion }}"
-          git push origin release-v${{ github.event.inputs.operatorVersion }}
+          git push origin ${{ steps.release-branch.outputs.name }}
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
@@ -64,6 +69,6 @@ jobs:
           tag_name: v${{ github.event.inputs.operatorVersion }}
           body: "**This release enables installations of Authorino v${{ github.event.inputs.authorinoVersion }}**"
           generate_release_notes: true
-          target_commitish: release-v${{ github.event.inputs.operatorVersion }}
+          target_commitish: ${{ steps.release-branch.outputs.name }}
           prerelease: ${{ github.event.inputs.prerelease }}
           token: ${{ secrets.KUADRANT_DEV_PAT }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,14 @@ jobs:
       - name: Derive release branch name
         id: release-branch
         run: |
-          release_branch=release-$(echo "${{ github.event.inputs.operatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
+          version="${{ github.event.inputs.operatorVersion }}"
+          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$'; then
+            echo "Error: version must be semver format (e.g., 0.24.1, 0.25.0-rc1)"
+            exit 1
+          fi
+          # Extract major.minor from version (e.g., 0.24.1 → 0.24)
+          # Removes: pre-release suffix ([+-].*) and patch version (\.[0-9]*$)
+          release_branch=release-$(echo "$version" | sed 's/[+-].*//; s/\.[0-9]*$//')
           echo "name=$release_branch" >> $GITHUB_OUTPUT
       - name: Create release branch
         if: ${{ !startsWith(github.event.inputs.gitRef, 'release-') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,13 @@ jobs:
     name: Release operator
     runs-on: ubuntu-latest
     steps:
+      - name: Validate version input
+        run: |
+          version="${{ github.event.inputs.operatorVersion }}"
+          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$'; then
+            echo "Error: version must be semver format (e.g., 0.24.1, 0.25.0-rc1)"
+            exit 1
+          fi
       - name: Install gettext-base
         run: |
           sudo apt-get update
@@ -43,14 +50,9 @@ jobs:
       - name: Derive release branch name
         id: release-branch
         run: |
-          version="${{ github.event.inputs.operatorVersion }}"
-          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$'; then
-            echo "Error: version must be semver format (e.g., 0.24.1, 0.25.0-rc1)"
-            exit 1
-          fi
           # Extract major.minor from version (e.g., 0.24.1 → 0.24)
           # Removes: pre-release suffix ([+-].*) and patch version (\.[0-9]*$)
-          release_branch=release-$(echo "$version" | sed 's/[+-].*//; s/\.[0-9]*$//')
+          release_branch=release-$(echo "${{ github.event.inputs.operatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
           echo "name=$release_branch" >> $GITHUB_OUTPUT
       - name: Create release branch
         if: ${{ !startsWith(github.event.inputs.gitRef, 'release-') }}


### PR DESCRIPTION
## Summary

Updates the release workflow to use minor-level branch naming without `v` prefix per [RFC 0018](https://github.com/Kuadrant/architecture/blob/main/rfcs/0018-release-branch-naming.md).

## Changes

**Granularity change**: the workflow previously created a new branch per patch release (`release-v0.24.0`, `release-v0.24.1`). Now it uses one branch per minor (`release-0.24`) — patch releases are new tags on the same branch.

- Add a `Derive release branch name` step that computes `release-X.Y` from the version input
- Change `startsWith` check from `release-v` to `release-`
- Use derived branch name for `git push` and `target_commitish`
- `RELEASE.md:82` left as-is (historical link to `release-v0.10.0` which is a real existing branch)

Part of Kuadrant/kuadrant-operator#1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)