### PR TITLE
ci: trigger test workflow on release branches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,10 +2,10 @@ name: Test
 
 on:
   push:
-    branches: [ 'main', 'master' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
   pull_request:
-    branches: [ 'main', 'master' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
   merge_group:
     types: [ checks_requested ]


### PR DESCRIPTION
## Summary

Adds `release-*` to the push and pull_request branch triggers in `test.yaml` so CI runs on release branches.

Without this, PRs targeting release branches (e.g., backport PRs for patch releases) don't get CI validation.

Part of the RFC 0018 migration (Kuadrant/kuadrant-operator#1981).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration testing workflow to automatically run tests on release preparation branches alongside main development branches, ensuring consistent code quality assurance across all deployment stages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/authorino-operator/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->