### PR TITLE
Backport fixes for v0.24.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Validate version input
         run: |
           version="${{ github.event.inputs.operatorVersion }}"
-          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$'; then
+          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].+)?$'; then
             echo "Error: version must be semver format (e.g., 0.24.1, 0.25.0-rc1)"
             exit 1
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,10 +40,15 @@ jobs:
         with:
           go-version-file: go.mod
         id: go
-      - name: Create release branch
-        if: ${{ !startsWith(github.event.inputs.gitRef, 'release-v') }}
+      - name: Derive release branch name
+        id: release-branch
         run: |
-          git checkout -b release-v${{ github.event.inputs.operatorVersion }}
+          release_branch=release-$(echo "${{ github.event.inputs.operatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
+          echo "name=$release_branch" >> $GITHUB_OUTPUT
+      - name: Create release branch
+        if: ${{ !startsWith(github.event.inputs.gitRef, 'release-') }}
+        run: |
+          git checkout -b ${{ steps.release-branch.outputs.name }}
       - name: Prepare release
         run: |
           VERSION=${{ github.event.inputs.operatorVersion }} \
@@ -56,7 +61,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add -A && git commit -m "Prepared release v${{ github.event.inputs.operatorVersion }}"
-          git push origin release-v${{ github.event.inputs.operatorVersion }}
+          git push origin ${{ steps.release-branch.outputs.name }}
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
@@ -64,6 +69,6 @@ jobs:
           tag_name: v${{ github.event.inputs.operatorVersion }}
           body: "**This release enables installations of Authorino v${{ github.event.inputs.authorinoVersion }}**"
           generate_release_notes: true
-          target_commitish: release-v${{ github.event.inputs.operatorVersion }}
+          target_commitish: ${{ steps.release-branch.outputs.name }}
           prerelease: ${{ github.event.inputs.prerelease }}
           token: ${{ secrets.KUADRANT_DEV_PAT }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,14 @@ jobs:
       - name: Derive release branch name
         id: release-branch
         run: |
-          release_branch=release-$(echo "${{ github.event.inputs.operatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
+          version="${{ github.event.inputs.operatorVersion }}"
+          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$'; then
+            echo "Error: version must be semver format (e.g., 0.24.1, 0.25.0-rc1)"
+            exit 1
+          fi
+          # Extract major.minor from version (e.g., 0.24.1 → 0.24)
+          # Removes: pre-release suffix ([+-].*) and patch version (\.[0-9]*$)
+          release_branch=release-$(echo "$version" | sed 's/[+-].*//; s/\.[0-9]*$//')
           echo "name=$release_branch" >> $GITHUB_OUTPUT
       - name: Create release branch
         if: ${{ !startsWith(github.event.inputs.gitRef, 'release-') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,13 @@ jobs:
     name: Release operator
     runs-on: ubuntu-latest
     steps:
+      - name: Validate version input
+        run: |
+          version="${{ github.event.inputs.operatorVersion }}"
+          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$'; then
+            echo "Error: version must be semver format (e.g., 0.24.1, 0.25.0-rc1)"
+            exit 1
+          fi
       - name: Install gettext-base
         run: |
           sudo apt-get update
@@ -43,14 +50,9 @@ jobs:
       - name: Derive release branch name
         id: release-branch
         run: |
-          version="${{ github.event.inputs.operatorVersion }}"
-          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$'; then
-            echo "Error: version must be semver format (e.g., 0.24.1, 0.25.0-rc1)"
-            exit 1
-          fi
           # Extract major.minor from version (e.g., 0.24.1 → 0.24)
           # Removes: pre-release suffix ([+-].*) and patch version (\.[0-9]*$)
-          release_branch=release-$(echo "$version" | sed 's/[+-].*//; s/\.[0-9]*$//')
+          release_branch=release-$(echo "${{ github.event.inputs.operatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
           echo "name=$release_branch" >> $GITHUB_OUTPUT
       - name: Create release branch
         if: ${{ !startsWith(github.event.inputs.gitRef, 'release-') }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,10 +2,10 @@ name: Test
 
 on:
   push:
-    branches: [ 'main', 'master' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
   pull_request:
-    branches: [ 'main', 'master' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
   merge_group:
     types: [ checks_requested ]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino-operator
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Summary

Prepares the `release-0.24` branch for v0.24.1 (Kuadrant 1.4.4). Replaces the closed #309 which targeted the older 0.23 line.

Kuadrant 1.4.3 used authorino-operator v0.23.1. Since v0.24.0 already contains all the bug fixes we would have backported (cert secret fix, controller-runtime bump), 1.4.4 bumps to the 0.24 line instead.

## Changes

- **Go 1.25.8 → 1.25.9** — aligns with all other Kuadrant 1.4.4 components
- **RFC 0018 release branch naming** — backport of #308 (workflow changes for `release-X.Y` naming)
- **CI trigger on release branches** — backport of #310 (test workflow runs on release branch pushes/PRs)

## Why v0.24.1, not v0.23.2?

v0.24.0 has no API/CRD breaking changes vs v0.23.1 — only bug fixes, CI improvements, and a controller-runtime bump. Cherry-picking those same fixes backwards to 0.23 would produce identical code with more effort. The 0.24 line will also be used for Kuadrant 1.5.

Part of Kuadrant/kuadrant-operator#1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)