### PR TITLE
feat: add USE_IMAGE_DIGESTS flag for digest-based image references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,11 @@ OPERATOR_IMAGE ?= $(IMAGE_TAG_BASE):$(IMAGE_TAG)
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:$(IMAGE_TAG)
 
+# USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
+# You can enable this value if you would like to use SHA Based Digests
+# To enable set flag to true
+USE_IMAGE_DIGESTS ?= false
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 ifneq ($(origin CHANNELS), undefined)
@@ -306,6 +311,12 @@ deploy-manifest: kustomize
 
 ##@ OLM manifest bundle
 
+# BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
+BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS) --package authorino-operator
+ifeq ($(USE_IMAGE_DIGESTS), true)
+	BUNDLE_GEN_FLAGS += --use-image-digests
+endif
+
 .PHONY: bundle
 bundle: export IMAGE_TAG := $(IMAGE_TAG)
 bundle: export BUNDLE_VERSION := $(BUNDLE_VERSION)
@@ -318,7 +329,7 @@ bundle: manifests kustomize operator-sdk yq ## Generate bundle manifests and met
 	envsubst \
         < config/manifests/bases/authorino-operator.clusterserviceversion.template.yaml \
         > config/manifests/bases/authorino-operator.clusterserviceversion.yaml
-	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS) --package authorino-operator
+	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	($(YQ) e -e '.config.replaces' $(BUILD_CONFIG_FILE) && \
 		V="$(shell $(YQ) e -e '.config.replaces' $(BUILD_CONFIG_FILE))" $(YQ) eval '.spec.replaces = strenv(V)' -i $(BUNDLE_CSV)) || \
 		($(YQ) eval '.' -i $(BUNDLE_CSV) && echo "no replaces added")
@@ -341,6 +352,10 @@ bundle-custom-modifications:
 	@echo "LABEL $(OPENSHIFT_VERSIONS_ANNOTATION_KEY)=$(OPENSHIFT_SUPPORTED_VERSIONS)" >> bundle.Dockerfile
 	# Set Quay image expiry label in bundle Dockerfile
 	@echo "$$QUAY_EXPIRY_TIME_LABEL" >> bundle.Dockerfile
+ifeq ($(USE_IMAGE_DIGESTS),true)
+	# Deduplicate relatedImages and remove name field (operator-sdk --use-image-digests creates duplicates)
+	$(YQ) -i '.spec.relatedImages |= unique_by(.image) | del(.spec.relatedImages[].name)' bundle/manifests/authorino-operator.clusterserviceversion.yaml
+endif
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/Makefile
+++ b/Makefile
@@ -333,10 +333,10 @@ bundle: manifests kustomize operator-sdk yq ## Generate bundle manifests and met
 	($(YQ) e -e '.config.replaces' $(BUILD_CONFIG_FILE) && \
 		V="$(shell $(YQ) e -e '.config.replaces' $(BUILD_CONFIG_FILE))" $(YQ) eval '.spec.replaces = strenv(V)' -i $(BUNDLE_CSV)) || \
 		($(YQ) eval '.' -i $(BUNDLE_CSV) && echo "no replaces added")
+	$(MAKE) bundle-custom-modifications
 	$(OPERATOR_SDK) bundle validate ./bundle
 	# Roll back edit
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${DEFAULT_OPERATOR_IMAGE}
-	$(MAKE) bundle-custom-modifications
 
 .PHONY: bundle-custom-modifications
 OPENSHIFT_VERSIONS_ANNOTATION_KEY="com.redhat.openshift.versions"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -22,5 +22,6 @@ COPY bundle/tests/scorecard /tests/scorecard/
 # Custom labels
 LABEL com.redhat.openshift.versions=v4.12
 
+# Quay image expiry
 ARG QUAY_IMAGE_EXPIRY=never
 LABEL quay.expires-after=${QUAY_IMAGE_EXPIRY}

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -57,7 +57,7 @@ catalog-build: ## Build a catalog image.
 # Push the catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
-	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+	$(MAKE) docker-push OPERATOR_IMAGE=$(CATALOG_IMG)
 
 deploy-catalog: kustomize yq ## Deploy operator to the K8s cluster specified in ~/.kube/config using OLM catalog image.
 	V="$(CATALOG_IMG)" $(YQ) eval '.spec.image = strenv(V)' -i config/deploy/olm/catalogsource.yaml


### PR DESCRIPTION
## Summary

Adds optional USE_IMAGE_DIGESTS flag to enable digest-based image references in operator bundles.

## Changes

- Added `USE_IMAGE_DIGESTS` flag (default: false) to enable SHA256 digest references
- Created `BUNDLE_GEN_FLAGS` variable with conditional `--use-image-digests`
- Added bundle post-generation step to deduplicate relatedImages (operator-sdk creates duplicates when using digests)
- Fixed bundle validation to run after all bundle modifications complete

Digest-based references enable ImageDigestMirrorSet to redirect image pulls to internal registries.

## Related

Related to https://github.com/Kuadrant/kuadrant-operator/issues/1894