### PR TITLE
fix: fall back to tag_name when release name is empty in set-replaces-directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,7 @@ set-authorino-default-image: yq ## Sets the default Authorino image in the build
 set-replaces-directive: yq ## Sets the value for the OLM replaces directive in the build file.
 	$(eval REPLACES_VERSION=$(shell curl -sSL -H "Accept: application/vnd.github+json" \
                https://api.github.com/repos/Kuadrant/authorino-operator/releases/latest | \
-               jq -r '.name // .tag_name'))
+               jq -r 'if (.name // "" | length) > 0 then .name else .tag_name end'))
 	V="authorino-operator.$(REPLACES_VERSION)" $(YQ) e -i '.config.replaces = strenv(V)' $(BUILD_CONFIG_FILE)
 
 .PHONY: prepare-release

--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,7 @@ set-authorino-default-image: yq ## Sets the default Authorino image in the build
 set-replaces-directive: yq ## Sets the value for the OLM replaces directive in the build file.
 	$(eval REPLACES_VERSION=$(shell curl -sSL -H "Accept: application/vnd.github+json" \
                https://api.github.com/repos/Kuadrant/authorino-operator/releases/latest | \
-               jq -r '.name'))
+               jq -r '.name // .tag_name'))
 	V="authorino-operator.$(REPLACES_VERSION)" $(YQ) e -i '.config.replaces = strenv(V)' $(BUILD_CONFIG_FILE)
 
 .PHONY: prepare-release


### PR DESCRIPTION
## Summary
Fixes the `prepare-release` failure in the v0.25.0 release workflow ([run #26561992452](https://github.com/Kuadrant/authorino-operator/actions/runs/26561992452)).

## Problem
The `set-replaces-directive` Makefile target fetches the latest GitHub release name to build the OLM `spec.replaces` value. When a release has an empty `name` field (v0.23.2 was created without `--title`), `jq -r '.name'` returns an empty string, producing `authorino-operator.` which fails OLM bundle validation:

```
spec.replaces "authorino-operator." is invalid: a lowercase RFC 1123 subdomain must consist of...
```

## Fix
Use jq's alternative operator (`//`) to fall back to `tag_name` when `name` is empty or null.

Also fixed: `gh release edit v0.23.2 --title v0.23.2` to set the missing release name.

## Known limitation
This target uses `/releases/latest` which returns the most recently published release globally, not per-branch. When releasing on multiple minor branches (e.g. v0.23.x and v0.25.x), the `replaces` directive could point to the wrong version. A follow-up should make `REPLACES_VERSION` an explicit workflow input.

## Test plan
- [x] Verified `gh api repos/Kuadrant/authorino-operator/releases/latest --jq '.name // .tag_name'` now returns `v0.23.2`
- [ ] Re-run the v0.25.0 release workflow after merging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved robustness of release-version detection by handling cases where the latest release name is missing or empty, falling back to the tag name to reduce release-processing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->