### PR TITLE
Update Authorino manifests to v0.26.1 for v0.25.1 patch release

### DIFF
--- a/.github/workflows/build-images-branches.yaml
+++ b/.github/workflows/build-images-branches.yaml
@@ -8,12 +8,53 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  detect-config:
+    name: Detect build configuration
+    runs-on: ubuntu-latest
+    outputs:
+      operatorVersion: ${{ steps.config.outputs.operatorVersion }}
+      authorinoVersion: ${{ steps.config.outputs.authorinoVersion }}
+      authorinoImage: ${{ steps.config.outputs.authorinoImage }}
+      channels: ${{ steps.config.outputs.channels }}
+      defaultChannel: ${{ steps.config.outputs.defaultChannel }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Read configuration from build.yaml
+        id: config
+        run: |
+          BUILD_FILE="build.yaml"
+          if [ -f "$BUILD_FILE" ]; then
+            echo "build.yaml found, extracting configuration"
+            # Read values using grep/sed (same approach as Makefile, with trimming)
+            OPERATOR_VERSION=$(grep -E '^\s+version:' "$BUILD_FILE" 2>/dev/null | sed -E 's/.*version:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$//' || echo "0.0.0")
+            AUTHORINO_VERSION=$(grep -E '^\s+authorinoVersion:' "$BUILD_FILE" 2>/dev/null | sed -E 's/.*authorinoVersion:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$//' || echo "latest")
+            AUTHORINO_IMAGE=$(grep -E '^\s+authorinoImage:' "$BUILD_FILE" 2>/dev/null | sed -E 's/.*authorinoImage:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$//' || echo "quay.io/kuadrant/authorino:latest")
+            CHANNELS="stable"
+            DEFAULT_CHANNEL="stable"
+          else
+            echo "build.yaml not found, using default values"
+            OPERATOR_VERSION="0.0.0"
+            AUTHORINO_VERSION="latest"
+            AUTHORINO_IMAGE="quay.io/kuadrant/authorino:latest"
+            CHANNELS=""
+            DEFAULT_CHANNEL=""
+          fi
+          echo "operatorVersion=${OPERATOR_VERSION}" >> $GITHUB_OUTPUT
+          echo "authorinoVersion=${AUTHORINO_VERSION}" >> $GITHUB_OUTPUT
+          echo "authorinoImage=${AUTHORINO_IMAGE}" >> $GITHUB_OUTPUT
+          echo "channels=${CHANNELS}" >> $GITHUB_OUTPUT
+          echo "defaultChannel=${DEFAULT_CHANNEL}" >> $GITHUB_OUTPUT
+
   build-branches:
     name: Calls build-images-base workflow
+    needs: detect-config
     uses: ./.github/workflows/build-images-base.yaml
     secrets: inherit
     with:
-      operatorVersion: 0.0.0
+      operatorVersion: ${{ needs.detect-config.outputs.operatorVersion }}
       operatorTag: ${{ github.ref_name }}
-      authorinoVersion: latest
-      relatedImageAuthorino: quay.io/kuadrant/authorino:latest
+      authorinoVersion: ${{ needs.detect-config.outputs.authorinoVersion }}
+      relatedImageAuthorino: ${{ needs.detect-config.outputs.authorinoImage }}
+      channels: ${{ needs.detect-config.outputs.channels }}
+      defaultChannel: ${{ needs.detect-config.outputs.defaultChannel }}

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
+# Include release defaults early so variables like VERSION, AUTHORINO_VERSION,
+# and CHANNELS are available for immediate evaluation below.
+-include $(PROJECT_DIR)/make/release.mk
+
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):

--- a/Makefile
+++ b/Makefile
@@ -16,17 +16,39 @@ MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
-# Include release defaults early so variables like VERSION, AUTHORINO_VERSION,
-# and CHANNELS are available for immediate evaluation below.
--include $(PROJECT_DIR)/make/release.mk
-
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
+# Build configuration file (created by 'make create-build-file' or 'make prepare-release')
+BUILD_CONFIG_FILE ?= build.yaml
+
+# Read release configuration from build.yaml if present
+# This allows release branches to define VERSION, AUTHORINO_VERSION, and CHANNELS
+# Uses grep/sed for simple YAML parsing without requiring yq at variable definition time
+BUILD_CONFIG_VERSION ?= $(shell test -f $(BUILD_CONFIG_FILE) && grep -E '^\s+version:' $(BUILD_CONFIG_FILE) 2>/dev/null | sed -E 's/.*version:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$$//' || echo "")
+BUILD_CONFIG_AUTHORINO_VERSION ?= $(shell test -f $(BUILD_CONFIG_FILE) && grep -E '^\s+authorinoVersion:' $(BUILD_CONFIG_FILE) 2>/dev/null | sed -E 's/.*authorinoVersion:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$$//' || echo "")
+
 # VERSION defines the project version for the bundle.
+# Priority: command-line > build.yaml > git SHA
+VERSION ?= $(BUILD_CONFIG_VERSION)
 VERSION ?= $(shell git rev-parse HEAD)
+
+# AUTHORINO_VERSION priority: command-line > build.yaml > 'latest' (set below)
+ifndef AUTHORINO_VERSION
+ifneq ($(BUILD_CONFIG_AUTHORINO_VERSION),)
+AUTHORINO_VERSION = $(BUILD_CONFIG_AUTHORINO_VERSION)
+endif
+endif
+
+# CHANNELS defaults to stable if build.yaml has a version field, otherwise left undefined
+ifndef CHANNELS
+ifneq ($(BUILD_CONFIG_VERSION),)
+CHANNELS = stable
+DEFAULT_CHANNEL = stable
+endif
+endif
 
 # Address of the container registry
 DEFAULT_REGISTRY = quay.io
@@ -99,8 +121,7 @@ endif
 # Container Engine to be used for building image and with kind
 CONTAINER_ENGINE ?= docker
 
-# Build file used to store replaces/authorinoImage options.
-BUILD_CONFIG_FILE ?= build.yaml
+# Default and actual Authorino images
 DEFAULT_AUTHORINO_IMAGE = $(DEFAULT_REGISTRY)/$(DEFAULT_ORG)/authorino:$(AUTHORINO_IMAGE_TAG)
 ACTUAL_DEFAULT_AUTHORINO_IMAGE ?= $(shell $(YQ) e -e '.config.authorinoImage' $(BUILD_CONFIG_FILE) || echo $(DEFAULT_AUTHORINO_IMAGE))
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,3 +1,3 @@
 config:
-  authorinoImage: quay.io/kuadrant/authorino:v0.26.0
-  replaces: authorino-operator.v0.23.2
+  authorinoImage: quay.io/kuadrant/authorino:v0.26.1
+  replaces: authorino-operator.v0.25.0

--- a/build.yaml
+++ b/build.yaml
@@ -1,3 +1,5 @@
 config:
-  authorinoImage: quay.io/kuadrant/authorino:v0.26.1
+  version: 0.25.1
   replaces: authorino-operator.v0.25.0
+  authorinoVersion: 0.26.1
+  authorinoImage: quay.io/kuadrant/authorino:v0.26.1

--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -5,34 +5,6 @@ metadata:
     alm-examples: |-
       [
         {
-          "apiVersion": "authorino.kuadrant.io/v1beta2",
-          "kind": "AuthConfig",
-          "metadata": {
-            "name": "my-api-protection"
-          },
-          "spec": {
-            "authentication": {
-              "api-key-users": {
-                "apiKey": {
-                  "selector": {
-                    "matchLabels": {
-                      "group": "friends"
-                    }
-                  }
-                },
-                "credentials": {
-                  "authorizationHeader": {
-                    "prefix": "APIKEY"
-                  }
-                }
-              }
-            },
-            "hosts": [
-              "my-api.io"
-            ]
-          }
-        },
-        {
           "apiVersion": "authorino.kuadrant.io/v1beta3",
           "kind": "AuthConfig",
           "metadata": {
@@ -82,8 +54,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/authorino-operator:v0.25.0
-    createdAt: "2026-05-28T14:45:22Z"
+    containerImage: quay.io/kuadrant/authorino-operator:v0.25.1
+    createdAt: "2026-06-19T14:15:09Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/authorino-operator
@@ -94,17 +66,12 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: authorino-operator.v0.25.0
+  name: authorino-operator.v0.25.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: API to describe the desired protection for a service
-        displayName: AuthConfig
-        kind: AuthConfig
-        name: authconfigs.authorino.kuadrant.io
-        version: v1beta2
       - description: API to describe the desired protection for a service
         displayName: AuthConfig
         kind: AuthConfig
@@ -288,8 +255,8 @@ spec:
                       - /manager
                     env:
                       - name: RELATED_IMAGE_AUTHORINO
-                        value: quay.io/kuadrant/authorino:v0.26.0
-                    image: quay.io/kuadrant/authorino-operator:v0.25.0
+                        value: quay.io/kuadrant/authorino:v0.26.1
+                    image: quay.io/kuadrant/authorino-operator:v0.25.1
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -392,7 +359,7 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-    - image: quay.io/kuadrant/authorino:v0.26.0
+    - image: quay.io/kuadrant/authorino:v0.26.1
       name: authorino
-  version: 0.25.0
-  replaces: authorino-operator.v0.23.2
+  version: 0.25.1
+  replaces: authorino-operator.v0.25.0

--- a/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
+++ b/bundle/manifests/authorino.kuadrant.io_authconfigs.yaml
@@ -2542,7 +2542,7 @@ spec:
                 type: object
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/charts/authorino-operator/Chart.yaml
+++ b/charts/authorino-operator/Chart.yaml
@@ -18,8 +18,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The version will be properly set when the chart is released matching the operator version
-version: "0.25.0"
-appVersion: "0.25.0"
+version: "0.25.1"
+appVersion: "0.25.1"
 maintainers:
   - email: mcassola@redhat.com
     name: Guilherme Cassolato

--- a/charts/authorino-operator/templates/manifests.yaml
+++ b/charts/authorino-operator/templates/manifests.yaml
@@ -2541,7 +2541,7 @@ spec:
                 type: object
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -6179,8 +6179,8 @@ spec:
         - /manager
         env:
         - name: RELATED_IMAGE_AUTHORINO
-          value: quay.io/kuadrant/authorino:v0.26.0
-        image: quay.io/kuadrant/authorino-operator:v0.25.0
+          value: quay.io/kuadrant/authorino:v0.26.1
+        image: quay.io/kuadrant/authorino-operator:v0.25.1
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/authorino/kustomization.yaml
+++ b/config/authorino/kustomization.yaml
@@ -2,14 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/Kuadrant/authorino/install?ref=v0.26.0
+- github.com/Kuadrant/authorino/install?ref=v0.26.1
 # - webhook
 
 # # Configures the conversion webhook
 # images:
 # - name: AUTHORINO_IMAGE
 #   newName: quay.io/kuadrant/authorino
-#   newTag: v0.26.0
+#   newTag: v0.26.1
 
 # patchesStrategicMerge:
 # - webhook/patches/webhook_in_authconfigs.yaml

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -2548,7 +2548,7 @@ spec:
                 type: object
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -6186,8 +6186,8 @@ spec:
         - /manager
         env:
         - name: RELATED_IMAGE_AUTHORINO
-          value: quay.io/kuadrant/authorino:v0.26.0
-        image: quay.io/kuadrant/authorino-operator:v0.25.0
+          value: quay.io/kuadrant/authorino:v0.26.1
+        image: quay.io/kuadrant/authorino-operator:v0.25.1
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
             - /manager
           env:
             - name: RELATED_IMAGE_AUTHORINO
-              value: quay.io/kuadrant/authorino:v0.26.0
+              value: quay.io/kuadrant/authorino:v0.26.1
           args:
             - --leader-elect
           image: controller:latest

--- a/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
@@ -5,13 +5,13 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/authorino-operator:v0.25.0
+    containerImage: quay.io/kuadrant/authorino-operator:v0.25.1
     createdAt: 2021-12-08T10-00-00Z
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/authorino-operator
     support: kuadrant
-  name: authorino-operator.v0.25.0
+  name: authorino-operator.v0.25.1
   namespace: placeholder
   labels:
     operatorframework.io/arch.amd64: supported
@@ -78,4 +78,4 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
-  version: 0.25.0
+  version: 0.25.1

--- a/make/release.mk
+++ b/make/release.mk
@@ -1,5 +1,0 @@
-#Release default values
-VERSION=0.25.1
-AUTHORINO_VERSION=0.26.1
-CHANNELS=stable
-DEFAULT_CHANNEL=stable

--- a/make/release.mk
+++ b/make/release.mk
@@ -1,0 +1,5 @@
+#Release default values
+VERSION=0.25.1
+AUTHORINO_VERSION=0.26.1
+CHANNELS=stable
+DEFAULT_CHANNEL=stable


### PR DESCRIPTION
## Summary
Updates Authorino manifests to v0.26.1 to backport AuthConfig v1beta2 API deprecation fixes.

## Changes
- Updates Authorino image: `v0.26.0` → `v0.26.1`
- Updates `build.yaml` with new Authorino version
- Updates `replaces` directive: `v0.23.2` → `v0.25.0`
- Regenerates OLM bundle manifests
- Regenerates Helm chart manifests
- Updates Authorino CRD manifests (AuthConfig deprecation)

## Context
This backports upstream Authorino bug fixes related to the deprecation of the AuthConfig v1beta2 API. These manifest updates are patch-safe as they reflect fixes in the operand (Authorino) that correspond to this operator version.

## Related
- Part of v0.25.1 patch release preparation
- Authorino v0.26.1 contains deprecation fixes

---
Generated via `/kdt:patch-release` workflow