### PR TITLE
Use build.yaml for release configuration in CI workflows

### DIFF
--- a/.github/workflows/build-images-branches.yaml
+++ b/.github/workflows/build-images-branches.yaml
@@ -8,12 +8,53 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  detect-config:
+    name: Detect build configuration
+    runs-on: ubuntu-latest
+    outputs:
+      operatorVersion: ${{ steps.config.outputs.operatorVersion }}
+      authorinoVersion: ${{ steps.config.outputs.authorinoVersion }}
+      authorinoImage: ${{ steps.config.outputs.authorinoImage }}
+      channels: ${{ steps.config.outputs.channels }}
+      defaultChannel: ${{ steps.config.outputs.defaultChannel }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Read configuration from build.yaml
+        id: config
+        run: |
+          BUILD_FILE="build.yaml"
+          if [ -f "$BUILD_FILE" ]; then
+            echo "build.yaml found, extracting configuration"
+            # Read values using grep/sed (same approach as Makefile, with trimming)
+            OPERATOR_VERSION=$(grep -E '^\s+version:' "$BUILD_FILE" 2>/dev/null | sed -E 's/.*version:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$//' || echo "0.0.0")
+            AUTHORINO_VERSION=$(grep -E '^\s+authorinoVersion:' "$BUILD_FILE" 2>/dev/null | sed -E 's/.*authorinoVersion:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$//' || echo "latest")
+            AUTHORINO_IMAGE=$(grep -E '^\s+authorinoImage:' "$BUILD_FILE" 2>/dev/null | sed -E 's/.*authorinoImage:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$//' || echo "quay.io/kuadrant/authorino:latest")
+            CHANNELS="stable"
+            DEFAULT_CHANNEL="stable"
+          else
+            echo "build.yaml not found, using default values"
+            OPERATOR_VERSION="0.0.0"
+            AUTHORINO_VERSION="latest"
+            AUTHORINO_IMAGE="quay.io/kuadrant/authorino:latest"
+            CHANNELS=""
+            DEFAULT_CHANNEL=""
+          fi
+          echo "operatorVersion=${OPERATOR_VERSION}" >> $GITHUB_OUTPUT
+          echo "authorinoVersion=${AUTHORINO_VERSION}" >> $GITHUB_OUTPUT
+          echo "authorinoImage=${AUTHORINO_IMAGE}" >> $GITHUB_OUTPUT
+          echo "channels=${CHANNELS}" >> $GITHUB_OUTPUT
+          echo "defaultChannel=${DEFAULT_CHANNEL}" >> $GITHUB_OUTPUT
+
   build-branches:
     name: Calls build-images-base workflow
+    needs: detect-config
     uses: ./.github/workflows/build-images-base.yaml
     secrets: inherit
     with:
-      operatorVersion: 0.0.0
+      operatorVersion: ${{ needs.detect-config.outputs.operatorVersion }}
       operatorTag: ${{ github.ref_name }}
-      authorinoVersion: latest
-      relatedImageAuthorino: quay.io/kuadrant/authorino:latest
+      authorinoVersion: ${{ needs.detect-config.outputs.authorinoVersion }}
+      relatedImageAuthorino: ${{ needs.detect-config.outputs.authorinoImage }}
+      channels: ${{ needs.detect-config.outputs.channels }}
+      defaultChannel: ${{ needs.detect-config.outputs.defaultChannel }}

--- a/.github/workflows/build-images-branches.yaml
+++ b/.github/workflows/build-images-branches.yaml
@@ -7,10 +7,15 @@ on:
       - "!main"
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   detect-config:
     name: Detect build configuration
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       operatorVersion: ${{ steps.config.outputs.operatorVersion }}
       authorinoVersion: ${{ steps.config.outputs.authorinoVersion }}
@@ -19,7 +24,9 @@ jobs:
       defaultChannel: ${{ steps.config.outputs.defaultChannel }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Read configuration from build.yaml
         id: config
         run: |
@@ -27,11 +34,18 @@ jobs:
           if [ -f "$BUILD_FILE" ]; then
             echo "build.yaml found, extracting configuration"
             # Read values using grep/sed (same approach as Makefile, with trimming)
-            OPERATOR_VERSION=$(grep -E '^\s+version:' "$BUILD_FILE" 2>/dev/null | sed -E 's/.*version:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$//' || echo "0.0.0")
-            AUTHORINO_VERSION=$(grep -E '^\s+authorinoVersion:' "$BUILD_FILE" 2>/dev/null | sed -E 's/.*authorinoVersion:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$//' || echo "latest")
-            AUTHORINO_IMAGE=$(grep -E '^\s+authorinoImage:' "$BUILD_FILE" 2>/dev/null | sed -E 's/.*authorinoImage:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$//' || echo "quay.io/kuadrant/authorino:latest")
-            CHANNELS="stable"
-            DEFAULT_CHANNEL="stable"
+            # Use parameter expansion for fallback when fields are missing
+            OPERATOR_VERSION=$(grep -E '^\s+version:' "$BUILD_FILE" 2>/dev/null | sed -E 's/.*version:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$//')
+            AUTHORINO_VERSION=$(grep -E '^\s+authorinoVersion:' "$BUILD_FILE" 2>/dev/null | sed -E 's/.*authorinoVersion:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$//')
+            AUTHORINO_IMAGE=$(grep -E '^\s+authorinoImage:' "$BUILD_FILE" 2>/dev/null | sed -E 's/.*authorinoImage:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$//')
+            CHANNELS=$(grep -E '^\s+channels:' "$BUILD_FILE" 2>/dev/null | sed -E 's/.*channels:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$//')
+            DEFAULT_CHANNEL=$(grep -E '^\s+defaultChannel:' "$BUILD_FILE" 2>/dev/null | sed -E 's/.*defaultChannel:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$//')
+            # Apply fallbacks for empty values
+            OPERATOR_VERSION=${OPERATOR_VERSION:-0.0.0}
+            AUTHORINO_VERSION=${AUTHORINO_VERSION:-latest}
+            AUTHORINO_IMAGE=${AUTHORINO_IMAGE:-quay.io/kuadrant/authorino:latest}
+            CHANNELS=${CHANNELS:-stable}
+            DEFAULT_CHANNEL=${DEFAULT_CHANNEL:-stable}
           else
             echo "build.yaml not found, using default values"
             OPERATOR_VERSION="0.0.0"
@@ -50,7 +64,11 @@ jobs:
     name: Calls build-images-base workflow
     needs: detect-config
     uses: ./.github/workflows/build-images-base.yaml
-    secrets: inherit
+    # Only pass secrets actually required by build-images-base.yaml (principle of least privilege)
+    # These are used for docker login to push images to the container registry
+    secrets:
+      IMG_REGISTRY_USERNAME: ${{ secrets.IMG_REGISTRY_USERNAME }}
+      IMG_REGISTRY_TOKEN: ${{ secrets.IMG_REGISTRY_TOKEN }}
     with:
       operatorVersion: ${{ needs.detect-config.outputs.operatorVersion }}
       operatorTag: ${{ github.ref_name }}

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,34 @@ LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
+# Build configuration file (created by 'make create-build-file' or 'make prepare-release')
+BUILD_CONFIG_FILE ?= build.yaml
+
+# Read release configuration from build.yaml if present
+# This allows release branches to define VERSION, AUTHORINO_VERSION, and CHANNELS
+# Uses grep/sed for simple YAML parsing without requiring yq at variable definition time
+BUILD_CONFIG_VERSION ?= $(shell test -f $(BUILD_CONFIG_FILE) && grep -E '^\s+version:' $(BUILD_CONFIG_FILE) 2>/dev/null | sed -E 's/.*version:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$$//' || echo "")
+BUILD_CONFIG_AUTHORINO_VERSION ?= $(shell test -f $(BUILD_CONFIG_FILE) && grep -E '^\s+authorinoVersion:' $(BUILD_CONFIG_FILE) 2>/dev/null | sed -E 's/.*authorinoVersion:\s*//;s/^[[:space:]]+//;s/[[:space:]]+$$//' || echo "")
+
 # VERSION defines the project version for the bundle.
+# Priority: command-line > build.yaml > git SHA
+VERSION ?= $(BUILD_CONFIG_VERSION)
 VERSION ?= $(shell git rev-parse HEAD)
+
+# AUTHORINO_VERSION priority: command-line > build.yaml > 'latest' (set below)
+ifndef AUTHORINO_VERSION
+ifneq ($(BUILD_CONFIG_AUTHORINO_VERSION),)
+AUTHORINO_VERSION = $(BUILD_CONFIG_AUTHORINO_VERSION)
+endif
+endif
+
+# CHANNELS defaults to stable if build.yaml has a version field, otherwise left undefined
+ifndef CHANNELS
+ifneq ($(BUILD_CONFIG_VERSION),)
+CHANNELS = stable
+DEFAULT_CHANNEL = stable
+endif
+endif
 
 # Address of the container registry
 DEFAULT_REGISTRY = quay.io
@@ -100,8 +126,7 @@ endif
 # Container Engine to be used for building image and with kind
 CONTAINER_ENGINE ?= docker
 
-# Build file used to store replaces/authorinoImage options.
-BUILD_CONFIG_FILE ?= build.yaml
+# Default and actual Authorino images
 DEFAULT_AUTHORINO_IMAGE = $(DEFAULT_REGISTRY)/$(DEFAULT_ORG)/authorino:$(AUTHORINO_IMAGE_TAG)
 ACTUAL_DEFAULT_AUTHORINO_IMAGE ?= $(shell $(YQ) e -e '.config.authorinoImage' $(BUILD_CONFIG_FILE) || echo $(DEFAULT_AUTHORINO_IMAGE))
 

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,7 @@ BUILD_CONFIG_AUTHORINO_VERSION ?= $(shell test -f $(BUILD_CONFIG_FILE) && grep -
 
 # VERSION defines the project version for the bundle.
 # Priority: command-line > build.yaml > git SHA
-VERSION ?= $(BUILD_CONFIG_VERSION)
-VERSION ?= $(shell git rev-parse HEAD)
+VERSION ?= $(if $(strip $(BUILD_CONFIG_VERSION)),$(BUILD_CONFIG_VERSION),$(shell git rev-parse HEAD))
 
 # AUTHORINO_VERSION priority: command-line > build.yaml > 'latest' (set below)
 ifndef AUTHORINO_VERSION


### PR DESCRIPTION
## Problem
The `build-images-branches.yaml` workflow currently passes hardcoded values (`VERSION=0.0.0`, `AUTHORINO_VERSION=latest`) to the base workflow. This causes issues for branches targeting release branches (e.g., backport branches for patch releases) because:

1. The hardcoded versions don't match what's committed in the branch
2. `make verify-manifests` and `make verify-bundle` fail in CI because manifests are generated with different versions than what's committed
3. Release branches need to use specific versions, not `0.0.0` and `latest`

## Solution
Enable the Makefile and CI workflows to read release configuration from `build.yaml` when present:

- **For dev branches** (no `build.yaml`): Falls back to defaults (`0.0.0`, `latest`) - no change in behavior
- **For release branches** (has `build.yaml`): Automatically uses the correct versions from `build.yaml`

## Changes

### Makefile
- Reads `VERSION`, `AUTHORINO_VERSION`, and `CHANNELS` from `build.yaml` if file exists
- Uses grep/sed for parsing (no yq dependency needed at variable definition time)
- Includes whitespace trimming for robustness
- Falls back to git SHA and 'latest' when `build.yaml` doesn't exist

### GitHub Workflow (build-images-branches.yaml)
- Adds `detect-config` job to extract configuration from `build.yaml`
- Passes extracted values to `build-images-base` workflow
- Falls back to `0.0.0`/`latest` when `build.yaml` not found

## Alternative Considered
Commit `build.yaml` in main with default values (`VERSION=0.0.0`, `AUTHORINO_VERSION=latest`, etc.) and simplify the Makefile to always read from the build file without fallback logic.

This alternative was **discarded for now** to make the change less disruptive - `build.yaml` continues to only exist in release branches. However, we're open to revisiting this decision in the future if having a committed `build.yaml` in main proves beneficial.

## Benefits
- ✅ Release/backport branches can use `build.yaml` to set correct versions automatically
- ✅ CI verification passes because generated manifests match committed ones
- ✅ No change for dev branches (maintain current behavior)
- ✅ Cleaner than environment-specific workarounds

## Testing
- ✅ Tested on release backport branches (v0.23.3, v0.24.1, v0.25.1)
- ✅ Variable extraction works correctly with whitespace trimming
- ✅ Falls back gracefully when `build.yaml` doesn't exist

---
Developed while preparing patch releases v0.23.3, v0.24.1, and v0.25.1

Contains commits of #326, which should be merged first for a clean history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved build infrastructure by detecting build parameters from `build.yaml` when present, including versioning and release channel defaults, with sensible fallbacks when the file is missing.
  * Updated branch image builds to use these dynamically detected values and tightened registry credential passing.
  * Enhanced the Makefile to derive release-related variables from `build.yaml`, defaulting channels to `stable` when unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->