### PR TITLE
Upgrade Go to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build the authorino binary
 # https://catalog.redhat.com/software/containers/ubi10/go-toolset
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi10/go-toolset:1.25 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi10/go-toolset:1.26 AS builder
 WORKDIR /workspace
 
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino-operator
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Upgrade Go from 1.25.9 to 1.26.3.

**Changes:**
- `go.mod`: updated Go version from 1.25.9 to 1.26.3
- `Dockerfile`: updated builder image from `go-toolset:1.25` to `go-toolset:1.26`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain version from 1.25.9 to 1.26.3 across build configuration and development environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->