### PR TITLE
Pin github action versions with Ratchet

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -75,11 +75,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go
@@ -87,20 +87,20 @@ jobs:
         run: make yq
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
         with:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}
           tags: |
             type=raw,value=${{ inputs.operatorTag }}
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
           registry: ${{ env.IMG_REGISTRY_HOST }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
       - name: Build and push operator image
         id: build-image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
@@ -124,16 +124,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - name: Install gettext
         run: sudo apt-get update && sudo apt-get install -y gettext-base
       - name: Set up Go
         id: go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
           go-version-file: go.mod
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Run make bundle
         run: |
           CHANNEL_ARGS=""
@@ -168,20 +168,20 @@ jobs:
             $CHANNEL_ARGS
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
         with:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle
           tags: |
             type=raw,value=${{ inputs.operatorTag }}
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
           registry: ${{ env.IMG_REGISTRY_HOST }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
       - name: Build and push bundle image
         id: build-image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
         with:
           context: .
           file: ./bundle.Dockerfile
@@ -201,14 +201,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - name: Set up Go
         id: go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
           go-version-file: go.mod
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Run make catalog
         run: |
           make catalog \
@@ -218,20 +218,20 @@ jobs:
         run: git --no-pager diff
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
         with:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-catalog
           tags: |
             type=raw,value=${{ inputs.operatorTag }}
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
           registry: ${{ env.IMG_REGISTRY_HOST }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
       - name: Build and push catalog image
         id: build-image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
         with:
           context: ./catalog
           file: ./catalog/${{ env.OPERATOR_NAME }}-catalog.Dockerfile

--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -16,10 +16,10 @@ jobs:
       relatedImageAuthorino: ${{ steps.extract-authorino-version.outputs.relatedImageAuthorino }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - name: Set up Go
         id: go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
           go-version-file: go.mod
       - name: Install yq

--- a/.github/workflows/build-images-nightly.yaml
+++ b/.github/workflows/build-images-nightly.yaml
@@ -21,7 +21,7 @@ jobs:
       authorino_digest: ${{ steps.get-digest.outputs.digest }}
     steps:
       - name: Install crane
-        uses: imjasonh/setup-crane@v0.1
+        uses: imjasonh/setup-crane@5146f708a817ea23476677995bf2133943b9be0b # ratchet:imjasonh/setup-crane@v0.1
       - id: get-digest
         name: Get digest of latest authorino image
         run: |

--- a/.github/workflows/delete-release-helm-chart.yaml
+++ b/.github/workflows/delete-release-helm-chart.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - name: Parse Tag
         run: |
           tag=${{ github.event.release.tag_name || inputs.operatorTag }}

--- a/.github/workflows/issues-workflow.yaml
+++ b/.github/workflows/issues-workflow.yaml
@@ -17,7 +17,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event.issue.number != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@31b3f3ccdc584546fc445612dec3f38ff5edb41c # ratchet:actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/Kuadrant/projects/18
           github-token: ${{ secrets.ADD_ISSUES_TOKEN }}

--- a/.github/workflows/ratchet-check.yaml
+++ b/.github/workflows/ratchet-check.yaml
@@ -1,0 +1,26 @@
+name: Ratchet Check
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+jobs:
+  ratchet:
+    runs-on: ubuntu-latest
+    name: Check pinned actions
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: sethvargo/ratchet@8b4ca256dbed184350608a3023620f267f0a5253 # ratchet:sethvargo/ratchet@v0.11.4
+        with:
+          files: |
+            .github/workflows/*.yaml
+            .github/workflows/*.yml

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -32,11 +32,11 @@ jobs:
           else
             echo "::error::Invalid semver tag: $TAG"
             echo "Expected a valid SemVer (https://semver.org/) format, i.e.: v1.2.3, v1.2.3-alpha1, v1.2.3-dev"
-            exit 1  
+            exit 1
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
@@ -60,7 +60,7 @@ jobs:
           echo "OPERATOR_TAG=${tag}" >> $GITHUB_ENV
 
       - name: Upload package to GitHub Release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # ratchet:svenstaro/upload-release-action@v2
         id: upload-chart
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
           overwrite: true
 
       - name: Upload provenance file to GitHub Release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # ratchet:svenstaro/upload-release-action@v2
         id: upload-prov-file
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -85,3 +85,4 @@ jobs:
             VERSION=${{env.OPERATOR_VERSION}} \
             HELM_WORKFLOWS_TOKEN=${{ secrets.HELM_WORKFLOWS_TOKEN }} \
             BROWSER_DOWNLOAD_URL=${{ steps.upload-chart.outputs.browser_download_url }}
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,11 +39,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gettext-base
       - name: Checkout code at git ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.gitRef }}
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go
@@ -78,7 +78,7 @@ jobs:
           git add -A && git commit -m "Prepared release v${{ github.event.inputs.operatorVersion }}"
           git push origin ${{ steps.release-branch.outputs.name }}
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # ratchet:softprops/action-gh-release@v2
         with:
           name: v${{ github.event.inputs.operatorVersion }}
           tag_name: v${{ github.event.inputs.operatorVersion }}

--- a/.github/workflows/sync-authorino-manifests.yaml
+++ b/.github/workflows/sync-authorino-manifests.yaml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
         with:
           ref: main
           token: ${{ secrets.KUADRANT_DEV_PAT }}
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check.outputs.skip == 'false'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # ratchet:peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.KUADRANT_DEV_PAT }}
           commit-message: Update Authorino manifests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,13 +2,13 @@ name: Test
 
 on:
   push:
-    branches: [ 'main', 'master', 'release-*' ]
+    branches: ['main', 'master', 'release-*']
 
   pull_request:
-    branches: [ 'main', 'master', 'release-*' ]
+    branches: ['main', 'master', 'release-*']
 
   merge_group:
-    types: [ checks_requested ]
+    types: [checks_requested]
 
 jobs:
   verify-manifests:
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go
@@ -46,9 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go
@@ -60,16 +60,16 @@ jobs:
     name: Test Scripts
     strategy:
       matrix:
-        platform: [ ubuntu-latest, macos-latest ]
+        platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     defaults:
       run:
         shell: bash
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go
@@ -81,16 +81,16 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        platform: [ ubuntu-latest, macos-latest ]
+        platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     defaults:
       run:
         shell: bash
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go
@@ -98,7 +98,7 @@ jobs:
         run: |
           make test
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # ratchet:codecov/codecov-action@v3
         with:
           flags: unit
           verbose: true
@@ -109,9 +109,9 @@ jobs:
     # This check adds a list of checks to one job to simplify adding settings to the repo.
     # If a new check is added in this file, and it should be retested on entry to the merge queue,
     # it needs to be added to the list below aka needs: [ existing check 1, existing check 2, new check ].
-    needs: [ verify-manifests, verify-bundle, verify-fmt, test-scripts, unit-tests ]
+    needs: [verify-manifests, verify-bundle, verify-fmt, test-scripts, unit-tests]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - run: echo '${{ toJSON(needs) }}' | jq -e 'all(.[]; .result == "success" or .result == "skipped")'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,9 @@ The default Authorino image is injected at compile time. When building:
 Before submitting changes:
 
 ```bash
+# Run all verification checks
+make verify-all
+
 # Verify manifests are up to date
 make verify-manifests
 
@@ -210,4 +213,13 @@ make verify-bundle
 
 # Verify code formatting
 make verify-fmt
+
+# Verify GitHub Actions are pinned to commit SHAs
+make verify-ratchet
+```
+
+When adding or updating GitHub Actions in workflow files, pin them to commit SHAs:
+
+```bash
+make ratchet-pin
 ```

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ OPM ?= $(LOCALBIN)/opm
 HELM ?= $(LOCALBIN)/helm
 KIND ?= $(LOCALBIN)/kind
 ENVTEST ?= $(LOCALBIN)/setup-envtest
+RATCHET ?= $(LOCALBIN)/ratchet
 
 ## Tool Versions
 OPERATOR_SDK_VERSION ?= v1.32.0
@@ -147,6 +148,7 @@ YQ_VERSION ?= v4.34.2
 OPM_VERSION ?= v1.48.0
 HELM_VERSION ?= v3.15.0
 KIND_VERSION ?= v0.23.0
+RATCHET_VERSION ?= v0.11.4
 # ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.16)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime 2>/dev/null | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 
@@ -159,6 +161,7 @@ OPM_V_BINARY := $(LOCALBIN)/opm-$(OPM_VERSION)
 HELM_V_BINARY := $(LOCALBIN)/helm-$(HELM_VERSION)
 KIND_V_BINARY := $(LOCALBIN)/kind-$(KIND_VERSION)
 ENVTEST_V_BINARY := $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
+RATCHET_V_BINARY := $(LOCALBIN)/ratchet-$(RATCHET_VERSION)
 
 .PHONY: operator-sdk
 operator-sdk: $(OPERATOR_SDK_V_BINARY) ## Download operator-sdk locally if necessary.
@@ -200,6 +203,11 @@ $(KIND_V_BINARY): $(LOCALBIN)
 envtest: $(ENVTEST_V_BINARY) ## Download setup-envtest locally if necessary.
 $(ENVTEST_V_BINARY): $(LOCALBIN)
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
+
+.PHONY: ratchet
+ratchet: $(RATCHET_V_BINARY) ## Download ratchet locally if necessary.
+$(RATCHET_V_BINARY): $(LOCALBIN)
+	$(call go-install-tool,$(RATCHET),github.com/sethvargo/ratchet,$(RATCHET_VERSION))
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0
@@ -392,9 +400,18 @@ prepare-release: ## Prepares a release: create build info file, generate manifes
 	$(MAKE) manifests bundle VERSION=$(VERSION) AUTHORINO_VERSION=$(AUTHORINO_VERSION)
 	$(MAKE) helm-build VERSION=$(VERSION) AUTHORINO_VERSION=$(AUTHORINO_VERSION)
 
+##@ Code Style
+
+.PHONY: ratchet-pin
+ratchet-pin: ratchet ## Pin GitHub Actions to commit SHAs.
+	$(RATCHET) pin $$(find .github/workflows -name '*.yaml' -o -name '*.yml')
+
 ##@ Verify
 
 ## Targets to verify actions that generate/modify code have been executed and output committed
+
+.PHONY: verify-all
+verify-all: verify-manifests verify-bundle verify-fmt verify-ratchet ## Run all verification checks.
 
 OPERATOR_IMAGE_REPO = $(shell echo $(OPERATOR_IMAGE) | cut -d: -f1)
 DEFAULT_AUTHORINO_IMAGE_REPO = $(shell echo $(DEFAULT_AUTHORINO_IMAGE) | cut -d: -f1)
@@ -420,6 +437,10 @@ verify-bundle: bundle yq ## Verify bundle update.
 .PHONY: verify-fmt
 verify-fmt: fmt ## Verify fmt update.
 	git diff --exit-code ./api ./controllers
+
+.PHONY: verify-ratchet
+verify-ratchet: ratchet ## Verify GitHub Actions are pinned to commit SHAs.
+	$(RATCHET) lint $$(find .github/workflows -name '*.yaml' -o -name '*.yml')
 
 # Include last to avoid changing MAKEFILE_LIST used above
 include ./make/*.mk


### PR DESCRIPTION
 ## Summary
  - Pin all GitHub Action references to commit SHAs using [ratchet](https://github.com/sethvargo/ratchet)
  - Add `ratchet-pin` and `verify-ratchet` Make targets for pinning and verifying action references
  - Add  CI workflow to block PRs with unpinned action references

Part of the work on https://github.com/Kuadrant/kuadrant-operator/issues/2055

## Motivation
Tags are mutable — action maintainers can force-push them, silently changing the code our CI runs. Pinning to commit SHAs makes each reference immutable, mitigating supply-chain attacks.
