### PR TITLE
Add CodeQL workflow for SAST scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+# generated from the template https://github.com/actions/starter-workflows/blob/1035244887e26fbbd4f1017d919fb5995cc521c4/code-scanning/codeql.yml
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  merge_group:
+    types: ["checks_requested"]
+  schedule:
+    - cron: '40 3 * * 6' # random schedule to avoid hitting the rate limit of the CodeQL and GitHub Actions API
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: autobuild
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # ratchet:github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # ratchet:github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary
  - Enable CodeQL static analysis to scan Go code for security vulnerabilities and coding errors
  - Runs on pushes and PRs to `main`, plus a weekly scheduled scan
  - Addresses [the SAST scanning on openssf scorecard ](https://github.com/ossf/scorecard/blob/c395761df6afe1a69e476bc60a013a94bcbc153f/docs/checks.md#sast)(currently 0/10)

Part of the work on https://github.com/Kuadrant/kuadrant-operator/issues/2038