### PR TITLE
Add cosigning and provenance attestation to image builds

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -112,11 +112,16 @@ jobs:
             DIRTY=false
             DEFAULT_AUTHORINO_IMAGE=${{ inputs.relatedImageAuthorino }}
             QUAY_IMAGE_EXPIRY=${{ inputs.quayImageExpiry }}
-          provenance: false
+          provenance: true
       - name: Print image URL
         run: |
           echo "Image(s) pushed:"
           echo "${{ steps.meta.outputs.tags }}"
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # ratchet:sigstore/cosign-installer@v3
+      - name: Sign image with cosign
+        run: |
+          cosign sign --yes ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}@${{ steps.build-image.outputs.digest }}
 
   build-bundle:
     name: Build and push bundle image
@@ -189,11 +194,16 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           build-args: QUAY_IMAGE_EXPIRY=${{ inputs.quayImageExpiry }}
-          provenance: false
+          provenance: true
       - name: Print image URL
         run: |
           echo "Image(s) pushed:"
           echo "${{ steps.meta.outputs.tags }}"
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # ratchet:sigstore/cosign-installer@v3
+      - name: Sign image with cosign
+        run: |
+          cosign sign --yes ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle@${{ steps.build-image.outputs.digest }}
 
   build-catalog:
     name: Build and push catalog image
@@ -238,8 +248,13 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          provenance: false
+          provenance: true
       - name: Print image URL
         run: |
           echo "Image(s) pushed:"
           echo "${{ steps.meta.outputs.tags }}"
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # ratchet:sigstore/cosign-installer@v3
+      - name: Sign image with cosign
+        run: |
+          cosign sign --yes ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-catalog@${{ steps.build-image.outputs.digest }}

--- a/.github/workflows/build-images-branches.yaml
+++ b/.github/workflows/build-images-branches.yaml
@@ -10,6 +10,9 @@ on:
 jobs:
   build-branches:
     name: Calls build-images-base workflow
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build-images-base.yaml
     secrets: inherit
     with:

--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -38,6 +38,9 @@ jobs:
   build-release:
     name: Calls build-images-base workflow
     needs: set-vars
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build-images-base.yaml
     secrets: inherit
     with:

--- a/.github/workflows/build-images-main.yaml
+++ b/.github/workflows/build-images-main.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-main:
     name: Calls build-images-base workflow
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build-images-base.yaml
     secrets: inherit
     with:

--- a/.github/workflows/build-images-nightly.yaml
+++ b/.github/workflows/build-images-nightly.yaml
@@ -31,6 +31,9 @@ jobs:
   build-nightly:
     needs: [release-date, authorino-latest-digest]
     name: Calls build-images-base workflow
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build-images-base.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary
  - Sign all container images (operator, bundle, catalog) with cosign (https://github.com/sigstore/cosign) keyless
  signing using the GitHub OIDC identity
  - Enable SLSA build provenance for Docker Buildx workflows (`provenance: true`)
  - New actions are pinned by commit SHA using ratchet (https://github.com/sethvargo/ratchet) format comments, consistent with action pinning being added in https://github.com/Kuadrant/authorino-operator/pull/330

Part of the work on https://github.com/Kuadrant/kuadrant-operator/issues/2038

## Context

This improves the Signed-Releases (https://github.com/ossf/scorecard/blob/main/docs/checks.md#signed-releases) check from the OpenSSF Scorecard (https://scorecard.dev/). Merging this should bring this section score from current 0 to 10.

## Verification

Image builds cosigning and attestation was verified with the kuadrant-operator image builds (https://github.com/Kuadrant/kuadrant-operator/pull/2073), the successful run of which can be found [here](https://github.com/averevki/kuadrant-operator/actions/runs/28458948292), with the images pushed [here](https://quay.io/repository/averevki/kuadrant-operator-catalog?tab=tags). 
