### PR TITLE
Upgrade Go to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino-operator
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Upgrade Go from 1.26.3 to 1.26.4.

Go 1.26.4 includes security fixes for crypto/x509 (quadratic hostname verification DoS).

**Changes:**
- go.mod: go 1.26.3 → 1.26.4