### PR TITLE
Add gpg commit signature to the sync-manifests workflow

### DIFF
--- a/.github/workflows/sync-authorino-manifests.yaml
+++ b/.github/workflows/sync-authorino-manifests.yaml
@@ -50,6 +50,7 @@ jobs:
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           signoff: true
+          sign-commits: true
           base: main
           branch: sync/authorino-manifests
           delete-branch: true


### PR DESCRIPTION
sync-manifests PRs can't be merged without the verified commit signature, e.g. https://github.com/Kuadrant/authorino-operator/pull/336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled commit signing for automatically created pull requests, improving trust and traceability of generated changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->