### PR TITLE
fix: checkout existing release branch in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,10 +54,16 @@ jobs:
           # Removes: pre-release suffix ([+-].*) and patch version (\.[0-9]*$)
           release_branch=release-$(echo "${{ github.event.inputs.operatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
           echo "name=$release_branch" >> $GITHUB_OUTPUT
-      - name: Create release branch
+      - name: Create or checkout release branch
         if: ${{ !startsWith(github.event.inputs.gitRef, 'release-') }}
         run: |
-          git checkout -b ${{ steps.release-branch.outputs.name }}
+          branch=${{ steps.release-branch.outputs.name }}
+          if git ls-remote --exit-code --heads origin "$branch" > /dev/null 2>&1; then
+            git fetch origin "$branch"
+            git checkout "$branch"
+          else
+            git checkout -b "$branch"
+          fi
       - name: Prepare release
         run: |
           VERSION=${{ github.event.inputs.operatorVersion }} \


### PR DESCRIPTION
## Summary

- Fix release workflow failing when the release branch already exists on origin (e.g. patch releases like v0.25.2)
- Check for the remote branch first and fetch/checkout it if present, otherwise create a new one

## Problem

The release workflow unconditionally ran `git checkout -b <release-branch>`, which created a new local branch from the checked-out gitRef. When the release branch already existed on origin (from a previous release), the subsequent `git push` was rejected because the local branch diverged from the remote.

See: https://github.com/Kuadrant/authorino-operator/actions/runs/29233186429/job/86761778828

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release creation workflows by reliably checking out existing release branches or creating new ones when needed.
  * Increased consistency for subsequent release preparation and publishing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->