### PR TITLE
prepare-release: v0.25.2

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 config:
-  version: 0.25.1
+  version: 0.25.2
   replaces: authorino-operator.v0.25.0
   authorinoVersion: 0.26.2
   authorinoImage: quay.io/kuadrant/authorino:v0.26.2

--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -54,8 +54,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/authorino-operator:v0.25.1
-    createdAt: "2026-07-15T07:14:06Z"
+    containerImage: quay.io/kuadrant/authorino-operator:v0.25.2
+    createdAt: "2026-07-15T08:46:28Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/authorino-operator
@@ -66,7 +66,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: authorino-operator.v0.25.1
+  name: authorino-operator.v0.25.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -256,7 +256,7 @@ spec:
                     env:
                       - name: RELATED_IMAGE_AUTHORINO
                         value: quay.io/kuadrant/authorino:v0.26.2
-                    image: quay.io/kuadrant/authorino-operator:v0.25.1
+                    image: quay.io/kuadrant/authorino-operator:v0.25.2
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -361,5 +361,5 @@ spec:
   relatedImages:
     - image: quay.io/kuadrant/authorino:v0.26.2
       name: authorino
-  version: 0.25.1
+  version: 0.25.2
   replaces: authorino-operator.v0.25.0

--- a/charts/authorino-operator/Chart.yaml
+++ b/charts/authorino-operator/Chart.yaml
@@ -18,8 +18,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The version will be properly set when the chart is released matching the operator version
-version: "0.25.1"
-appVersion: "0.25.1"
+version: "0.25.2"
+appVersion: "0.25.2"
 maintainers:
   - email: mcassola@redhat.com
     name: Guilherme Cassolato

--- a/charts/authorino-operator/templates/manifests.yaml
+++ b/charts/authorino-operator/templates/manifests.yaml
@@ -6180,7 +6180,7 @@ spec:
         env:
         - name: RELATED_IMAGE_AUTHORINO
           value: quay.io/kuadrant/authorino:v0.26.2
-        image: quay.io/kuadrant/authorino-operator:v0.25.1
+        image: quay.io/kuadrant/authorino-operator:v0.25.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -6187,7 +6187,7 @@ spec:
         env:
         - name: RELATED_IMAGE_AUTHORINO
           value: quay.io/kuadrant/authorino:v0.26.2
-        image: quay.io/kuadrant/authorino-operator:v0.25.1
+        image: quay.io/kuadrant/authorino-operator:v0.25.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
@@ -5,13 +5,13 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/authorino-operator:v0.25.1
+    containerImage: quay.io/kuadrant/authorino-operator:v0.25.2
     createdAt: 2021-12-08T10-00-00Z
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/authorino-operator
     support: kuadrant
-  name: authorino-operator.v0.25.1
+  name: authorino-operator.v0.25.2
   namespace: placeholder
   labels:
     operatorframework.io/arch.amd64: supported
@@ -78,4 +78,4 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
-  version: 0.25.1
+  version: 0.25.2


### PR DESCRIPTION
Generated release manifests for v0.25.2 via `make prepare-release VERSION=0.25.2 AUTHORINO_VERSION=0.26.2 CHANNELS=stable`.

**Depends on:** #339 (backport cherry-picks) must merge first.

Once both are merged, tag `v0.25.2` from the release branch and create the GitHub release.