### PR TITLE
fix: corrected build argument for docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 docker-build: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 docker-build: DIRTY=$(shell $(PROJECT_DIR)/utils/check-git-dirty.sh || echo "unknown")
 docker-build:  ## Build docker image with the manager.
-	docker build --build-arg OPERATOR_VERSION=$(VERSION) --build-arg GIT_SHA=$(GIT_SHA) --build-arg DIRTY=$(DIRTY) --build-arg ACTUAL_DEFAULT_AUTHORINO_IMAGE=$(ACTUAL_DEFAULT_AUTHORINO_IMAGE) --build-arg QUAY_IMAGE_EXPIRY=$(QUAY_IMAGE_EXPIRY) -t $(OPERATOR_IMAGE) .
+	docker build --build-arg OPERATOR_VERSION=$(VERSION) --build-arg GIT_SHA=$(GIT_SHA) --build-arg DIRTY=$(DIRTY) --build-arg DEFAULT_AUTHORINO_IMAGE=$(ACTUAL_DEFAULT_AUTHORINO_IMAGE) --build-arg QUAY_IMAGE_EXPIRY=$(QUAY_IMAGE_EXPIRY) -t $(OPERATOR_IMAGE) .
 
 docker-push: ## Push docker image with the manager.
 	docker push ${OPERATOR_IMAGE}


### PR DESCRIPTION
The `ACTUAL_DEFAULT_AUTHORINO_IMAGE` argument was being passed to the Docker build command, but this did not match the argument expected by the Dockerfile. The `Dockerfile` expects the `DEFAULT_AUTHORINO_IMAGE` build argument, so this change aligns the build command with the Dockerfile configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker build configuration to pass the default Authorino image correctly during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->