### PR TITLE
Backport CVE fixes for v0.23.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino-operator
 
-go 1.25.9
+go 1.26.4
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Cherry-picks Go 1.26.4 and golang.org/x/net v0.55.0 onto release-0.23 for a v0.23.4 patch release.