### PR TITLE
fix: bump Dockerfile to Go 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build the authorino binary
 # https://catalog.redhat.com/software/containers/ubi10/go-toolset
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi10/go-toolset:1.25 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi10/go-toolset:1.26 AS builder
 WORKDIR /workspace
 
 # Copy the Go Modules manifests


### PR DESCRIPTION
Dockerfile uses go-toolset:1.25 but go.mod requires Go 1.26.4. Build fails with GOTOOLCHAIN=local.