### PR TITLE
Upgrade Go to 1.26.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino-operator
 
-go 1.26.4
+go 1.26.7
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Summary

- Upgrade Go toolchain from 1.26.4 to 1.26.7

## Test plan

- [ ] Unit tests pass
- [ ] Image builds successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)