### PR TITLE
Prepare release v0.25.3

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,5 @@
 config:
-  version: 0.25.2
-  replaces: authorino-operator.v0.25.0
-  authorinoVersion: 0.26.2
-  authorinoImage: quay.io/kuadrant/authorino:v0.26.2
+  version: 0.25.3
+  replaces: authorino-operator.v0.25.2
+  authorinoVersion: 0.26.3
+  authorinoImage: quay.io/kuadrant/authorino:v0.26.3

--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -54,8 +54,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/authorino-operator:v0.25.2
-    createdAt: "2026-07-15T08:46:28Z"
+    containerImage: quay.io/kuadrant/authorino-operator:v0.25.3
+    createdAt: "2026-08-27T13:57:12Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/authorino-operator
@@ -66,7 +66,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: authorino-operator.v0.25.2
+  name: authorino-operator.v0.25.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -255,8 +255,8 @@ spec:
                       - /manager
                     env:
                       - name: RELATED_IMAGE_AUTHORINO
-                        value: quay.io/kuadrant/authorino:v0.26.2
-                    image: quay.io/kuadrant/authorino-operator:v0.25.2
+                        value: quay.io/kuadrant/authorino:v0.26.3
+                    image: quay.io/kuadrant/authorino-operator:v0.25.3
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -359,7 +359,7 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-    - image: quay.io/kuadrant/authorino:v0.26.2
+    - image: quay.io/kuadrant/authorino:v0.26.3
       name: authorino
-  version: 0.25.2
-  replaces: authorino-operator.v0.25.0
+  version: 0.25.3
+  replaces: authorino-operator.v0.25.2

--- a/charts/authorino-operator/Chart.yaml
+++ b/charts/authorino-operator/Chart.yaml
@@ -18,8 +18,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The version will be properly set when the chart is released matching the operator version
-version: "0.25.2"
-appVersion: "0.25.2"
+version: "0.25.3"
+appVersion: "0.25.3"
 maintainers:
   - email: mcassola@redhat.com
     name: Guilherme Cassolato

--- a/charts/authorino-operator/templates/manifests.yaml
+++ b/charts/authorino-operator/templates/manifests.yaml
@@ -6179,8 +6179,8 @@ spec:
         - /manager
         env:
         - name: RELATED_IMAGE_AUTHORINO
-          value: quay.io/kuadrant/authorino:v0.26.2
-        image: quay.io/kuadrant/authorino-operator:v0.25.2
+          value: quay.io/kuadrant/authorino:v0.26.3
+        image: quay.io/kuadrant/authorino-operator:v0.25.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/authorino/kustomization.yaml
+++ b/config/authorino/kustomization.yaml
@@ -2,14 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/Kuadrant/authorino/install?ref=v0.26.2
+- github.com/Kuadrant/authorino/install?ref=v0.26.3
 # - webhook
 
 # # Configures the conversion webhook
 # images:
 # - name: AUTHORINO_IMAGE
 #   newName: quay.io/kuadrant/authorino
-#   newTag: v0.26.2
+#   newTag: v0.26.3
 
 # patchesStrategicMerge:
 # - webhook/patches/webhook_in_authconfigs.yaml

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -6186,8 +6186,8 @@ spec:
         - /manager
         env:
         - name: RELATED_IMAGE_AUTHORINO
-          value: quay.io/kuadrant/authorino:v0.26.2
-        image: quay.io/kuadrant/authorino-operator:v0.25.2
+          value: quay.io/kuadrant/authorino:v0.26.3
+        image: quay.io/kuadrant/authorino-operator:v0.25.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
             - /manager
           env:
             - name: RELATED_IMAGE_AUTHORINO
-              value: quay.io/kuadrant/authorino:v0.26.2
+              value: quay.io/kuadrant/authorino:v0.26.3
           args:
             - --leader-elect
           image: controller:latest

--- a/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
@@ -5,13 +5,13 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/authorino-operator:v0.25.2
+    containerImage: quay.io/kuadrant/authorino-operator:v0.25.3
     createdAt: 2021-12-08T10-00-00Z
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/authorino-operator
     support: kuadrant
-  name: authorino-operator.v0.25.2
+  name: authorino-operator.v0.25.3
   namespace: placeholder
   labels:
     operatorframework.io/arch.amd64: supported
@@ -78,4 +78,4 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
-  version: 0.25.2
+  version: 0.25.3


### PR DESCRIPTION
Prepare-release manifests for v0.25.3.

Bumps authorino operand from v0.26.2 to v0.26.3.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)