### PR TITLE
Backport patch-safe CVE fixes for v0.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/authorino-operator
 
-go 1.26.4
+go 1.26.7
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Cherry-pick of CVE security fix for the v0.23.5 patch release.

## Changes
- Upgrade Go toolchain directive from 1.26.4 to 1.26.7 (fixes Go stdlib CVEs: net/url, crypto/tls, html/template, net/http, encoding/asn1)

Note: authorino-operator does not use OTel directly so no OTel upgrade needed.
The authorino operand version will be updated to v0.24.4 via the release workflow.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)