### PR TITLE
Prepare release v0.23.5

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,4 @@
 config:
-  version: 0.23.4
-  replaces: authorino-operator.v0.23.3
-  authorinoVersion: 0.24.3
-  authorinoImage: quay.io/kuadrant/authorino:v0.24.3
+  authorinoImage: quay.io/kuadrant/authorino:v0.24.4
+  version: 0.23.5
+  replaces: authorino-operator.v0.23.4

--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,5 @@
 config:
-  authorinoImage: quay.io/kuadrant/authorino:v0.24.4
   version: 0.23.5
   replaces: authorino-operator.v0.23.4
+  authorinoVersion: 0.24.4
+  authorinoImage: quay.io/kuadrant/authorino:v0.24.4

--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/authorino-operator:v0.23.5
-    createdAt: "2026-08-29T08:38:45Z"
+    createdAt: "2026-08-29T08:49:44Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/authorino-operator

--- a/bundle/manifests/authorino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/authorino-operator.clusterserviceversion.yaml
@@ -54,8 +54,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/authorino-operator:v0.23.4
-    createdAt: "2026-07-23T13:57:46Z"
+    containerImage: quay.io/kuadrant/authorino-operator:v0.23.5
+    createdAt: "2026-08-29T08:38:45Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/authorino-operator
@@ -66,7 +66,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: authorino-operator.v0.23.4
+  name: authorino-operator.v0.23.5
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -255,8 +255,8 @@ spec:
                       - /manager
                     env:
                       - name: RELATED_IMAGE_AUTHORINO
-                        value: quay.io/kuadrant/authorino:v0.24.3
-                    image: quay.io/kuadrant/authorino-operator:v0.23.4
+                        value: quay.io/kuadrant/authorino:v0.24.4
+                    image: quay.io/kuadrant/authorino-operator:v0.23.5
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -359,7 +359,7 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-    - image: quay.io/kuadrant/authorino:v0.24.3
+    - image: quay.io/kuadrant/authorino:v0.24.4
       name: authorino
-  version: 0.23.4
-  replaces: authorino-operator.v0.23.3
+  version: 0.23.5
+  replaces: authorino-operator.v0.23.4

--- a/charts/authorino-operator/Chart.yaml
+++ b/charts/authorino-operator/Chart.yaml
@@ -18,8 +18,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The version will be properly set when the chart is released matching the operator version
-version: "0.23.4"
-appVersion: "0.23.4"
+version: "0.23.5"
+appVersion: "0.23.5"
 maintainers:
   - email: mcassola@redhat.com
     name: Guilherme Cassolato

--- a/charts/authorino-operator/templates/manifests.yaml
+++ b/charts/authorino-operator/templates/manifests.yaml
@@ -6067,8 +6067,8 @@ spec:
         - /manager
         env:
         - name: RELATED_IMAGE_AUTHORINO
-          value: quay.io/kuadrant/authorino:v0.24.3
-        image: quay.io/kuadrant/authorino-operator:v0.23.4
+          value: quay.io/kuadrant/authorino:v0.24.4
+        image: quay.io/kuadrant/authorino-operator:v0.23.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/authorino/kustomization.yaml
+++ b/config/authorino/kustomization.yaml
@@ -2,14 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/Kuadrant/authorino/install?ref=v0.24.3
+- github.com/Kuadrant/authorino/install?ref=v0.24.4
 # - webhook
 
 # # Configures the conversion webhook
 # images:
 # - name: AUTHORINO_IMAGE
 #   newName: quay.io/kuadrant/authorino
-#   newTag: v0.24.3
+#   newTag: v0.24.4
 
 # patchesStrategicMerge:
 # - webhook/patches/webhook_in_authconfigs.yaml

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -6074,8 +6074,8 @@ spec:
         - /manager
         env:
         - name: RELATED_IMAGE_AUTHORINO
-          value: quay.io/kuadrant/authorino:v0.24.3
-        image: quay.io/kuadrant/authorino-operator:v0.23.4
+          value: quay.io/kuadrant/authorino:v0.24.4
+        image: quay.io/kuadrant/authorino-operator:v0.23.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
             - /manager
           env:
             - name: RELATED_IMAGE_AUTHORINO
-              value: quay.io/kuadrant/authorino:v0.24.3
+              value: quay.io/kuadrant/authorino:v0.24.4
           args:
             - --leader-elect
           image: controller:latest

--- a/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/authorino-operator.clusterserviceversion.yaml
@@ -5,13 +5,13 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/authorino-operator:v0.23.4
+    containerImage: quay.io/kuadrant/authorino-operator:v0.23.5
     createdAt: 2021-12-08T10-00-00Z
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/authorino-operator
     support: kuadrant
-  name: authorino-operator.v0.23.4
+  name: authorino-operator.v0.23.5
   namespace: placeholder
   labels:
     operatorframework.io/arch.amd64: supported
@@ -78,4 +78,4 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
-  version: 0.23.4
+  version: 0.23.5


### PR DESCRIPTION
OLM manifests, Helm chart, and version files for authorino-operator v0.23.5.

- Pins authorino to v0.24.4
- replaces: authorino-operator.v0.23.4

🤖 Generated with [Claude Code](https://claude.ai/claude-code)